### PR TITLE
LCZ security autobalance

### DIFF
--- a/maps/site53/job/jobs/security.dm
+++ b/maps/site53/job/jobs/security.dm
@@ -64,6 +64,7 @@
 	department_flag = SEC
 	total_positions = 1
 	spawn_positions = 1
+	balance_limited = TRUE
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You also carry the responsibility of guarding the D-Cells. You should not leave your zone under usual SoP</b></big>"
 	economic_power = 4
 	minimal_player_age = 10
@@ -212,6 +213,7 @@
 	department_flag = SEC
 	total_positions = 4
 	spawn_positions = 4
+	balance_limited = TRUE
 	//duties = "<big><b>As the Guard you have more access than a Junior Guard, but do not control them. You are to guard tests and SCP's in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	economic_power = 4
 	minimal_player_age = 5
@@ -358,6 +360,7 @@
 	department_flag = SEC
 	total_positions = 20
 	spawn_positions = 20
+	balance_limited = TRUE
 	//duties = "<big><b>As the Junior Guard you have minimal access. You are to guard tests, SCP's and provide support in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	economic_power = 4
 //	minimal_player_age = 0
@@ -491,3 +494,4 @@
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
 	skill_points = 20
+


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

So this one probably needs more of a looking at for balancing purposes, but this has been requested a lot.

Essentially it creates an autobalance system that locks roles with `balance_limited` set to true. The ratio is hardcoded to 1:4 (guards: D-Class) for LCZ, with a minimum of 5 guards. I could have made this system more modular but it's so niche that I don't think it's necessary. It does allow easy setup for later roles in LCZ department or other departments that need to be restricted somehow.

Note: I have no way of feasibly testing this, not even with alts. Please double check my logic so after this gets merged it doesn't lock out LCZ guards completely 😄 