### PR TITLE
Sets chance for psionic latency to 2%

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -50,8 +50,8 @@
 	var/defer_roundstart_spawn = FALSE // If true, the job will be put off until all other jobs have been populated.
 	var/list/species_branch_rank_cache_ = list()
 	var/list/psi_faculties                // Starting psi faculties, if any.
-	var/psi_latency_chance = 0            // Chance of an additional psi latency, if any.
-	var/give_psionic_implant_on_join = TRUE // If psionic, will be implanted for control.
+	var/psi_latency_chance = 2            // Chance of an additional psi latency, if any.
+	var/give_psionic_implant_on_join = FALSE // If psionic, will be implanted for control.
 
 	var/use_species_whitelist // If set, restricts the job to players with the given species whitelist. This does NOT restrict characters joining as the job to the species itself.
 


### PR DESCRIPTION
### About pull request

Simple as that. Chance for psionic latencies(not powers themselves, mind you) is set to 2%.
Effectively this means that 1 out of 50 people will have a chance to awaken random psionic powers if they:
- A: Receive near deadly amount of brain damage (40% chance).
- B: Overdose on Three-Eye drug (tiny chance and requires overdose, which is quite deadly).
- C: Use Jerraman drug (almost guaranteed chance, but hard to make. DO NOT take more than 4 units).