### PR TITLE
re-enables dreaming and makes it more based around the SCP universe instead of SS13

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1842,6 +1842,7 @@
 #include "code\modules\fabrication\designs\micro\designs_cutlery.dm"
 #include "code\modules\fabrication\designs\micro\designs_glasses.dm"
 #include "code\modules\fabrication\designs\replicator\designs_food.dm"
+#include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\TextFilters.dm"
 #include "code\modules\food\recipes_stove.dm"
 #include "code\modules\games\boardgame.dm"

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -1,24 +1,11 @@
 
 var/list/dreams = list(
-	"an ID card","a bottle","a familiar face","a crewmember","a toolbox","a security officer","the captain",
-	"voices from all around","deep space","a doctor","the engine","a traitor","an ally","darkness",
-	"light","a scientist","a monkey","a catastrophe","a loved one","a gun","warmth","freezing","the sun",
-	"a hat","a ruined station","a planet","phoron","air","the medical bay","the bridge","blinking lights",
-	"a blue light","an abandoned laboratory","NanoTrasen", "pirates", "mercenaries","blood","healing","power","respect",
-	"riches","space","a crash","happiness","pride","a fall","water","flames","ice","melons","flying","the eggs","money",
-	"the chief engineer","the research director","the chief medical officer",
-	"a station engineer","the janitor","the atmospheric technician",
-	"a cargo technician","the botanist","a shaft miner","the psychologist","the chemist",
-	"the virologist","the roboticist","a chef","the bartender","a chaplain","a librarian","a mouse",
-	"a beach","the holodeck","a smokey room","a voice","the cold","a mouse","an operating table","the rain","a skrell",
-	"an unathi","a tajaran","the ai core","a beaker of strange liquid","the supermatter", "a creature built completely of stolen flesh",
-	"a GAS", "a IPC", "a Dionaea", "a being made of light", "the commanding officer", "the executive officer", "the chief of security", "the corporate liason",
-	"the representative", "the senior advisor", "the bridge officer", "the senior engineer", "the physician", "the corpsman", "the counselor",
-	"the medical contractor", "the security contractor", "the stowaway", "an old friend", "the prospector", "the NT pilot", "the passenger", "the chief of security",
-	"the master at arms", "the forensic technician", "the brig officer", "the tower", "the man with no face", "a field of flowers", "an old home", "the merc",
-	"a surgery table", "a needle", "a blade", "an ocean", "right behind you", "standing above you", "someone near by", "a place forgotten", "the exodus",
+	"an ID card","a strange smiling white mask","the devil","a researcher","a grim fate","a bizzare object","a man set ablaze","a gunfight","the gods","the spirits","a doctor with an red stoned amulet","the foundation", "a happy family", "a P90 closed bolt automatic rifle",
+	"the Harak","a pile of flesh","a long hallway","a dark and infinite stairway","a rotting elderly man approaching","filth","a pale man crying","a bananna","a monkey","the Global Occult Coalition","the world wars", "an angry boss", "a broken limb", "a holstered M1911", "a Dead Friend",
+	"the disease", "a dead man walking", "god himself", "a strange statue wanting a hug", "a security guard", "a joyful angry lizard", "a man in arizona", "the flesh that hates", "termination", "the end of the world", "the ocean", "a useless doctor", "an uncooperative prisoner", "the president",
+	"Site 19", "a plague doctor", "the sickness", "a teddy bear", "a lost friend", "a mutilated Ronald Reagan speaking", "a pill bottle", "the 05 Council", "Hatred", "a sunrise","a sunset", "a corruptive ray of sunlight", "a cup of coffee", "a great outfit", "a friendly D-Class Personnel", "a hallway full of corpses",
+	"D-Class Personnel", "a nurse", "The United Nations", "home", "a peaceful meadow", "a haunting forest", "an angry man", "a dead D-Class", "an imposter", "a Nobody", "a Friend", "a Stranger", "an enemy", "the gas prices", "a cat without an back half", "the moon", "the sun", "a strange floating object"
 	)
-
 mob/living/carbon/proc/dream()
 	dreaming = 1
 


### PR DESCRIPTION
New Text for Dreaming | Will be added onto later.

"an ID card","a strange smiling white mask","the devil","a researcher","a grim fate","a bizzare object","a man set ablaze","a gunfight","the gods","the spirits","a doctor with an red stoned amulet","the foundation", "a happy family", "a P90 closed bolt automatic rifle",
	"the Harak","a pile of flesh","a long hallway","a dark and infinite stairway","a rotting elderly man approaching","filth","a pale man crying","a bananna","a monkey","the Global Occult Coalition","the world wars", "an angry boss", "a broken limb", "a holstered M1911", "a Dead Friend",
	"the disease", "a dead man walking", "god himself", "a strange statue wanting a hug", "a security guard", "a joyful angry lizard", "a man in arizona", "the flesh that hates", "termination", "the end of the world", "the ocean", "a useless doctor", "an uncooperative prisoner", "the president",
	"Site 19", "a plague doctor", "the sickness", "a teddy bear", "a lost friend", "a mutilated Ronald Reagan speaking", "a pill bottle", "the 05 Council", "Hatred", "a sunrise","a sunset", "a corruptive ray of sunlight", "a cup of coffee", "a great outfit", "a friendly D-Class Personnel", "a hallway full of corpses",
	"D-Class Personnel", "a nurse", "The United Nations", "home", "a peaceful meadow", "a haunting forest", "an angry man", "a dead D-Class", "an imposter", "a Nobody", "a Friend", "a Stranger", "an enemy", "the gas prices", "a cat without an back half", "the moon", "the sun", "a strange floating object"
