### PR TITLE
Modifies runechat to not show whispers across the room, and adds whis…

### DIFF
--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -15,7 +15,7 @@ var/global/list/floating_chat_colors = list()
 /atom/movable
 	var/list/stored_chat_text
 
-/atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, duration = CHAT_MESSAGE_LIFESPAN)
+/atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, whisper = FALSE, unique_messages = null, duration = CHAT_MESSAGE_LIFESPAN)
 	set waitfor = FALSE
 
 	/// Get rid of any URL schemes that might cause BYOND to automatically wrap something in an anchor tag
@@ -48,6 +48,15 @@ var/global/list/floating_chat_colors = list()
 	// create 2 messages, one that appears if you know the language, and one that appears when you don't know the language
 	var/image/understood = generate_floating_text(src, capitalize(message), style, fontsize, duration, show_to)
 	var/image/gibberish = language ? generate_floating_text(src, language.scramble(message), style, fontsize, duration, show_to) : understood
+
+	//hack for unique messages, i.e. misunderstood whispers
+	for(var/client/client in unique_messages)
+		var/image/unique = generate_floating_text(src, capitalize(unique_messages[client]), style, fontsize, duration, show_to)
+
+		show_to -= client //remove the client from the normal list if we're giving them a unique response to this
+		if(!client.mob.is_deaf() && client.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)
+			client.images += unique
+
 
 	for(var/client/C in show_to)
 		if(!C.mob.is_deaf() && C.get_preference_value(/datum/client_preference/floating_messages) == GLOB.PREF_SHOW)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -90,6 +90,8 @@
 			var/turf/source = speaker? get_turf(speaker) : get_turf(src)
 			src.playsound_local(source, speech_sound, sound_vol, 1)
 
+		return message
+
 /mob/proc/on_hear_say(var/message)
 	to_chat(src, message)
 

--- a/code/modules/mob/language/human/arabic.dm
+++ b/code/modules/mob/language/human/arabic.dm
@@ -5,6 +5,7 @@
 	key = "4"
 	shorthand = "Arab"
 	space_chance = 35
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 5,
 		LANGUAGE_HUMAN_CHINESE = 5,

--- a/code/modules/mob/language/human/chinese.dm
+++ b/code/modules/mob/language/human/chinese.dm
@@ -11,6 +11,7 @@
 	key = "2"
 	shorthand = "Mand"
 	space_chance = 30
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 5,
 		LANGUAGE_HUMAN_ARABIC = 5,

--- a/code/modules/mob/language/human/french.dm
+++ b/code/modules/mob/language/human/french.dm
@@ -10,6 +10,7 @@
 	colour = "french"
 	key = "8"
 	shorthand = "Fr"
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_SPANISH = 30,
 		LANGUAGE_HUMAN_ITALIAN = 25,

--- a/code/modules/mob/language/human/german.dm
+++ b/code/modules/mob/language/human/german.dm
@@ -15,6 +15,7 @@
 	key = "1"
 	flags = WHITELISTED
 	shorthand = "Ger"
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_CHINESE = 5,
 		LANGUAGE_HUMAN_ARABIC = 5,

--- a/code/modules/mob/language/human/indian.dm
+++ b/code/modules/mob/language/human/indian.dm
@@ -11,6 +11,7 @@
 	key = "3"
 	shorthand = "Hindi"
 	space_chance = 30
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 5,
 		LANGUAGE_HUMAN_CHINESE = 5,

--- a/code/modules/mob/language/human/italian.dm
+++ b/code/modules/mob/language/human/italian.dm
@@ -5,6 +5,7 @@
 	colour = "italian"
 	key = "7"
 	shorthand = "italo"
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 5,
 		LANGUAGE_HUMAN_FRENCH = 25,
@@ -16,4 +17,4 @@
 		 "la", "te", "re", "ge", "de", "ne", "se", "le", "ti", "ri", "gi", "di", "ni", "si"
 	)
 	has_written_form = TRUE
-	
+

--- a/code/modules/mob/language/human/japanese.dm
+++ b/code/modules/mob/language/human/japanese.dm
@@ -6,6 +6,7 @@
 	key = "6"
 	shorthand = "Jap"
 	space_chance = 25
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 5,
 		LANGUAGE_HUMAN_ARABIC = 5,

--- a/code/modules/mob/language/human/misc/gutter.dm
+++ b/code/modules/mob/language/human/misc/gutter.dm
@@ -5,6 +5,7 @@
 	colour = "rough"
 	key = "t"
 	space_chance = 70
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 75,
 		LANGUAGE_HUMAN_CHINESE = 20,

--- a/code/modules/mob/language/human/misc/spacer.dm
+++ b/code/modules/mob/language/human/misc/spacer.dm
@@ -9,6 +9,7 @@
 	warning = "Automatically given if spawning with no languages."
 	key = "j"
 	shorthand = "Eng"
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 25,
 		LANGUAGE_HUMAN_CHINESE = 5,

--- a/code/modules/mob/language/human/russian.dm
+++ b/code/modules/mob/language/human/russian.dm
@@ -4,6 +4,7 @@
 	colour = "russian"
 	key = "r"
 	shorthand = "Russ"
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 5,
 		LANGUAGE_ENGLISH = 20

--- a/code/modules/mob/language/human/selenian.dm
+++ b/code/modules/mob/language/human/selenian.dm
@@ -5,6 +5,7 @@
 	key = "7"
 	shorthand = "Sel"
 	space_chance = 100
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 85,
 		LANGUAGE_HUMAN_CHINESE = 15,

--- a/code/modules/mob/language/human/spanish.dm
+++ b/code/modules/mob/language/human/spanish.dm
@@ -11,6 +11,7 @@
 	colour = "iberian"
 	key = "5"
 	shorthand = "Spain"
+	whisper_verb = "whispers"
 	partial_understanding = list(
 		LANGUAGE_HUMAN_GERMAN = 15,
 		LANGUAGE_HUMAN_FRENCH = 30,

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -314,6 +314,8 @@ var/list/channel_to_radio_key = new
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message, verb, speaking)
 
+	var/heard_message
+	var/list/unique = list()
 	if(whispering)
 		var/eavesdroping_range = 5
 		var/list/eavesdroping = list()
@@ -323,15 +325,16 @@ var/list/channel_to_radio_key = new
 		eavesdroping_obj -= listening_obj
 		for(var/mob/M in eavesdroping)
 			if(M)
-				M.hear_say(stars(message), verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
+				heard_message = M.hear_say(stars(message), verb, speaking, alt_name, italics, src, speech_sound, sound_vol)
 				if(M.client)
 					speech_bubble_recipients |= M.client
+					unique[M.client] = heard_message
 
 		for(var/obj/O in eavesdroping)
 			spawn(0)
 				if(O) //It's possible that it could be deleted in the meantime.
 					O.hear_talk(src, stars(message), verb, speaking)
-	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, speaking, italics, speech_bubble_recipients)
+	INVOKE_ASYNC(src, /atom/movable/proc/animate_chat, message, speaking, italics, speech_bubble_recipients, whispering, unique)
 
 	if(whispering)
 		log_whisper("[name]/[key] : [message]")


### PR DESCRIPTION
…per verbs to all current languages to make it more clear that people are whispering.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

As title says. Runechat was overriding default behavior of whispers, this simply updates runechat to use that behavior and adds whisper verbs to all spoken languages.