### PR TITLE
Fixing airlock overlays not recompiling before flick animation

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -750,10 +750,9 @@ About the new airlock wires panel:
 	add_overlay(lights_overlay)
 	add_overlay(sparks_overlay)
 	add_overlay(damage_overlay)
+	compile_overlays()
 
 /obj/machinery/door/airlock/do_animate(animation)
-	if(overlays)
-		cut_overlays()
 
 	switch(animation)
 		if("opening")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/41485301/177738954-f8425553-5574-4672-9ba0-83f04a063d25.png)

close #177 