### PR TITLE
Re-enables naturally-rolling antagonist drones.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -133,7 +133,7 @@
 	if(user && fabricator && !((fabricator.stat & NOPOWER) || !fabricator.produce_drones || fabricator.drone_progress < 100))
 		log_and_message_admins("has joined the round as a maintenance drone.")
 		var/mob/drone = fabricator.create_drone(user.client)
-		if(drone)
-			drone.status_flags |= NO_ANTAG
+//		if(drone)
+//			drone.status_flags |= NO_ANTAG
 		return 1
 	return


### PR DESCRIPTION
Needs discussion at the higher levels. While drones are not prevented from being antagonists if admin-spawned (which is strange but understandable), part of the PR that mapped them in was prefaced as allowing them to be antags as they have far less reach, and die in two-shots from a handgun (thus making them EXTREMELY easy to disable), while only gaining a plasma-cutter.


Of course they're still subject to antag breaching rules.