### PR TITLE
Some small code cleanup

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -72,9 +72,6 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	if(anger==100)
 		angry = TRUE
 
-
-#warn work on anger system
-
 /mob/living/carbon/human/scp049/Login()
 	. = ..()
 	if(client)

--- a/code/modules/SCP/SCPs/SCP-096.dm
+++ b/code/modules/SCP/SCPs/SCP-096.dm
@@ -294,7 +294,7 @@
 
 /mob/living/simple_animal/hostile/scp096/proc/murder(var/mob/living/T)
 
-	if(T && T in kill_list)
+	if(T in kill_list)
 		T.loc = src.loc
 		visible_message("<span class='danger'>[src] grabs [T]!</span>")
 		dir = 2

--- a/code/modules/mob/living/carbon/human/species/outsider/scp049.dm
+++ b/code/modules/mob/living/carbon/human/species/outsider/scp049.dm
@@ -4,13 +4,12 @@
 	icon_template = 'icons/SCP/scp-049.dmi'
 	has_organ = list()
 	siemens_coefficient = 0
-	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_SCAN
+	species_flags = SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED | SPECIES_FLAG_NO_TANGLE | SPECIES_FLAG_NO_PAIN
 	show_ssd = null
 	show_coma = null
 	blood_color = "#622a37"
 	flesh_color = "#442A37"
 
-	species_flags = SPECIES_FLAG_NO_SLIP | SPECIES_FLAG_NO_POISON | SPECIES_FLAG_NO_EMBED | SPECIES_FLAG_NO_TANGLE | SPECIES_FLAG_NO_PAIN
 	spawn_flags = SPECIES_IS_RESTRICTED
 
 	genders = list(MALE)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

Removes an unecesary declaration of` species_flag` in `scp049.dm` 
Removes a warning which really should be an annotation somewhere else and not a warning in the code 
Removes a useless &&