### PR TITLE
Alternate titles for science, more skills for senior and chief scientist

### DIFF
--- a/maps/site53/job/jobs/command.dm
+++ b/maps/site53/job/jobs/command.dm
@@ -138,6 +138,7 @@
 		access_med_comms,
 		access_eng_comms,
 		access_sec_comms,
+		access_adminlvl2,
 		access_adminlvl1
 	)
 
@@ -213,6 +214,7 @@
 	access = list(
 		access_com_comms,
 		access_adminlvl1
+		access_adminlvl2,
 	)
 	minimal_access = list()
 

--- a/maps/site53/job/jobs/research.dm
+++ b/maps/site53/job/jobs/research.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 6
 	//supervisors = "the Research Director and anyone in a higher position than you"
 	economic_power = 4
-	alt_titles = list("Xenobiologist Associate", "Xenoarcheologist Associate")
+	alt_titles = list("Junior Xenobiologist", "Junior Xenoarcheologist", "Assistant Researcher", "Research Assistant", "Research Intern", "Junior Researcher", "Junior Robotics Technician")
 	ideal_character_age = 22
 	alt_titles = null
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/science/juniorscientist
@@ -41,7 +41,7 @@
 	spawn_positions = 6
 	//supervisors = "the Research Director and anyone in a higher position than you"
 	economic_power = 4
-	alt_titles = list("Xenobiologist", "Xenoarcheologist")
+	alt_titles = list("Xenobiologist", "Xenoarcheologist", "Robotics Technician")
 	minimal_player_age = 5
 	ideal_character_age = 22
 	alt_titles = null
@@ -76,7 +76,7 @@
 	spawn_positions = 6
 	//supervisors = "the Research Director and anyone in a higher position than you"
 	economic_power = 4
-	alt_titles = list("Senior Xenobiologist", "Senior Xenoarcheologist")
+	alt_titles = list("Senior Xenobiologist", "Senior Xenoarcheologist", "Senior Robotics Technician")
 	minimal_player_age = 10
 	ideal_character_age = 22
 	alt_titles = null
@@ -97,7 +97,7 @@
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
-	                    SKILL_DEVICES     = SKILL_BASIC,
+	                    SKILL_DEVICES     = SKILL_TRAINED,
 	                    SKILL_SCIENCE     = SKILL_EXPERIENCED)
 
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MASTER,
@@ -140,8 +140,8 @@
 	minimal_access = list()
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
-	                    SKILL_COMPUTER    = SKILL_BASIC,
-	                    SKILL_DEVICES     = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_TRAINED,
+	                    SKILL_DEVICES     = SKILL_TRAINED,
 	                    SKILL_SCIENCE     = SKILL_EXPERIENCED)
 
 	max_skill = list(   SKILL_ANATOMY     = SKILL_MASTER,


### PR DESCRIPTION
Gives RD trained in IT and complex devices.
Gives SR trained in complex devices.
Gives more alternate titles for Junior, Intermediate and Senior Researcher:
Also gives command crew level-2 access, requested by docderp.
Researcher Associate: "Junior Xenobiologist", "Junior Xenoarcheologist", "Assistant Researcher", "Research Assistant", Researcher: "Research Intern", "Junior Researcher", "Junior Robotics Technician"
"Xenobiologist", "Xenoarcheologist", "Robotics Technician"
Senior Researcher: "Senior Xenobiologist", "Senior Xenoarcheologist", "Senior Robotics Technician"