### PR TITLE
Fix language runtime

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1260,8 +1260,9 @@
 		remove_language(lang.name)
 
 	for(var/thing in free_languages)
-		var/datum/language/lang = thing
-		add_language(lang.name)
+		if(!isnull(thing))
+			var/datum/language/lang = thing
+			add_language(lang.name)
 
 	if(LAZYLEN(default_languages) && isnull(default_language))
 		default_language = default_languages[1]


### PR DESCRIPTION
What i _think_ is happing is that because free_languges is associated list, it can have a key but a null value assigned to it. So it will still go trough the for loop, resulting in a null error when trying to acces name of language.

Tiny bandaid should reduce shitty runtimes?

![Image](https://cdn.discordapp.com/attachments/896526221565898842/995756657105707109/unknown.png)

![Image2](https://cdn.discordapp.com/attachments/896526221565898842/995756920264728646/unknown.png)