### PR TITLE
Cleans up a bunch of references in SCPs to prevent harddels

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -62,8 +62,11 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	)
 
 /mob/living/carbon/human/scp049/Destroy()
+	pestilence_images = null
+	attempted_surgery_on = null
+	target = null
 	GLOB.scp049s -= src
-	. = ..()
+	return ..()
 
 /mob/living/carbon/human/scp049/Life()
 	..()

--- a/code/modules/SCP/SCPs/SCP-096.dm
+++ b/code/modules/SCP/SCPs/SCP-096.dm
@@ -43,6 +43,11 @@
 	emote_hear = list("makes a faint groaning sound")
 	emote_see = list("shuffles around aimlessly", "shivers")
 
+/mob/living/simple_animal/hostile/scp096/Destroy()
+	kill_list = null
+	examine_urge_list = null
+	return ..()
+
 /mob/living/simple_animal/hostile/scp096/Life()
 	if(hibernate)
 		return

--- a/code/modules/SCP/SCPs/SCP-106.dm
+++ b/code/modules/SCP/SCPs/SCP-106.dm
@@ -53,8 +53,9 @@ GLOBAL_LIST_EMPTY(scp106_spawnpoints)
 	GLOB.scp106s |= src
 
 /mob/living/carbon/human/scp106/Destroy()
+	target = null
 	GLOB.scp106s -= src
-	..()
+	return ..()
 
 
 /mob/living/carbon/human/scp106/proc/update_stuff_PD()

--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -42,7 +42,6 @@ GLOBAL_LIST_EMPTY(scp173s)
 	var/breach_cooldown
 
 /mob/living/scp_173/Initialize()
-	..()
 	GLOB.scp173s += src
 	defecation_cooldown = world.time + 5 MINUTES // Give everyone some time to prepare
 	spawn_area = get_area(src)
@@ -51,8 +50,10 @@ GLOBAL_LIST_EMPTY(scp173s)
 	add_language(LANGUAGE_GUTTER, FALSE)
 	add_language(LANGUAGE_SIGN, FALSE)
 	add_language(LANGUAGE_ENGLISH, FALSE)
+	return ..()
 
 /mob/living/scp_173/Destroy()
+	next_blinks = null
 	GLOB.scp173s -= src
 	..()
 

--- a/code/modules/SCP/SCPs/SCP-263.dm
+++ b/code/modules/SCP/SCPs/SCP-263.dm
@@ -31,6 +31,10 @@
 
 	)
 
+/mob/living/simple_animal/hostile/scp_263/Destroy()
+	target = null
+	return ..()
+
 /mob/living/simple_animal/hostile/scp_263/proc/On()
 	set category = "SCP-263"
 	set name = "On"

--- a/code/modules/SCP/SCPs/SCP-294.dm
+++ b/code/modules/SCP/SCPs/SCP-294.dm
@@ -24,7 +24,9 @@ GLOBAL_LIST_EMPTY(scp294_reagents)
 	player_names += GLOB.player_list
 
 /obj/machinery/scp294/Destroy()
-	. = ..()
+	player_names = null
+	victim = null
+	return ..()
 
 /datum/scp/scp_294
 	name = "SCP-294"

--- a/code/modules/SCP/SCPs/SCP-513.dm
+++ b/code/modules/SCP/SCPs/SCP-513.dm
@@ -32,6 +32,10 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/item/scp513/Destroy()
+	victims = null
+	next_braindamage_stage = null
+	braindamage_stage = null
+	wake_up_timing = null
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/modules/SCP/SCPs/SCP-895.dm
+++ b/code/modules/SCP/SCPs/SCP-895.dm
@@ -18,6 +18,9 @@
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/closet/coffin/scp895/Destroy()
+	cooldown = null
+	start = null
+	users = null
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/modules/SCP/SCPs/SCP-999.dm
+++ b/code/modules/SCP/SCPs/SCP-999.dm
@@ -33,6 +33,7 @@ GLOBAL_LIST_EMPTY(scp999s)
 	return 0
 
 /mob/living/simple_animal/scp_999/Destroy()
+	last_healing = null
 	GLOB.scp999s -= src
 	..()
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Cleans up a bunch of references stored in SCPs in their Destroy() to prevent harddeletions