### PR TITLE
Runtime flooring doesnt exist fix

### DIFF
--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -137,6 +137,8 @@ var/list/flooring_cache = list()
 
 	//If we get here then its a normal floor
 	else if (T.is_floor())
+		if (istype(T,turf/unsimulated))
+			return FALSE
 		var/turf/simulated/floor/t = T
 
 		//Check for window frames.


### PR DESCRIPTION
flooring is a variable of /turf/simulated/floor, but when this proc is called with unsimulated floor it runtimes since the var doesnt exist. Early return when its simulated will somewhat ensure this cant happen

![img](https://cdn.discordapp.com/attachments/896526221565898842/995759582620160030/unknown.png)