### PR TITLE
Makes HCZ-LCZ-EZ comm colors actually discernible.

### DIFF
--- a/code/__defines/colors.dm
+++ b/code/__defines/colors.dm
@@ -107,7 +107,7 @@
 #define	COMMS_COLOR_ENGINEER   "#a66300"
 #define	COMMS_COLOR_SECURITY   "#930000"
 #define	COMMS_COLOR_SECURITY_I "#935050"
-#define	COMMS_COLOR_COMMAND    "#204090"
+#define	COMMS_COLOR_COMMAND    "#4160ad"
 #define	COMMS_COLOR_CENTCOMM   "#5c5c7c"
 #define	COMMS_COLOR_SYNDICATE  "#6d3f40"
 #define	COMMS_COLOR_SKRELL     "#7331c4"
@@ -115,6 +115,9 @@
 #define COMMS_COLOR_BEARCAT    "#590e2d"
 #define COMMS_COLOR_COLONY     "#ceaf3e"
 #define COMMS_COLOR_VERNE      "#738465"
+#define COMMS_COLOR_HCZ        "#884a5a"
+#define COMMS_COLOR_LCZ        "#b8a058"
+#define COMMS_COLOR_ECZ        "#545c68"
 
 #define WOOD_COLOR_GENERIC     "#d5a66e"
 #define WOOD_COLOR_RICH        "#792f27"

--- a/code/controllers/communications.dm
+++ b/code/controllers/communications.dm
@@ -193,7 +193,10 @@ var/list/channel_color_presets = list(
 	"Raging Red" = COMMS_COLOR_SECURITY,
 	"Spectacular Silver" = COMMS_COLOR_ENTERTAIN,
 	"Tantalizing Turquoise" = COMMS_COLOR_MEDICAL,
-	"Viewable Violet" = COMMS_COLOR_SKRELL
+	"Viewable Violet" = COMMS_COLOR_SKRELL,
+	"Generic Gray" = COMMS_COLOR_HCZ,
+	"Velvet Violet" = COMMS_COLOR_LCZ,
+	"Outstanding Orange" = COMMS_COLOR_ECZ
 )
 
 // central command channels, i.e deathsquid & response teams

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -236,9 +236,9 @@
 		list(MED_I_FREQ, "Medical (I)", COMMS_COLOR_MEDICAL_I),
 		list(SEC_I_FREQ, "Security (I)", COMMS_COLOR_SECURITY_I),
 		list(HAIL_FREQ, "Hailing", COMMS_COLOR_HAILING),
-		list(SEC_HCZ_FREQ, "HCZ", COMMS_COLOR_SECURITY),
-		list(SEC_LCZ_FREQ, "LCZ", COMMS_COLOR_SECURITY),
-		list(SEC_ECZ_FREQ, "ECZ", COMMS_COLOR_SECURITY)
+		list(SEC_HCZ_FREQ, "HCZ", COMMS_COLOR_HCZ),
+		list(SEC_LCZ_FREQ, "LCZ", COMMS_COLOR_LCZ),
+		list(SEC_ECZ_FREQ, "ECZ", COMMS_COLOR_ECZ)
 	)
 	autolinkers = list("common")
 
@@ -307,18 +307,18 @@
 
 /obj/machinery/telecomms/server/presets/securityhcz
 	id = "HCZ Security Server"
-	channel_tags = list(list(SEC_HCZ_FREQ, "HCZ Security", COMMS_COLOR_EXPLORER))
+	channel_tags = list(list(SEC_HCZ_FREQ, "HCZ Security", COMMS_COLOR_HCZ))
 	freq_listening = list(SEC_HCZ_FREQ)
 	autolinkers = list("hcz-security")
 
 /obj/machinery/telecomms/server/presets/securitylcz
 	id = "LCZ Security Server"
-	channel_tags = list(list(SEC_LCZ_FREQ, "LCZ Security", COMMS_COLOR_COMMAND))
+	channel_tags = list(list(SEC_LCZ_FREQ, "LCZ Security", COMMS_COLOR_LCZ))
 	freq_listening = list(SEC_LCZ_FREQ)
 	autolinkers = list("lcz-security")
 
 /obj/machinery/telecomms/server/presets/securityecz
 	id = "ECZ Security Server"
-	channel_tags = list(list(SEC_ECZ_FREQ, "ECZ Security", COMMS_COLOR_SECURITY /*determines color */))
+	channel_tags = list(list(SEC_ECZ_FREQ, "ECZ Security", COMMS_COLOR_ECZ /*determines color */))
 	freq_listening = list(SEC_ECZ_FREQ)
 	autolinkers = list("ecz-security")


### PR DESCRIPTION
https://cdn.discordapp.com/attachments/897180559971856405/993276992537509888/unknown.png - pic of the colors used.

:cl: Bamhalazam
tweak: Makes HCZ-LCZ-EZ comm colors actually discernible. 
/:cl: