### PR TITLE
LCZ Armory Update for the LCZ Armory Update

### DIFF
--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -14,8 +14,7 @@
 "aad" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -58,8 +57,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -102,13 +100,11 @@
 /area/site53/reswing/robotics)
 "aao" = (
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -117,7 +113,6 @@
 "aap" = (
 /obj/machinery/computer/shuttle_control{
 	name = "Light Containment Tram control console";
-	req_access = list();
 	shuttle_tag = "Light Containment Tram"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -172,8 +167,7 @@
 "aaA" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/lowertrams/brownline)
@@ -202,18 +196,15 @@
 /area/site53/lowertrams/orangeline)
 "aaG" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/closet/crate/bin,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -235,9 +226,7 @@
 "aaK" = (
 /obj/machinery/computer/shuttle_control{
 	dir = 4;
-	icon_state = "computer";
 	name = "Light Containment Tram control console";
-	req_access = list();
 	shuttle_tag = "Light Containment Tram"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -250,9 +239,7 @@
 "aaM" = (
 /obj/machinery/computer/shuttle_control{
 	dir = 4;
-	icon_state = "computer";
 	name = "Light Containment Tram control console";
-	req_access = list();
 	shuttle_tag = "Light Containment Tram"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -336,8 +323,7 @@
 /obj/item/stack/material/deuterium/fifty,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/item/stack/material/deuterium/fifty,
 /obj/item/stack/material/deuterium/fifty,
@@ -357,8 +343,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access = list(301)
 	},
 /turf/simulated/floor/reinforced,
@@ -376,8 +360,7 @@
 /obj/machinery/cooker/grill,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/restaurantkitchenarea)
@@ -442,8 +425,7 @@
 /area/site53/lowertrams/hub)
 "abi" = (
 /obj/machinery/power/apc/hyper{
-	dir = 8;
-	icon_state = "apc0"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -469,8 +451,7 @@
 "abl" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/freezer,
@@ -587,8 +568,7 @@
 "abG" = (
 /obj/effect/paint_stripe/yellow,
 /obj/structure/sign/directions/engineering{
-	dir = 1;
-	icon_state = "direction_eng"
+	dir = 1
 	},
 /turf/simulated/wall/prepainted,
 /area/site53/lowertrams/orangeline)
@@ -612,7 +592,6 @@
 "abK" = (
 /obj/structure/stairs/north,
 /obj/structure/sign/directions/medical{
-	icon_state = "direction_med";
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -634,8 +613,7 @@
 "abO" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -647,8 +625,7 @@
 "abP" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -656,8 +633,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -669,9 +645,7 @@
 /obj/structure/table/standard,
 /obj/item/storage/slide_projector,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp8containment{
@@ -686,8 +660,7 @@
 "abT" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/brown/mono,
@@ -712,8 +685,7 @@
 "abX" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
@@ -752,9 +724,7 @@
 "acd" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/camera/network/entrance{
-	icon_state = "camera"
-	},
+/obj/machinery/camera/network/entrance,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertrams/redline)
 "ace" = (
@@ -764,9 +734,7 @@
 /area/site53/lowertrams/redline)
 "acf" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/lino,
 /area/site53/lowertrams/restaurant)
@@ -921,9 +889,7 @@
 	name = "trash bin"
 	},
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurant)
@@ -1038,8 +1004,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
@@ -1113,8 +1078,7 @@
 /area/site53/uhcz/scp106observ)
 "ade" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -1157,14 +1121,12 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/simulated/floor,
@@ -1179,8 +1141,7 @@
 "adk" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/closet/crate/bin{
@@ -1200,8 +1161,7 @@
 /area/site53/lowertrams/restaurant)
 "adm" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/computer/fusion/fuel_control{
 	dir = 4;
@@ -1262,8 +1222,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/lino,
 /area/site53/lowertrams/restaurant)
@@ -1295,8 +1254,7 @@
 "adz" = (
 /obj/structure/bed/chair,
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -1308,13 +1266,11 @@
 "adA" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -1335,33 +1291,28 @@
 	req_access = list(201)
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "adE" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "adF" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -1395,8 +1346,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/brownline)
@@ -1560,8 +1510,7 @@
 /obj/structure/railing/mapped,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/open,
 /area/site53/lowertrams/hub)
@@ -1592,8 +1541,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -1622,8 +1570,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -1640,8 +1587,7 @@
 /area/site53/lowertrams/brownline)
 "aei" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
@@ -1673,7 +1619,6 @@
 	dir = 4
 	},
 /obj/machinery/door/blast/regular{
-	begins_closed = 1;
 	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
 	name = "UHCZ Secure Maintenance Tunnel Lockdown"
 	},
@@ -1753,12 +1698,10 @@
 "aet" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -1778,22 +1721,53 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "aew" = (
-/obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/tram/hcz)
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/checkequip{
+	name = "\improper LCZ Security Center"
+	})
 "aex" = (
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -1831,13 +1805,11 @@
 "aeE" = (
 /obj/structure/closet/secure_closet/mtf/enlisted,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/item/device/flashlight/maglight,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1851,8 +1823,7 @@
 /area/vacant/prototype/engine)
 "aeG" = (
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1888,8 +1859,7 @@
 "aeM" = (
 /obj/structure/closet/secure_closet/mtf/enlisted,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/item/device/flashlight/maglight,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1977,8 +1947,7 @@
 "afb" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/rack,
 /turf/simulated/floor/tiled/monotile/white,
@@ -2065,15 +2034,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/computer/fusion/core_control{
 	dir = 4;
@@ -2198,8 +2165,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/table/rack{
 	dir = 8
@@ -2270,8 +2236,7 @@
 /area/site53/science/aiccore)
 "afM" = (
 /obj/machinery/door/airlock/civilian{
-	name = "Unisex Restrooms";
-	req_access = list()
+	name = "Unisex Restrooms"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -2328,7 +2293,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular{
-	begins_closed = 1;
 	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
 	name = "UHCZ Secure Maintenance Tunnel Lockdown"
 	},
@@ -2354,8 +2318,7 @@
 "afX" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/surgery,
@@ -2435,14 +2398,12 @@
 /area/site53/lowertrams/brownline)
 "agf" = (
 /obj/structure/disposalpipe/up{
-	dir = 4;
-	icon_state = "pipe-u"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 16;
 	d2 = 0;
-	icon_state = "16-0";
-	pixel_y = 0
+	icon_state = "16-0"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2674,8 +2635,7 @@
 "agw" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2722,8 +2682,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -2761,8 +2720,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -2815,8 +2773,7 @@
 /area/site53/ulcz/hallways)
 "agM" = (
 /obj/structure/disposaloutlet{
-	dir = 1;
-	icon_state = "outlet"
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor,
@@ -2919,8 +2876,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/monotile/white,
@@ -3006,8 +2962,7 @@
 /area/site53/lowertrams/brownline)
 "ahj" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Escape Train";
-	req_access = list()
+	name = "Escape Train"
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -3070,8 +3025,7 @@
 	})
 "ahq" = (
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -3084,8 +3038,7 @@
 /area/site53/lowertrams/hub)
 "ahs" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
@@ -3215,8 +3168,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
@@ -3429,8 +3381,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/hyper{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics{
@@ -3517,8 +3468,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -3535,8 +3485,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/bed/chair{
 	dir = 1
@@ -3563,8 +3512,7 @@
 /area/site53/uhcz/scp106observ)
 "aio" = (
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -3588,7 +3536,6 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
@@ -3635,7 +3582,6 @@
 /obj/machinery/fusion_fuel_injector/mapped{
 	anchored = 0;
 	dir = 1;
-	icon_state = "injector0";
 	id_tag = "fusion_injector2";
 	initial_id_tag = "fusion_injector2"
 	},
@@ -3653,8 +3599,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lowertrams/redline)
@@ -3692,8 +3637,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/junction/yjunction{
-	dir = 1;
-	icon_state = "pipe-y"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -3710,20 +3654,16 @@
 "aiD" = (
 /obj/structure/cable{
 	d1 = 32;
-	d2 = 1;
 	icon_state = "32-1"
 	},
 /obj/structure/disposalpipe/down{
-	dir = 4;
-	icon_state = "pipe-d"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 1;
-	icon_state = "down-scrubbers"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 1;
-	icon_state = "down-supply"
+	dir = 1
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
@@ -3821,20 +3761,16 @@
 	req_access = list(503)
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access = list(301)
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/item/rig/ce/equipped,
 /turf/simulated/floor/tiled/techfloor,
@@ -3870,8 +3806,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/breakroom)
@@ -3886,8 +3821,7 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -3908,7 +3842,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -3924,8 +3857,7 @@
 /obj/structure/flora/pottedplant,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -3944,13 +3876,11 @@
 /area/site53/engineering/breakroom)
 "aiZ" = (
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -3963,8 +3893,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/breakroom)
@@ -4078,8 +4007,7 @@
 /area/site53/engineering/primaryhallway)
 "ajr" = (
 /obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/sleeproom)
@@ -4091,8 +4019,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/sleeproom)
@@ -4257,8 +4184,7 @@
 /area/site53/engineering/breakroom)
 "ajM" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	dir = 1;
-	icon_state = "corner_white_three_quarters"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -4323,8 +4249,7 @@
 /area/site53/engineering/controlroom)
 "ajW" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/breakroom)
@@ -4335,7 +4260,6 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -4396,23 +4320,10 @@
 /area/site53/lowertrams/hub)
 "akd" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
-"ake" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/door/airlock/highsecurity{
-	req_access = list()
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "akf" = (
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 22
@@ -4423,8 +4334,7 @@
 	})
 "akg" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -4527,8 +4437,7 @@
 /area/site53/lhcz/scp343entrance)
 "aks" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/bed,
 /obj/structure/curtain/open/bed{
@@ -4569,9 +4478,7 @@
 /area/site53/engineering/controlroom)
 "akw" = (
 /obj/effect/catwalk_plated/dark,
-/obj/machinery/door/airlock/highsecurity{
-	req_access = list()
-	},
+/obj/machinery/door/airlock/highsecurity,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -4612,7 +4519,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -4628,7 +4534,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -4641,7 +4546,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -4661,7 +4565,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -4687,8 +4590,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/containment_engineer)
@@ -4696,8 +4598,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/containment_engineer)
@@ -4753,7 +4654,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -4765,8 +4665,7 @@
 /area/site53/engineering/controlroom)
 "akS" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -4813,9 +4712,7 @@
 "akX" = (
 /obj/structure/closet/secure_closet/mtf/breachshotguns,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp8containment{
@@ -4829,8 +4726,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/containment_engineer)
@@ -4870,12 +4766,10 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -4896,8 +4790,7 @@
 "alh" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -4917,8 +4810,7 @@
 /area/site53/upper_surface/serverfarmcontrol)
 "alj" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/light/spot{
 	dir = 8
@@ -4945,8 +4837,7 @@
 /area/site53/uhcz/hallways)
 "all" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/button/blast_door{
 	dir = 4;
@@ -4985,20 +4876,17 @@
 /area/site53/uhcz/scp895)
 "alo" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/machinery/space_heater,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5006,8 +4894,7 @@
 /area/site53/engineering/controlroom)
 "alp" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -5019,8 +4906,7 @@
 /area/site53/engineering/controlroom)
 "alq" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
@@ -5045,8 +4931,7 @@
 /area/site53/engineering/controlroom)
 "alt" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/controlroom)
@@ -5174,8 +5059,7 @@
 /area/shuttle/escape_pod7/station)
 "alJ" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5186,8 +5070,7 @@
 /area/vacant/prototype/engine)
 "alL" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -5268,8 +5151,7 @@
 /area/site53/lowertrams/hczmaint)
 "alV" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5340,9 +5222,7 @@
 "amf" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
@@ -5390,8 +5270,7 @@
 "amn" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 8
@@ -5430,8 +5309,7 @@
 /area/site53/engineering/primaryhallway)
 "ams" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techfloor,
@@ -5450,7 +5328,6 @@
 /area/site53/engineering/engine_smes)
 "amu" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = 32;
 	req_access = list(304,504,303)
 	},
@@ -5488,8 +5365,7 @@
 "amA" = (
 /obj/structure/closet/secure_closet/mtf/enlisted,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -5503,8 +5379,7 @@
 	})
 "amB" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod7/station)
@@ -5514,8 +5389,7 @@
 "amD" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/engineering/primaryhallway)
@@ -5530,15 +5404,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/computer/atmoscontrol{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
 "amG" = (
 /obj/machinery/door/airlock/engineering{
-	locked = 0;
 	name = "Communications Maintenance";
 	req_access = list(501)
 	},
@@ -5554,13 +5426,11 @@
 /area/site53/upper_surface/serverfarmtunnel)
 "amH" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/maintenancetunnel)
@@ -5620,8 +5490,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/janitorial)
@@ -5630,8 +5499,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
@@ -5659,8 +5527,7 @@
 "amR" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -5713,8 +5580,7 @@
 /area/site53/engineering/primaryhallway)
 "amX" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -5728,8 +5594,7 @@
 /area/site53/engineering/primaryhallway)
 "amY" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5737,31 +5602,26 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "amZ" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "ana" = (
 /obj/structure/bed/chair,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp8containment{
@@ -5845,8 +5705,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
@@ -5858,12 +5717,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	dir = 1;
-	icon_state = "corner_white_three_quarters"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -5891,8 +5748,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/auxstorage)
@@ -5908,8 +5764,7 @@
 /area/site53/engineering/controlroom)
 "ans" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/controlroom)
@@ -5920,8 +5775,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -5932,15 +5786,13 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
 "anv" = (
 /obj/machinery/power/port_gen/pacman{
-	anchored = 0;
 	sheets = 25
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -6027,8 +5879,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -6043,8 +5894,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6059,8 +5909,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6070,7 +5919,6 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/structure/catwalk,
@@ -6098,8 +5946,7 @@
 /area/site53/engineering/primaryhallway)
 "anJ" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -6128,16 +5975,14 @@
 /area/site53/lowertrams/hczmaint)
 "anM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/site53/engineering/controlroom)
 "anN" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6226,8 +6071,7 @@
 /area/vacant/prototype/control)
 "anX" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
@@ -6297,8 +6141,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/controlroom)
@@ -6335,8 +6178,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/primaryhallway)
@@ -6351,8 +6193,7 @@
 /area/site53/engineering/primaryhallway)
 "aon" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/flora/pottedplant/minitree,
 /obj/structure/railing/mapped{
@@ -6404,16 +6245,14 @@
 "aos" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aot" = (
 /obj/structure/flora/pottedplant,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	dir = 1;
-	icon_state = "corner_white_three_quarters"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -6437,8 +6276,7 @@
 "aox" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
@@ -6469,8 +6307,7 @@
 	})
 "aoC" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -6481,8 +6318,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/unsimulated/mineral,
 /area/space)
@@ -6574,6 +6410,13 @@
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
 /obj/machinery/button/blast_door{
 	dir = 4;
 	id_tag = "ULCZ Secure Armoury";
@@ -6581,6 +6424,19 @@
 	pixel_x = -22;
 	req_access = list(204)
 	},
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper LCZ Security Center"
@@ -6620,8 +6476,7 @@
 /area/site53/engineering/locker_room)
 "aoS" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6637,7 +6492,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast2"
 	},
@@ -6680,8 +6534,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/table/standard,
@@ -6698,7 +6551,6 @@
 "aoZ" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/structure/catwalk,
@@ -6740,8 +6592,7 @@
 /area/site53/engineering/controlroom)
 "ape" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/flora/pottedplant/minitree,
 /obj/structure/railing/mapped,
@@ -6764,7 +6615,6 @@
 /area/site53/reswing/robotics)
 "apg" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast2"
 	},
@@ -6781,8 +6631,7 @@
 "api" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/railing/mapped{
 	dir = 8
@@ -6791,13 +6640,10 @@
 /area/site53/lowertrams/escape)
 "apj" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -6823,7 +6669,6 @@
 "apo" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
@@ -6915,9 +6760,7 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
@@ -6950,8 +6793,7 @@
 "apC" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -6959,8 +6801,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access = list(301)
 	},
 /turf/simulated/floor/tiled/dark,
@@ -6999,8 +6839,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
@@ -7019,15 +6858,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "apK" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/table/steel,
 /obj/item/paper/reactor,
@@ -7078,8 +6915,7 @@
 /area/site53/engineering/primaryhallway)
 "apQ" = (
 /obj/machinery/power/apc/hyper{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/monotile,
@@ -7184,8 +7020,7 @@
 "aqf" = (
 /obj/structure/catwalk,
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
@@ -7202,7 +7037,6 @@
 /obj/structure/closet/jcloset_torch,
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -7212,8 +7046,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/primaryhallway)
@@ -7270,7 +7103,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
@@ -7288,12 +7120,10 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -7346,8 +7176,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -7360,8 +7189,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7373,8 +7201,7 @@
 "aqv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7385,12 +7212,10 @@
 /area/site53/engineering/primaryhallway)
 "aqw" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7409,8 +7234,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7440,8 +7264,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7472,9 +7295,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
@@ -7503,8 +7324,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7517,8 +7337,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -7531,8 +7350,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
@@ -7540,8 +7358,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -7608,8 +7425,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -7631,8 +7447,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7644,8 +7459,7 @@
 "aqQ" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/lowertrams/escape)
@@ -7689,8 +7503,7 @@
 /area/site53/engineering/controlroom)
 "aqV" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/dark,
@@ -7708,12 +7521,10 @@
 /area/site53/engineering/atmos)
 "aqY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7724,8 +7535,7 @@
 /area/site53/engineering/primaryhallway)
 "aqZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7733,8 +7543,7 @@
 /area/site53/engineering/primaryhallway)
 "ara" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/table/steel,
 /obj/item/device/flashlight/lamp,
@@ -7757,8 +7566,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7773,7 +7581,6 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/effect/floor_decal/corner/red{
@@ -7797,13 +7604,11 @@
 /area/site53/engineering/auxstorage)
 "are" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/filingcabinet,
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/dark,
@@ -7824,8 +7629,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -7864,8 +7668,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -7939,9 +7742,7 @@
 /area/vacant/prototype/engine)
 "art" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp8containment{
@@ -7961,7 +7762,6 @@
 "arv" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/plating,
@@ -7969,12 +7769,10 @@
 "arw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -7988,8 +7786,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8003,16 +7800,14 @@
 /area/site53/engineering/primaryhallway)
 "ary" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/engineering/atmos)
 "arz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/r_wall/prepainted,
@@ -8026,8 +7821,7 @@
 /area/site53/engineering/atmos)
 "arB" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8
@@ -8055,8 +7849,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8085,8 +7878,7 @@
 	id_tag = "englock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8101,12 +7893,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8132,8 +7922,7 @@
 	pixel_x = 11
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -8179,8 +7968,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8189,8 +7977,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -8212,8 +7999,7 @@
 /obj/structure/bed/chair,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/orange/mono,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -8223,13 +8009,6 @@
 /area/site53/uhcz/scp8containment{
 	name = "\improper Biohazard Test Chamber"
 	})
-"arQ" = (
-/obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/tram/lcz)
 "arR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -8241,8 +8020,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -8256,8 +8034,7 @@
 	id_tag = "englock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -8267,12 +8044,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8283,15 +8058,13 @@
 /area/site53/engineering/primaryhallway)
 "arT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -8319,12 +8092,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -8341,8 +8112,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -8353,8 +8123,7 @@
 /area/site53/engineering/primaryhallway)
 "arY" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/table/steel,
 /obj/item/clothing/suit/storage/hooded/wintercoat/engineering,
@@ -8384,8 +8153,7 @@
 /area/vacant/prototype/control)
 "asc" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8410,8 +8178,7 @@
 /area/site53/engineering/primaryhallway)
 "ase" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -8419,8 +8186,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	icon_state = "map-scrubbers"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -8570,8 +8336,7 @@
 /area/site53/engineering/atmos)
 "asw" = (
 /obj/machinery/atmospherics/portables_connector{
-	dir = 4;
-	icon_state = "map_connector"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -8584,8 +8349,7 @@
 /area/site53/engineering/atmos)
 "asy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/table/rack{
 	dir = 8
@@ -8666,9 +8430,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8701,30 +8463,26 @@
 	pixel_x = 11
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "asJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
 "asK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
 "asL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow,
 /turf/simulated/floor/tiled/dark,
@@ -8818,9 +8576,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
@@ -8884,31 +8640,26 @@
 /obj/machinery/atmospherics/omni/filter{
 	tag_east = 5;
 	tag_north = 2;
-	tag_south = 1;
-	tag_west = 0
+	tag_south = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "atd" = (
 /obj/effect/floor_decal/corner/black{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 1;
-	icon_state = "intact"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "ate" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/plating,
@@ -8997,20 +8748,17 @@
 /area/site53/engineering/primaryhallway)
 "atp" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
 "atq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -9026,16 +8774,14 @@
 /area/site53/engineering/atmos)
 "att" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 1;
-	icon_state = "map"
+	dir = 1
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "atu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled/monotile,
@@ -9044,12 +8790,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/prototype/control)
@@ -9062,12 +8806,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -9083,12 +8825,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9102,12 +8842,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9124,10 +8862,8 @@
 /area/vacant/prototype/engine)
 "atA" = (
 /obj/machinery/door/blast/regular{
-	icon_state = "pdoor1";
 	id_tag = "logisticsecurestor";
-	name = "Logistics Secure Storage";
-	p_open = 0
+	name = "Logistics Secure Storage"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile,
@@ -9145,14 +8881,12 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/site53/logistics/logistics{
@@ -9166,8 +8900,7 @@
 /area/site53/engineering/atmos)
 "atE" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -9193,8 +8926,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -9232,12 +8964,10 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -9246,8 +8976,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9257,7 +8986,6 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/effect/floor_decal/corner/yellow/three_quarters{
@@ -9300,12 +9028,10 @@
 /area/site53/engineering/atmos)
 "atQ" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/table/standard,
 /obj/item/device/radio,
@@ -9362,8 +9088,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9399,8 +9124,7 @@
 /area/site53/engineering/primaryhallway)
 "atY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 6;
-	icon_state = "intact-supply"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -9414,27 +9138,17 @@
 "aua" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
-"aub" = (
-/obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/engineering/primaryhallway)
 "auc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -9472,8 +9186,7 @@
 "aug" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9599,12 +9312,10 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -9630,8 +9341,7 @@
 "aux" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -9653,20 +9363,17 @@
 /area/site53/engineering/biosupplies)
 "auA" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "auB" = (
 /obj/effect/floor_decal/corner/orange,
 /obj/effect/floor_decal/corner/black{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -9680,12 +9387,10 @@
 /area/site53/engineering/atmos)
 "auD" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/flora/pottedplant/flower,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -9725,8 +9430,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
@@ -9744,8 +9448,7 @@
 	id_tag = "englock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -9771,8 +9474,7 @@
 /area/site53/engineering/storage)
 "auN" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/monotile,
@@ -9819,10 +9521,8 @@
 /area/site53/engineering/storage)
 "auS" = (
 /obj/machinery/door/blast/regular{
-	icon_state = "pdoor1";
 	id_tag = "logisticsecurestor";
-	name = "Logistics Secure Storage";
-	p_open = 0
+	name = "Logistics Secure Storage"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/structure/cable{
@@ -9836,8 +9536,7 @@
 	})
 "auT" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9852,8 +9551,7 @@
 /area/site53/engineering/controlroom)
 "auU" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9866,16 +9564,13 @@
 /obj/machinery/light,
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -9895,8 +9590,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/atmos)
@@ -9933,8 +9627,7 @@
 /area/vacant/prototype/engine)
 "avc" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/suit_storage_unit/engineering{
 	islocked = 0;
@@ -9947,8 +9640,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
-	dir = 9;
-	icon_state = "intact-supply"
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -9959,16 +9651,14 @@
 /area/site53/engineering/atmos)
 "ave" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
-	dir = 4;
-	icon_state = "map"
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "avf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 8;
-	icon_state = "map"
+	dir = 8
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/monotile,
@@ -10006,8 +9696,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -10078,28 +9767,23 @@
 	id_tag = "englock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
 "avu" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "avv" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/scp8containment{
@@ -10116,18 +9800,14 @@
 /obj/structure/closet/secure_closet/mtf/breachshotguns,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/checkequip{
-	name = "\improper LCZ Security Center"
-	})
+/area/site53/ulcz/hallways)
 "avy" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10150,12 +9830,10 @@
 /area/site53/engineering/storage)
 "avB" = (
 /obj/effect/floor_decal/corner/orange{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10176,7 +9854,6 @@
 	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -10193,7 +9870,6 @@
 	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -10206,7 +9882,6 @@
 	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -10224,8 +9899,7 @@
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10241,7 +9915,6 @@
 	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -10264,7 +9937,6 @@
 	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -10289,9 +9961,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -10323,20 +9993,17 @@
 /area/vacant/prototype/engine)
 "avP" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "avQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /obj/machinery/meter,
 /obj/structure/cable{
@@ -10348,8 +10015,7 @@
 /area/site53/engineering/atmos)
 "avR" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -10364,8 +10030,7 @@
 	id_tag = "englock"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
@@ -10375,8 +10040,7 @@
 /area/site53/engineering/primaryhallway)
 "avS" = (
 /obj/machinery/atmospherics/pipe/cap/hidden{
-	dir = 8;
-	icon_state = "cap"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10384,8 +10048,7 @@
 /area/site53/engineering/primaryhallway)
 "avT" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -10405,19 +10068,16 @@
 "avW" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "avX" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	dir = 4;
-	icon_state = "corner_white_three_quarters"
+	dir = 4
 	},
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -10446,8 +10106,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	dir = 4;
-	icon_state = "corner_white_three_quarters"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -10455,23 +10114,20 @@
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/orange/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertrams/orangeline)
 "awd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "awe" = (
 /obj/machinery/atmospherics/valve/digital/open{
-	dir = 4;
-	icon_state = "map_valve1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10481,8 +10137,7 @@
 /area/site53/engineering/atmos)
 "awg" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10513,8 +10168,7 @@
 	})
 "awl" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+	dir = 1
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -10551,8 +10205,7 @@
 /area/site53/engineering/atmos)
 "awp" = (
 /obj/effect/floor_decal/corner/yellow/three_quarters{
-	dir = 4;
-	icon_state = "corner_white_three_quarters"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -10586,8 +10239,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10599,12 +10251,10 @@
 /area/site53/engineering/primaryhallway)
 "awv" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10612,22 +10262,19 @@
 /area/site53/engineering/atmos)
 "aww" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "awx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10662,8 +10309,7 @@
 "awB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10698,8 +10344,7 @@
 "awE" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10740,7 +10385,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -10763,9 +10407,7 @@
 "awL" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -10790,8 +10432,7 @@
 /area/site53/engineering/storage)
 "awP" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/suit_storage_unit/engineering{
 	islocked = 0;
@@ -10843,8 +10484,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/light/small/red{
 	dir = 8;
@@ -10905,8 +10545,7 @@
 /area/site53/engineering/engine_smes)
 "axa" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled/monotile,
@@ -10920,8 +10559,7 @@
 /area/site53/engineering/engine_smes)
 "axc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/monotile,
@@ -10948,8 +10586,7 @@
 /area/site53/engineering/atmos)
 "axe" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 1;
-	icon_state = "map"
+	dir = 1
 	},
 /obj/machinery/meter,
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -10966,8 +10603,7 @@
 	})
 "axg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -10979,8 +10615,7 @@
 /area/site53/engineering/atmos)
 "axi" = (
 /obj/effect/floor_decal/corner/orange{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/white,
 /obj/machinery/light{
@@ -10993,8 +10628,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11017,14 +10651,10 @@
 /obj/machinery/atmospherics/omni/mixer{
 	active_power_usage = 7500;
 	tag_east = 2;
-	tag_east_con = null;
-	tag_north = 0;
-	tag_north_con = null;
 	tag_south = 1;
 	tag_south_con = 0.21;
 	tag_west = 1;
-	tag_west_con = 0.79;
-	use_power = 1
+	tag_west_con = 0.79
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -11050,7 +10680,6 @@
 	icon_state = "warning"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "engineeringcontrolroom"
 	},
@@ -11091,8 +10720,7 @@
 /area/site53/engineering/atmos)
 "axs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -11128,8 +10756,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/biosupplies)
@@ -11160,8 +10787,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -11179,8 +10805,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Atmos";
@@ -11214,8 +10839,7 @@
 /area/site53/engineering/atmos)
 "axD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/structure/sign/warning/compressed_gas,
 /obj/effect/paint_stripe/yellow,
@@ -11293,8 +10917,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -11303,12 +10926,10 @@
 /area/vacant/prototype/engine)
 "axN" = (
 /obj/effect/floor_decal/corner/white{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -11316,8 +10937,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -11327,9 +10947,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/engine)
@@ -11339,12 +10957,10 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable{
-	RCon_tag = "Prototype - Distribution";
-	charge = 0
+	RCon_tag = "Prototype - Distribution"
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -11367,8 +10983,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11427,8 +11042,7 @@
 /area/vacant/prototype/engine)
 "axX" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -11448,8 +11062,7 @@
 /area/site53/engineering/biosupplies)
 "aya" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -11460,8 +11073,7 @@
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -11469,7 +11081,6 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -11491,8 +11102,7 @@
 /area/site53/engineering/primaryhallway)
 "ayd" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -11502,8 +11112,7 @@
 /area/vacant/prototype/engine)
 "aye" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -11511,17 +11120,14 @@
 "ayf" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access = list(201)
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -11541,8 +11147,7 @@
 /area/site53/engineering/bathrooms)
 "ayh" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11566,9 +11171,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/obj/machinery/alarm{
-	pixel_y = 0
-	},
+/obj/machinery/alarm,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/engine)
 "ayj" = (
@@ -11594,8 +11197,7 @@
 "ayl" = (
 /obj/structure/catwalk,
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-8"
@@ -11607,15 +11209,13 @@
 /area/site53/engineering/engine_smes)
 "aym" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "ayn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -11650,8 +11250,7 @@
 /area/site53/lowertrams/hczmaint)
 "ays" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/monotile,
@@ -11710,8 +11309,7 @@
 /area/site53/lowertrams/orangeline)
 "ayA" = (
 /obj/machinery/power/apc/hyper{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -11758,8 +11356,7 @@
 "ayH" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11770,8 +11367,7 @@
 /area/site53/lowertrams/orangeline)
 "ayI" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -11780,8 +11376,7 @@
 /area/site53/engineering/primaryhallway)
 "ayJ" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/tram/engineering)
@@ -11790,8 +11385,7 @@
 /area/site53/tram/engineering)
 "ayL" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -11822,15 +11416,13 @@
 "ayP" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "ayQ" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -11899,12 +11491,10 @@
 /area/site53/lowertrams/brownline)
 "aza" = (
 /obj/effect/floor_decal/corner/white{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6;
-	icon_state = "intact"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -11938,8 +11528,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -11959,8 +11548,7 @@
 /area/site53/engineering/atmos)
 "aze" = (
 /obj/effect/floor_decal/corner/blue{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11974,8 +11562,7 @@
 "azf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/floor_decal/corner/blue{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11990,8 +11577,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
-	dir = 8;
-	icon_state = "corner_white"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12058,8 +11644,7 @@
 /area/site53/engineering/storage)
 "azn" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -12118,13 +11703,11 @@
 /area/vacant/prototype/engine)
 "azt" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/curtain/open/shower/engineering,
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -12139,8 +11722,7 @@
 /area/vacant/prototype/engine)
 "azv" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/curtain/open/shower/engineering,
 /obj/structure/window/reinforced,
@@ -12213,7 +11795,6 @@
 "azD" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Entrance Zone Network")
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -12300,15 +11881,13 @@
 	})
 "azN" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "azO" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled,
@@ -12318,8 +11897,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/engine)
@@ -12409,8 +11987,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -12431,8 +12008,7 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/engineering/uppernukeladders)
@@ -12464,8 +12040,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
@@ -12501,13 +12076,11 @@
 /area/site53/engineering/engine_smes)
 "aAi" = (
 /obj/structure/bed/chair{
-	dir = 8;
-	icon_state = "chair_preview"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/tram/engineering)
@@ -12517,28 +12090,24 @@
 /area/site53/lowertrams/redline)
 "aAk" = (
 /obj/structure/bed/chair{
-	dir = 8;
-	icon_state = "chair_preview"
+	dir = 8
 	},
 /obj/effect/shuttle_landmark/engineering/start,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/tram/engineering)
 "aAl" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/engine)
 "aAm" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/closet/crate/secure/biohazard,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -12567,8 +12136,7 @@
 /area/site53/engineering/storage)
 "aAq" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12624,35 +12192,29 @@
 /obj/structure/lattice,
 /obj/structure/cable{
 	d1 = 32;
-	d2 = 1;
 	icon_state = "32-1"
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
-	dir = 1;
-	icon_state = "down-scrubbers"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/zpipe/down/supply{
-	dir = 1;
-	icon_state = "down-supply"
+	dir = 1
 	},
 /turf/simulated/open,
 /area/site53/engineering/maintenance/upperselfdestruct)
 "aAy" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/upperselfdestruct)
 "aAz" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -12703,8 +12265,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12716,8 +12277,7 @@
 /area/site53/lowertrams/hub)
 "aAG" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -12731,8 +12291,7 @@
 "aAH" = (
 /obj/structure/plasticflaps,
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -12742,8 +12301,7 @@
 "aAI" = (
 /obj/structure/closet/secure_closet/mtf/enlisted,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/camera/network/lcz,
 /obj/item/device/flashlight/maglight,
@@ -12799,12 +12357,10 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -12832,8 +12388,7 @@
 /area/site53/lowertrams/brownline)
 "aAR" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -12854,12 +12409,10 @@
 /area/site53/uhcz/scp106observ)
 "aAT" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -12868,8 +12421,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12883,16 +12435,14 @@
 /area/site53/engineering/primaryhallway)
 "aAV" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
 "aAW" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/vending/engineering{
 	dir = 1;
@@ -12902,8 +12452,7 @@
 /area/site53/engineering/storage)
 "aAX" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/vending/engivend{
 	dir = 1;
@@ -12919,8 +12468,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12934,8 +12482,7 @@
 /area/site53/engineering/primaryhallway)
 "aBa" = (
 /obj/machinery/power/apc{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -12978,8 +12525,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13032,8 +12578,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13048,8 +12593,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -13063,8 +12607,7 @@
 "aBj" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13076,8 +12619,7 @@
 "aBk" = (
 /obj/machinery/light,
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/tram/engineering)
@@ -13085,8 +12627,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -13126,14 +12667,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -13161,12 +12700,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13175,8 +12712,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -13200,14 +12736,6 @@
 "aBx" = (
 /turf/simulated/floor,
 /area/space)
-"aBz" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/site53/uhcz/hallways)
 "aBA" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
@@ -13241,8 +12769,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
@@ -13270,12 +12797,10 @@
 /area/site53/lowertrams/brownline)
 "aBJ" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/machinery/light/small/red{
 	dir = 8;
@@ -13288,8 +12813,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13298,8 +12822,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -13313,8 +12836,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13323,8 +12845,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -13340,8 +12861,7 @@
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/engineering/primaryhallway)
@@ -13349,8 +12869,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13359,19 +12878,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aBQ" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -13385,15 +12901,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aBR" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -13407,36 +12921,30 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aBS" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13459,8 +12967,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/power/apc{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -13480,8 +12987,7 @@
 "aBX" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/hallways)
@@ -13533,7 +13039,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -13546,7 +13051,6 @@
 "aCi" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -13690,8 +13194,7 @@
 /area/site53/uhcz/scp106maintup)
 "aCw" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/vending/robotics{
 	dir = 1;
@@ -13701,8 +13204,7 @@
 /area/site53/engineering/storage)
 "aCx" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/vending/tool{
 	dir = 1
@@ -13711,8 +13213,7 @@
 /area/site53/engineering/storage)
 "aCy" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -13728,9 +13229,7 @@
 "aCA" = (
 /obj/structure/cable/green,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
-	operating = 1;
 	pixel_y = -24
 	},
 /turf/simulated/floor/plating,
@@ -13772,8 +13271,7 @@
 	amount = 50
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -13785,7 +13283,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/blast/regular{
-	begins_closed = 1;
 	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
 	name = "UHCZ Secure Maintenance Tunnel Lockdown"
 	},
@@ -13828,8 +13325,7 @@
 	amount = 50
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -13851,15 +13347,13 @@
 	amount = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
 "aCI" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor/tiled/monotile,
@@ -13911,8 +13405,7 @@
 /area/site53/uhcz/scp106maintup)
 "aCN" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -13932,12 +13425,10 @@
 /area/site53/lowertrams/hczmaint)
 "aCP" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/structure/table/rack{
 	dir = 8
@@ -13965,7 +13456,6 @@
 /obj/structure/lattice,
 /obj/structure/cable{
 	d1 = 32;
-	d2 = 1;
 	icon_state = "32-1"
 	},
 /obj/machinery/light/small,
@@ -13975,13 +13465,6 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/upper_surface/serverfarmcontrol)
-"aCU" = (
-/obj/structure/bed/chair{
-	dir = 8;
-	icon_state = "chair_preview"
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/tram/engineering)
 "aCV" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor,
@@ -14028,20 +13511,17 @@
 /area/site53/engineering/atmos)
 "aDc" = (
 /obj/effect/floor_decal/corner/white{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
 "aDd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/r_wall/prepainted,
@@ -14074,8 +13554,7 @@
 /area/site53/engineering/atmos)
 "aDi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5;
-	icon_state = "intact"
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -14110,8 +13589,7 @@
 /area/site53/engineering/atmos)
 "aDl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -14243,8 +13721,7 @@
 "aDB" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/zonecommanderoffice{
@@ -14257,8 +13734,7 @@
 	})
 "aDD" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -14300,7 +13776,6 @@
 "aDH" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/structure/closet/firecloset,
@@ -14412,9 +13887,7 @@
 "aDU" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/clothing/head/bio_hood/virology,
 /obj/item/clothing/head/bio_hood/virology,
@@ -14461,8 +13934,7 @@
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor/plating,
 /area/site53/logistics/logistics{
@@ -14476,8 +13948,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -14571,12 +14042,10 @@
 /obj/structure/lattice,
 /obj/structure/cable{
 	d1 = 32;
-	d2 = 1;
 	icon_state = "32-1"
 	},
 /obj/structure/disposalpipe/down{
-	dir = 1;
-	icon_state = "pipe-d"
+	dir = 1
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106maintup)
@@ -14680,8 +14149,7 @@
 "aEv" = (
 /obj/structure/closet/secure_closet/mtf/enlisted,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/item/clothing/suit/bio_suit/security,
 /obj/item/clothing/head/bio_hood/security,
@@ -14693,8 +14161,7 @@
 "aEw" = (
 /obj/structure/closet/secure_closet/mtf/enlisted,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -14731,9 +14198,7 @@
 	name = "\improper Biohazard Test Chamber"
 	})
 "aEz" = (
-/obj/machinery/door/airlock/highsecurity{
-	req_access = list()
-	},
+/obj/machinery/door/airlock/highsecurity,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -14745,8 +14210,7 @@
 "aEA" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -14774,8 +14238,7 @@
 /area/site53/lowertrams/redline)
 "aEE" = (
 /obj/machinery/power/apc/hyper{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -14826,9 +14289,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/hallways)
@@ -14856,8 +14317,7 @@
 "aEN" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -14935,18 +14395,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lowertrams/redline)
-"aEV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lowertrams/redline)
 "aEW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -14989,8 +14437,7 @@
 /area/site53/lowertrams/orangeline)
 "aFb" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -15016,8 +14463,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -15048,12 +14494,10 @@
 /area/site53/ulcz/hallways)
 "aFg" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -15065,8 +14509,7 @@
 	})
 "aFh" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -15095,8 +14538,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/bed/chair{
 	dir = 4
@@ -15144,7 +14586,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access = list(201)
 	},
 /obj/structure/cable{
@@ -15172,8 +14613,7 @@
 "aFr" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15199,7 +14639,6 @@
 "aFt" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -15229,12 +14668,10 @@
 /area/site53/lowertrams/redline)
 "aFv" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -15252,14 +14689,12 @@
 /area/space)
 "aFx" = (
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aFy" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "check3"
 	},
@@ -15273,8 +14708,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/bathrooms)
@@ -15286,8 +14720,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/biosupplies)
@@ -15358,8 +14791,7 @@
 /area/site53/uhcz/securitypost)
 "aFJ" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15385,8 +14817,7 @@
 /area/site53/uhcz/hallways)
 "aFM" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -15445,8 +14876,7 @@
 	})
 "aFU" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 4;
-	icon_state = "corner_white"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -15457,16 +14887,13 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "aFW" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -15479,13 +14906,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/restaurantkitchenarea)
-"aFY" = (
-/obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
-	},
-/turf/simulated/floor/lino,
-/area/site53/lowertrams/restaurant)
 "aFZ" = (
 /obj/machinery/cooker/candy,
 /obj/structure/table/standard,
@@ -15505,15 +14925,13 @@
 /area/site53/lowertrams/restaurant)
 "aGc" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/structure/table/standard,
@@ -15523,8 +14941,7 @@
 /area/site53/engineering/controlroom)
 "aGd" = (
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15535,16 +14952,13 @@
 /area/site53/lowertrams/redline)
 "aGe" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/corner/yellow{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/structure/table/standard,
@@ -15558,7 +14972,6 @@
 /obj/structure/closet/l3closet/general,
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled,
@@ -15566,7 +14979,6 @@
 "aGg" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /obj/structure/hygiene/sink{
@@ -15588,15 +15000,13 @@
 "aGi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGj" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15621,8 +15031,7 @@
 	req_access = list(501)
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9;
-	icon_state = "corner_white"
+	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -15636,15 +15045,13 @@
 /area/site53/engineering/primaryhallway)
 "aGo" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGp" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15654,16 +15061,14 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15679,8 +15084,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15689,8 +15093,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15698,37 +15101,24 @@
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"aGw" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
 "aGx" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGy" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGz" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15770,8 +15160,7 @@
 	})
 "aGF" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15787,15 +15176,13 @@
 /area/site53/ulcz/scp151)
 "aGH" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGI" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15830,20 +15217,17 @@
 "aGO" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGP" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -15857,8 +15241,7 @@
 /area/site53/uhcz/securitypost)
 "aGR" = (
 /obj/effect/floor_decal/corner/red{
-	dir = 1;
-	icon_state = "corner_white"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15877,8 +15260,7 @@
 /area/site53/uhcz/securitypost)
 "aGS" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -15891,8 +15273,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -15906,8 +15287,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -15928,8 +15308,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -15971,13 +15350,11 @@
 /area/site53/uhcz/medicalpost)
 "aHb" = (
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -16041,7 +15418,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access = list(201)
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -16106,8 +15482,7 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile/white,
@@ -16136,8 +15511,7 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -16149,8 +15523,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16207,19 +15580,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp151)
 "aHw" = (
 /obj/structure/disposalpipe/trunk{
-	dir = 8;
-	icon_state = "pipe-t"
+	dir = 8
 	},
 /obj/machinery/disposal/deliveryChute{
-	dir = 8;
-	icon_state = "intake"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp151)
@@ -16237,12 +15607,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	icon_state = "map-scrubbers"
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16263,8 +15631,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16278,22 +15645,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHA" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHB" = (
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16348,8 +15712,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16359,8 +15722,7 @@
 	req_access = list(201)
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16371,8 +15733,7 @@
 	name = "trash bin"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16401,8 +15762,7 @@
 "aHN" = (
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16428,8 +15788,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16454,8 +15813,7 @@
 	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16463,7 +15821,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -16477,8 +15834,7 @@
 "aHU" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -16525,7 +15881,6 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 4;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -16635,8 +15990,7 @@
 "aIo" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16667,8 +16021,7 @@
 "aIr" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/power/terminal{
 	dir = 4
@@ -16844,8 +16197,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -16878,8 +16230,7 @@
 /area/site53/ulcz/scp151)
 "aIN" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/machinery/computer/shuttle_control/engineering{
 	dir = 8;
@@ -16896,8 +16247,7 @@
 /area/site53/engineering/primaryhallway)
 "aIP" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -16910,20 +16260,17 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aIR" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/railing/mapped{
 	dir = 4
@@ -16933,8 +16280,7 @@
 "aIS" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -16944,8 +16290,7 @@
 	name = "trash bin"
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -17209,8 +16554,7 @@
 	})
 "aJt" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/railing/mapped{
 	dir = 4
@@ -17219,8 +16563,7 @@
 /area/site53/ulcz/hallways)
 "aJu" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -17228,12 +16571,10 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -17272,15 +16613,13 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aJz" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -17310,15 +16649,13 @@
 	name = "Hallway"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aJD" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -17327,8 +16664,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -17353,7 +16689,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -17397,9 +16732,7 @@
 	})
 "aJL" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
@@ -17427,12 +16760,10 @@
 /area/site53/ulcz/scp078)
 "aJP" = (
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /obj/effect/catwalk_plated/white,
 /turf/simulated/open,
@@ -17444,15 +16775,13 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aJR" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -17465,7 +16794,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access = list(201)
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -17552,8 +16880,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+	dir = 1
 	},
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
@@ -17836,8 +17163,7 @@
 "aKz" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/scp8containment{
@@ -17856,7 +17182,6 @@
 "aKC" = (
 /obj/item/device/radio/intercom/locked{
 	dir = 1;
-	icon_state = "intercom";
 	name = "intercom (SCP-173)"
 	},
 /obj/structure/table/reinforced,
@@ -17946,7 +17271,6 @@
 	req_access = list(list(202,303))
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "173emerg"
 	},
@@ -17978,8 +17302,7 @@
 /area/site53/ulcz/scp173)
 "aKR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -18006,8 +17329,7 @@
 	})
 "aKV" = (
 /obj/machinery/door/airlock/maintenance{
-	name = "Cleaning Supplies";
-	req_access = list()
+	name = "Cleaning Supplies"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
@@ -18046,7 +17368,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -18060,8 +17381,7 @@
 "aLa" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -18118,8 +17438,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
@@ -18161,8 +17480,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -18229,16 +17547,14 @@
 	})
 "aLu" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -18261,8 +17577,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
@@ -18317,9 +17632,7 @@
 /area/site53/ulcz/scp173)
 "aLC" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -18329,7 +17642,6 @@
 "aLD" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -18347,16 +17659,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
 "aLH" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -18389,8 +17698,7 @@
 /area/site53/lowertrams/restaurant)
 "aLM" = (
 /obj/machinery/power/apc/hyper{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -18410,9 +17718,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/escape)
 "aLO" = (
-/obj/structure/closet/secure_closet/bar_torch{
-	req_access = list()
-	},
+/obj/structure/closet/secure_closet/bar_torch,
 /obj/item/book/manual/barman_recipes,
 /obj/item/clothing/gloves/thick,
 /obj/machinery/camera/network/entrance,
@@ -18439,8 +17745,7 @@
 "aLS" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -18485,7 +17790,6 @@
 "aLZ" = (
 /obj/item/device/radio/intercom/locked{
 	dir = 8;
-	icon_state = "intercom";
 	name = "intercom (SCP-173)";
 	pixel_x = -32
 	},
@@ -18503,7 +17807,6 @@
 "aMc" = (
 /obj/item/device/radio/intercom/locked{
 	dir = 4;
-	icon_state = "intercom";
 	name = "intercom (SCP-173)";
 	pixel_x = 32
 	},
@@ -18604,8 +17907,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -18656,8 +17958,7 @@
 /obj/item/ammo_magazine/box/a556,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/checkequip{
@@ -18672,8 +17973,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -18699,6 +17999,18 @@
 /obj/item/ammo_magazine/scp/mk9,
 /obj/item/ammo_magazine/scp/mk9,
 /obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper LCZ Security Center"
@@ -18706,7 +18018,6 @@
 "aMy" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "173emerg"
 	},
@@ -18715,13 +18026,10 @@
 "aMz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -18755,7 +18063,7 @@
 /area/site53/ulcz/scp173)
 "aMC" = (
 /obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/prepainted,
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper ULCZ Secure Armoury"
 	})
@@ -18764,12 +18072,6 @@
 /turf/simulated/wall/prepainted,
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper ULCZ Checkpoint"
-	})
-"aME" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/llcz/dclass/checkequip{
-	name = "\improper LCZ Security Center"
 	})
 "aMF" = (
 /obj/effect/paint_stripe/brown,
@@ -18840,8 +18142,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18860,8 +18161,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/white,
@@ -18870,14 +18170,12 @@
 "aMP" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/papershredder,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -18935,8 +18233,7 @@
 	})
 "aMU" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -18980,8 +18277,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -19017,17 +18313,6 @@
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper LCZ Security Center"
 	})
-"aNc" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/checkequip{
-	name = "\improper LCZ Security Center"
-	})
 "aNd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19044,8 +18329,7 @@
 "aNe" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/item/reagent_containers/glass/beaker/bowl{
 	name = "food bowl"
@@ -19075,8 +18359,7 @@
 	})
 "aNi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -19176,8 +18459,7 @@
 "aNq" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -19185,8 +18467,7 @@
 "aNr" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -19199,13 +18480,11 @@
 	})
 "aNt" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -19270,8 +18549,7 @@
 /area/site53/ulcz/scp999)
 "aNA" = (
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -19309,8 +18587,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp999)
@@ -19326,8 +18603,7 @@
 	},
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp999)
@@ -19342,13 +18618,11 @@
 /area/site53/ulcz/hallways)
 "aNH" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/monotile/white,
@@ -19420,8 +18694,7 @@
 	})
 "aNO" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -19445,8 +18718,7 @@
 	})
 "aNQ" = (
 /obj/structure/bed/chair{
-	dir = 8;
-	icon_state = "chair_preview"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/checkequip{
@@ -19468,7 +18740,6 @@
 "aNT" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/reagent_dispensers/coolanttank,
@@ -19513,8 +18784,7 @@
 /area/site53/lowertrams/redline)
 "aNZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8;
-	icon_state = "map-scrubbers"
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
@@ -19567,8 +18837,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8;
-	icon_state = "bordercolorcorner"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -19622,8 +18891,7 @@
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -19635,7 +18903,6 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 1;
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -19646,8 +18913,7 @@
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -19673,8 +18939,7 @@
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -19710,9 +18975,7 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/grass,
 /area/site53/science/aicobservation)
@@ -19753,12 +19016,10 @@
 /area/site53/engineering/controlroom)
 "aOy" = (
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /turf/simulated/floor/lino,
 /area/site53/lowertrams/restaurant)
@@ -19804,8 +19065,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19823,8 +19083,7 @@
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -19840,8 +19099,7 @@
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/corner/red{
-	dir = 10;
-	icon_state = "corner_white"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/uppernukeladders)
@@ -19849,8 +19107,7 @@
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/button/blast_door{
 	dir = 1;
@@ -19942,8 +19199,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1;
-	icon_state = "map-scrubbers"
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -19965,8 +19221,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -20059,7 +19314,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast2"
 	},
@@ -20175,8 +19429,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp263)
@@ -20193,8 +19446,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -20210,8 +19462,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -20362,9 +19613,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /obj/effect/floor_decal/corner/green/mono,
 /obj/structure/bed/chair,
@@ -20372,15 +19621,12 @@
 /area/site53/lowertrams/escape)
 "aPO" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/monotile,
@@ -20447,7 +19693,6 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Secure Armoury";
 	name = "ULCZ Secure Armoury"
@@ -20455,8 +19700,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/space,
 /area/site53/llcz/dclass/checkequip{
@@ -20508,8 +19752,7 @@
 "aQb" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp8containment{
@@ -20579,8 +19822,7 @@
 /obj/structure/barricade,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/barricade/spike{
 	name = "Spikes"
@@ -20591,9 +19833,7 @@
 	})
 "aQj" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
 	temperature = 80
@@ -20834,8 +20074,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
@@ -20849,8 +20088,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -20978,7 +20216,6 @@
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "Entity Cage";
 	name = "Entity Cage"
 	},
@@ -21005,7 +20242,6 @@
 /area/site53/upper_surface/serverfarminterior)
 "aRb" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(201)
 	},
@@ -21149,7 +20385,6 @@
 "aRv" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "Entity Cage Separator";
 	name = "Entity Cage Separator"
 	},
@@ -21196,7 +20431,6 @@
 "aRB" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "Research Arena Entrance";
 	name = "Research Arena Entrance"
 	},
@@ -21207,7 +20441,6 @@
 	})
 "aRC" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23;
 	req_access = list(201)
 	},
@@ -21219,8 +20452,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmtunnel)
@@ -21230,9 +20462,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp8containment{
@@ -21256,8 +20486,7 @@
 /area/site53/upper_surface/serverfarmtunnel)
 "aRF" = (
 /obj/structure/disposalpipe/up{
-	dir = 1;
-	icon_state = "pipe-u"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -21282,7 +20511,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access = list(201)
 	},
 /obj/machinery/computer/rcon{
@@ -21304,8 +20532,7 @@
 "aRL" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /obj/item/inflatable/door,
@@ -21378,8 +20605,7 @@
 	})
 "aRS" = (
 /obj/machinery/computer/message_monitor{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
@@ -21434,8 +20660,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -21507,7 +20732,6 @@
 "aSf" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "Research Arena Entrance";
 	name = "Research Arena Entrance"
 	},
@@ -21527,7 +20751,6 @@
 "aSh" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "Entity Cage Separator";
 	name = "Entity Cage Separator"
 	},
@@ -21590,8 +20813,7 @@
 /area/site53/upper_surface/serverfarmcontrol)
 "aSp" = (
 /obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
@@ -21636,16 +20858,13 @@
 "aSx" = (
 /obj/machinery/r_n_d/server/core,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
 "aSy" = (
 /obj/effect/floor_decal/industrial/loading{
-	dir = 4;
-	icon_state = "loadingarea"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics{
@@ -21653,8 +20872,7 @@
 	})
 "aSz" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -21700,9 +20918,7 @@
 /obj/structure/closet/crate/secure/large,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /mob/living/simple_animal/cat/scp_066,
 /turf/simulated/floor/tiled/monotile/white,
@@ -21735,8 +20951,7 @@
 	})
 "aSL" = (
 /obj/machinery/door/airlock/hatch/maintenance{
-	name = "Abandoned Maintenance Tunnel";
-	req_access = list()
+	name = "Abandoned Maintenance Tunnel"
 	},
 /turf/simulated/floor,
 /area/site53/surface/surface{
@@ -21798,8 +21013,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21841,7 +21055,6 @@
 /obj/structure/railing/mapped,
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "Entity Cage";
 	name = "Entity Cage"
 	},
@@ -21924,7 +21137,6 @@
 	req_access = list(list(202,303))
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "173emerg"
 	},
@@ -21941,7 +21153,6 @@
 "aTl" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Entrance Zone Network")
 	},
 /turf/simulated/floor/tiled/dark,
@@ -21977,8 +21188,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -21988,15 +21198,13 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aTq" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
@@ -22005,8 +21213,7 @@
 	})
 "aTr" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
@@ -22015,8 +21222,7 @@
 	})
 "aTs" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "LCZ Security Center";
@@ -22039,8 +21245,7 @@
 	})
 "aTu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 8
@@ -22065,8 +21270,7 @@
 /area/site53/engineering/primaryhallway)
 "aTx" = (
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22080,8 +21284,7 @@
 	})
 "aTz" = (
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22093,13 +21296,10 @@
 	},
 /obj/structure/hygiene/sink{
 	dir = 1;
-	icon_state = "sink";
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22108,13 +21308,11 @@
 "aTB" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22122,8 +21320,7 @@
 	})
 "aTC" = (
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22145,8 +21342,7 @@
 	pixel_y = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22160,16 +21356,14 @@
 	})
 "aTG" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTH" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22207,8 +21401,7 @@
 /obj/structure/flora/pottedplant,
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 8;
-	icon_state = "corner_white_diagonal"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22249,8 +21442,7 @@
 	})
 "aTR" = (
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22259,8 +21451,7 @@
 "aTS" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/effect/floor_decal/corner/blue/diagonal{
-	dir = 8;
-	icon_state = "corner_white_diagonal"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22273,8 +21464,7 @@
 	})
 "aTU" = (
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -22287,8 +21477,7 @@
 	})
 "aTV" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22305,8 +21494,7 @@
 /area/site53/ulcz/scp173)
 "aTX" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile/white,
@@ -22315,14 +21503,11 @@
 	})
 "aTY" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/bordercorner,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22330,17 +21515,13 @@
 	})
 "aTZ" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8;
-	icon_state = "bordercolorcorner"
+	dir = 8
 	},
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22372,8 +21553,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22384,8 +21564,7 @@
 /area/site53/engineering/engine_smes)
 "aUd" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22393,8 +21572,7 @@
 	})
 "aUe" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -22403,8 +21581,7 @@
 /area/site53/ulcz/hallways)
 "aUf" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -22439,8 +21616,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/reinforced,
@@ -22454,8 +21630,7 @@
 /area/site53/engineering/containment_engineer)
 "aUk" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22470,8 +21645,7 @@
 "aUm" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22480,8 +21654,7 @@
 "aUn" = (
 /obj/machinery/vending/fitness,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22490,8 +21663,7 @@
 "aUo" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22501,13 +21673,11 @@
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22515,8 +21685,7 @@
 	})
 "aUq" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/effect/landmark/start{
 	name = "LCZ Junior Guard"
@@ -22560,8 +21729,7 @@
 	})
 "aUv" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/device/flashlight/lamp,
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -22572,8 +21740,7 @@
 	})
 "aUw" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -22594,8 +21761,7 @@
 	})
 "aUy" = (
 /obj/effect/floor_decal/spline/plain/blue{
-	dir = 9;
-	icon_state = "spline_plain"
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/site53/llcz/dclass/checkequip{
@@ -22603,8 +21769,7 @@
 	})
 "aUz" = (
 /obj/effect/floor_decal/spline/plain/blue{
-	dir = 1;
-	icon_state = "spline_plain"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/site53/llcz/dclass/checkequip{
@@ -22612,8 +21777,7 @@
 	})
 "aUA" = (
 /obj/effect/floor_decal/spline/plain/blue{
-	dir = 5;
-	icon_state = "spline_plain"
+	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/site53/llcz/dclass/checkequip{
@@ -22622,8 +21786,7 @@
 "aUB" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -22681,8 +21844,7 @@
 	})
 "aUI" = (
 /obj/effect/floor_decal/spline/plain/blue{
-	dir = 8;
-	icon_state = "spline_plain"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/site53/llcz/dclass/checkequip{
@@ -22690,13 +21852,11 @@
 	})
 "aUJ" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -22709,8 +21869,7 @@
 	})
 "aUK" = (
 /obj/effect/floor_decal/spline/plain/blue{
-	dir = 4;
-	icon_state = "spline_plain"
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/site53/llcz/dclass/checkequip{
@@ -22719,8 +21878,7 @@
 "aUL" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22746,8 +21904,7 @@
 	})
 "aUO" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/filingcabinet/chestdrawer,
@@ -22757,8 +21914,7 @@
 	})
 "aUP" = (
 /obj/effect/floor_decal/spline/plain/blue{
-	dir = 10;
-	icon_state = "spline_plain"
+	dir = 10
 	},
 /turf/simulated/floor/wood,
 /area/site53/llcz/dclass/checkequip{
@@ -22772,8 +21928,7 @@
 	})
 "aUR" = (
 /obj/effect/floor_decal/spline/plain/blue{
-	dir = 6;
-	icon_state = "spline_plain"
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/site53/llcz/dclass/checkequip{
@@ -22782,8 +21937,7 @@
 "aUS" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22799,8 +21953,7 @@
 	})
 "aUU" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -22814,8 +21967,7 @@
 /area/shuttle/escape_pod7/station)
 "aUW" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -22888,8 +22040,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22898,8 +22049,7 @@
 "aVf" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/table/reinforced,
@@ -22937,8 +22087,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/site53/llcz/dclass/checkequip{
@@ -22953,8 +22102,7 @@
 	})
 "aVk" = (
 /obj/structure/bed/chair{
-	dir = 8;
-	icon_state = "chair_preview"
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/monotile/white,
@@ -22963,17 +22111,14 @@
 	})
 "aVl" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -22984,8 +22129,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -23025,8 +22169,7 @@
 	})
 "aVq" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -23048,8 +22191,7 @@
 	},
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -23058,8 +22200,7 @@
 "aVs" = (
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23074,8 +22215,7 @@
 "aVt" = (
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -23088,8 +22228,7 @@
 	},
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23123,8 +22262,7 @@
 "aVy" = (
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -23152,8 +22290,7 @@
 	})
 "aVA" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/monotile/white,
@@ -23174,8 +22311,7 @@
 /area/site53/ulcz/hallways)
 "aVC" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/monotile/white,
@@ -23228,8 +22364,7 @@
 	})
 "aVJ" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/effect/landmark/start{
 	name = "LCZ Guard"
@@ -23258,8 +22393,7 @@
 	})
 "aVM" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/effect/landmark/start{
 	name = "LCZ Junior Guard"
@@ -23271,8 +22405,7 @@
 "aVN" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /obj/item/pen,
@@ -23301,8 +22434,7 @@
 "aVP" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/securitypost)
@@ -23380,7 +22512,6 @@
 	req_access = list(203)
 	},
 /obj/machinery/door/blast/regular{
-	begins_closed = 1;
 	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
 	name = "UHCZ Secure Maintenance Tunnel Lockdown"
 	},
@@ -23474,7 +22605,6 @@
 	req_access = list(list(202,303))
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "173emerg"
 	},
@@ -23548,8 +22678,7 @@
 /area/site53/ulcz/generalpurpose)
 "aWr" = (
 /obj/machinery/camera/network/lcz{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500{
@@ -23565,19 +22694,16 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aWu" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -23604,7 +22730,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
@@ -23616,8 +22741,7 @@
 /area/site53/llcz/scp013)
 "aWA" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -23629,7 +22753,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
@@ -23690,8 +22813,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp013)
@@ -23776,12 +22898,10 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -23801,7 +22921,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -23818,7 +22937,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
@@ -23834,7 +22952,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
@@ -23876,21 +22993,18 @@
 /area/site53/llcz/scp131)
 "aXe" = (
 /obj/machinery/door/airlock/science{
-	name = "SCP-131";
-	req_access = list()
+	name = "SCP-131"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp131)
 "aXf" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 8
@@ -23916,21 +23030,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/ulcz/hallways)
-"aXh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
 "aXi" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-500";
@@ -24029,13 +23133,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose)
-"aXr" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/generalpurpose)
 "aXs" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/outline/orange,
@@ -24062,8 +23159,7 @@
 /obj/item/device/flashlight/lamp,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -24071,7 +23167,6 @@
 "aXy" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -24295,8 +23390,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/ulcz/tram)
@@ -24331,9 +23425,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -11;
-	pixel_y = 0;
-	pixel_z = 0
+	pixel_x = -11
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/green/mono,
@@ -24351,8 +23443,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/tramstation)
@@ -24429,8 +23520,7 @@
 /area/site53/upper_surface/serverfarminterior)
 "aYt" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	network = list("Light Containment Zone Network")
@@ -24443,13 +23533,10 @@
 "aYu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -24519,8 +23606,7 @@
 "aYC" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
@@ -24605,8 +23691,7 @@
 	})
 "aYN" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/item/stack/medical/splint,
 /obj/item/stack/medical/splint,
@@ -24631,8 +23716,7 @@
 "aYS" = (
 /obj/structure/closet/secure_closet/mtf/exp,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -24701,7 +23785,6 @@
 "aZb" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "car"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -24753,8 +23836,7 @@
 /area/site53/tram/scpcar)
 "aZi" = (
 /obj/machinery/computer{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/tram/scpcar)
@@ -24803,7 +23885,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -24813,31 +23894,27 @@
 	})
 "aZr" = (
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
 "aZs" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aZt" = (
 /obj/machinery/camera/network/entrance{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/lowertrams/brownline)
 "aZu" = (
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -24857,8 +23934,7 @@
 /area/site53/lowertrams/hczmaint)
 "aZw" = (
 /obj/machinery/camera/network/entrance{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /obj/structure/flora/pottedplant/floorleaf,
 /obj/effect/floor_decal/corner/green/mono,
@@ -24866,31 +23942,26 @@
 /area/site53/lowertrams/escape)
 "aZx" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aZy" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/camera/network/lcz{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aZz" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/camera/network/lcz{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -24904,8 +23975,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -24914,8 +23984,7 @@
 /area/site53/engineering/engine_smes)
 "aZC" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -24942,8 +24011,7 @@
 /area/site53/lhcz/scp035room)
 "aZH" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile/white,
@@ -24958,26 +24026,22 @@
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "aZK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "aZL" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -24988,8 +24052,7 @@
 "aZM" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/machinery/photocopier{
 	pixel_y = 3
@@ -25002,23 +24065,20 @@
 	icon_state = "warning"
 	},
 /obj/machinery/camera/network/scp035{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lhcz/scp035room)
 "aZO" = (
 /obj/structure/table/steel_reinforced,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/southright,
 /turf/simulated/floor/tiled/monotile/white,
@@ -25048,7 +24108,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -25067,8 +24126,7 @@
 /area/site53/lhcz/scp035room)
 "aZU" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
@@ -25096,20 +24154,17 @@
 "aZY" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "aZZ" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -25136,8 +24191,7 @@
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25148,8 +24202,7 @@
 "bae" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25174,8 +24227,7 @@
 /area/site53/lhcz/scp035room)
 "bah" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25204,8 +24256,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25229,22 +24280,19 @@
 "ban" = (
 /obj/structure/closet/radiation,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "bao" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "bap" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/machinery/button/blast_door{
 	dir = 8;
@@ -25272,12 +24320,10 @@
 /obj/item/device/radio,
 /obj/item/device/flashlight/maglight,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/camera/network/scp035{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25288,20 +24334,17 @@
 "bat" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "bau" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25324,8 +24367,7 @@
 "bax" = (
 /obj/structure/closet/radiation,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25336,24 +24378,20 @@
 "baz" = (
 /obj/structure/closet/radiation,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "baA" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
 "baB" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
-	operating = 1;
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
@@ -25370,8 +24408,7 @@
 "baD" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -25396,8 +24433,7 @@
 /area/site53/lhcz/scp343entrance)
 "baI" = (
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25408,8 +24444,7 @@
 /area/site53/lhcz/scp343entrance)
 "baJ" = (
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/structure/sign/scp/amnesiac{
 	pixel_x = 32
@@ -25419,16 +24454,14 @@
 "baK" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lhcz/scp343entrance)
 "baL" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -25441,8 +24474,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lhcz/scp343entrance)
@@ -25463,8 +24495,7 @@
 "baR" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/machinery/camera/network/scp343{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/scp343entrance)
@@ -25477,8 +24508,7 @@
 /area/site53/lhcz/scp343entrance)
 "baT" = (
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/scp343entrance)
@@ -25492,8 +24522,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lhcz/scp343entrance)
@@ -25507,12 +24536,10 @@
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/camera/network/scp343{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lhcz/scp343entrance)
@@ -25530,8 +24557,7 @@
 /area/site53/lhcz/scp343room)
 "bbb" = (
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/structure/sign/scp/memnetic{
 	pixel_x = 32
@@ -25543,8 +24569,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lhcz/scp343entrance)
@@ -25560,8 +24585,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lhcz/scp343entrance)
@@ -25599,19 +24623,15 @@
 /area/site53/lhcz/scp343entrance)
 "bbj" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/item/clothing/suit/bio_suit/security,
 /obj/item/clothing/head/bio_hood/security,
-/obj/structure/closet/secure_closet/mtf/nco{
-	req_access = list(202)
-	},
+/obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/storage/pill_bottle/amnesticsa,
 /obj/item/device/flashlight/maglight,
 /turf/simulated/floor/tiled/monotile/white,
@@ -25653,13 +24673,11 @@
 "bbq" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -25702,8 +24720,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/microwave{
 	pixel_y = 8
@@ -25853,8 +24870,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -25864,8 +24880,7 @@
 "bbV" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -25881,15 +24896,13 @@
 /obj/machinery/photocopier,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/wood,
 /area/site53/lhcz/scp343room)
 "bbY" = (
 /obj/machinery/power/apc{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -25901,8 +24914,7 @@
 	})
 "bbZ" = (
 /obj/machinery/power/apc{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -25914,8 +24926,7 @@
 	})
 "bca" = (
 /obj/structure/bed/chair/wood{
-	dir = 8;
-	icon_state = "wooden_chair_preview"
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/site53/lhcz/scp343room)
@@ -25953,8 +24964,7 @@
 /area/site53/lhcz/scp343room)
 "bcg" = (
 /obj/structure/bed/chair/wood{
-	dir = 1;
-	icon_state = "wooden_chair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/site53/lhcz/scp343room)
@@ -25978,12 +24988,10 @@
 "bcl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -26006,8 +25014,7 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/lino,
 /area/site53/lhcz/scp343room)
@@ -26018,12 +25025,10 @@
 "bcr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/site53/lhcz/scp343room)
@@ -26126,20 +25131,17 @@
 "bcD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/site53/lhcz/scp343room)
 "bcE" = (
 /obj/structure/bed/chair/wood{
-	dir = 1;
-	icon_state = "wooden_chair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/lino,
 /area/site53/lhcz/scp343room)
@@ -26249,8 +25251,7 @@
 "bcW" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/item/paper/scp/euclid/scp078,
 /obj/structure/table/reinforced,
@@ -26260,7 +25261,6 @@
 /obj/machinery/alarm{
 	alarm_id = "petrov3";
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 21
 	},
 /obj/structure/table/reinforced,
@@ -26268,8 +25268,7 @@
 /area/site53/ulcz/scp078)
 "bcY" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/structure/bed/chair,
@@ -26321,9 +25320,7 @@
 /obj/effect/floor_decal/corner/red/border,
 /obj/item/clothing/suit/bio_suit/security,
 /obj/item/clothing/head/bio_hood/security,
-/obj/structure/closet/secure_closet/mtf/nco{
-	req_access = list(202)
-	},
+/obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/storage/pill_bottle/amnesticsa,
 /obj/item/device/flashlight/maglight,
 /turf/simulated/floor/tiled/monotile/white,
@@ -26343,8 +25340,7 @@
 /area/site53/ulcz/hallways)
 "bdh" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/monotile,
@@ -26357,8 +25353,7 @@
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/closet/secure_closet/mtf/enlisted/hcz,
@@ -26405,8 +25400,7 @@
 /area/site53/lowertrams/restaurantkitchenarea)
 "bdq" = (
 /obj/structure/sign/directions/evac{
-	dir = 4;
-	icon_state = "direction_evac"
+	dir = 4
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/r_wall/prepainted,
@@ -26423,8 +25417,7 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/janitoroffice)
@@ -26457,8 +25450,7 @@
 /area/site53/lowertrams/janitoroffice)
 "bdx" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/under/kilt,
@@ -26476,8 +25468,7 @@
 /area/site53/lowertrams/hub)
 "bdB" = (
 /obj/machinery/power/apc{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -26528,8 +25519,7 @@
 "bdJ" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/clothing/mask/gas/sexyclown,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -26556,8 +25546,7 @@
 "bdN" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/clothing/shoes/swimmingfins,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -26565,8 +25554,7 @@
 "bdO" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/lowertrams/hub)
@@ -26622,8 +25610,7 @@
 "bdX" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertrams/hub)
@@ -26648,8 +25635,7 @@
 	})
 "beb" = (
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -26717,8 +25703,7 @@
 "ben" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/hub)
@@ -26726,12 +25711,10 @@
 /obj/structure/closet,
 /obj/item/clothing/under/gentlesuit,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/hub)
@@ -26784,8 +25767,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/hub)
@@ -26803,8 +25785,7 @@
 "bey" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/hub)
@@ -26818,23 +25799,20 @@
 "beA" = (
 /obj/machinery/washing_machine,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/hub)
 "beB" = (
 /obj/machinery/washing_machine,
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/hub)
 "beC" = (
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal,
 /obj/item/clothing/head/bowlerhat,
@@ -26936,13 +25914,10 @@
 "beM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -26964,8 +25939,7 @@
 /area/site53/surface/explorers)
 "beQ" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27003,7 +25977,6 @@
 "beV" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -27018,8 +25991,7 @@
 "beW" = (
 /obj/structure/closet/secure_closet/mtf/exp,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27031,8 +26003,7 @@
 "beY" = (
 /obj/structure/closet/secure_closet/mtf/exp,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27046,16 +26017,13 @@
 "bfb" = (
 /obj/structure/bed/chair/office/light,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/site53/surface/explorers)
 "bfc" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -27120,8 +26088,7 @@
 "bfl" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27139,8 +26106,7 @@
 "bfn" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27164,7 +26130,6 @@
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "50"
 	},
 /turf/simulated/floor/wood,
@@ -27176,7 +26141,6 @@
 "bfs" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "247lockdown"
 	},
@@ -27208,8 +26172,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/item/device/flashlight/pen,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -27222,8 +26185,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27263,24 +26225,20 @@
 /area/site53/surface/explorers)
 "bfG" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/surface/explorers)
 "bfH" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
 "bfI" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
@@ -27289,20 +26247,16 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
 "bfK" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
@@ -27327,12 +26281,10 @@
 /obj/machinery/vending/snack,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
@@ -27342,30 +26294,26 @@
 /area/site53/surface/explorers)
 "bfQ" = (
 /obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 8;
-	icon_state = "bordercolorcorner"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
 "bfR" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
 "bfS" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/surface/explorers)
 "bfT" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "Entity Cage Separator";
 	name = "Entity Cage Separator"
 	},
@@ -27389,8 +26337,7 @@
 /area/site53/ulcz/maintenance)
 "bfW" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
@@ -27409,8 +26356,7 @@
 /area/site53/surface/explorers)
 "bfZ" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27419,8 +26365,7 @@
 	pixel_y = 32
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27441,8 +26386,7 @@
 "bgd" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/orange/mono,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -27465,12 +26409,10 @@
 "bgh" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27493,8 +26435,7 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/recharger,
 /obj/effect/floor_decal/corner/orange/mono,
@@ -27502,12 +26443,10 @@
 /area/site53/surface/explorers)
 "bgl" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27529,33 +26468,28 @@
 /area/site53/ulcz/maintenance)
 "bgn" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
 "bgo" = (
 /obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
 "bgp" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
 "bgq" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
@@ -27570,8 +26504,7 @@
 "bgs" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/item/stack/flag/red,
 /obj/item/stack/flag/red,
@@ -27585,8 +26518,7 @@
 /obj/structure/barricade,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/barricade/spike{
 	name = "Spikes"
@@ -27599,24 +26531,21 @@
 "bgu" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
 "bgv" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
 "bgw" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/surface/explorers)
@@ -27631,7 +26560,6 @@
 	},
 /obj/machinery/door/blast/shutters{
 	dir = 8;
-	icon_state = "shutter1";
 	id_tag = "55"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -27675,8 +26603,7 @@
 	},
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/photocopier{
 	pixel_y = 3
@@ -27704,8 +26631,7 @@
 	})
 "bgE" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
@@ -27731,14 +26657,12 @@
 /obj/structure/bed/roller,
 /obj/structure/iv_drip,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -27805,8 +26729,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "ULCZ Booth Window 1";
@@ -27880,7 +26803,6 @@
 "bgS" = (
 /obj/structure/railing/mapped,
 /obj/machinery/door/blast/regular{
-	begins_closed = 1;
 	id_tag = "ULCZ Entry Line Cycle";
 	name = "ULCZ Checkpoint Processing Entries"
 	},
@@ -27929,7 +26851,6 @@
 	dir = 4
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
@@ -27952,7 +26873,6 @@
 	dir = 4
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
@@ -27991,7 +26911,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
@@ -28006,7 +26925,6 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
@@ -28112,7 +27030,6 @@
 "bhh" = (
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Secure Armoury";
 	name = "ULCZ Secure Armoury"
@@ -28120,8 +27037,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/checkequip{
@@ -28134,7 +27050,6 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "ULCZ Secure Armoury";
 	name = "ULCZ Secure Armoury"
@@ -28142,33 +27057,20 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/space,
 /area/site53/ulcz/hallways)
 "bhj" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
-"bhk" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
-	},
-/turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "bhl" = (
 /obj/effect/catwalk_plated/white,
@@ -28180,30 +27082,15 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"bhn" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/checkequip{
-	name = "\improper LCZ Security Center"
-	})
 "bho" = (
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/power/apc/hyper{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper LCZ Security Center"
@@ -28248,6 +27135,7 @@
 /obj/item/gun/projectile/pistol/mk9,
 /obj/item/gun/projectile/pistol/mk9,
 /obj/item/gun/projectile/pistol/mk9,
+/obj/item/gun/projectile/pistol/mk9,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper LCZ Security Center"
@@ -28260,20 +27148,6 @@
 /obj/item/gun/projectile/automatic/scp/p90,
 /obj/item/gun/projectile/automatic/scp/p90,
 /obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/checkequip{
-	name = "\improper LCZ Security Center"
-	})
-"bht" = (
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Equipment Room"
-	},
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/structure/table/rack,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/checkequip{
 	name = "\improper LCZ Security Center"
@@ -28344,7 +27218,6 @@
 	dir = 4
 	},
 /obj/machinery/door/blast/regular{
-	begins_closed = 1;
 	id_tag = "ULCZ Exit Line Cycle";
 	name = "ULCZ Exit Line Cycle"
 	},
@@ -28367,7 +27240,6 @@
 	},
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8;
-	icon_state = "loadingarea";
 	name = "Exit Line"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -28424,8 +27296,7 @@
 	})
 "bhD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/white,
@@ -28504,8 +27375,7 @@
 "bhI" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/securitypost)
@@ -28590,8 +27460,7 @@
 /obj/structure/closet/secure_closet/mtf/breachshotguns,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/zonecommanderoffice{
@@ -28625,8 +27494,7 @@
 /obj/item/ammo_magazine/box/a556,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/zonecommanderoffice{
@@ -28669,8 +27537,7 @@
 /obj/structure/bed/chair,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uhcz/securitypost)
@@ -28763,7 +27630,6 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "HCZ Secure Armoury";
 	name = "HCZ Secure Armoury"
@@ -28771,8 +27637,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/space,
 /area/site53/zonecommanderoffice{
@@ -28787,12 +27652,10 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "HCZ Secure Armoury";
 	name = "HCZ Secure Armoury"
@@ -28814,8 +27677,7 @@
 "bih" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/zonecommanderoffice{
@@ -28878,7 +27740,6 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "HCZ Secure Armoury";
 	name = "HCZ Secure Armoury"
@@ -28938,8 +27799,7 @@
 /obj/item/ammo_magazine/scp/p90_mag/rubber,
 /obj/item/ammo_magazine/scp/p90_mag/rubber,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 23
@@ -28950,8 +27810,7 @@
 	})
 "biq" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 23
@@ -28974,14 +27833,12 @@
 	})
 "bir" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/structure/closet/secure_closet/mtf/riotshotguns,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice{
@@ -28995,7 +27852,6 @@
 	name = "UHCZ Lockdown"
 	},
 /obj/machinery/door/blast/shutters{
-	begins_closed = 1;
 	id_tag = "UHCZ Booth Window 2";
 	name = "UHCZ Booth Window 2"
 	},
@@ -29031,8 +27887,7 @@
 /area/site53/uhcz/securitypost)
 "biw" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
@@ -29043,8 +27898,7 @@
 	})
 "bix" = (
 /obj/machinery/power/apc/hyper{
-	dir = 4;
-	icon_state = "apc0"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -29065,7 +27919,6 @@
 "biz" = (
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "HCZ Secure Armoury";
 	name = "HCZ Secure Armoury"
@@ -29090,8 +27943,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
-	dir = 4;
-	icon_state = "rwindow"
+	dir = 4
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
 /obj/machinery/door/blast/shutters{
@@ -29140,8 +27992,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/zonecommanderoffice{
@@ -29192,8 +28043,7 @@
 "biJ" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile,
@@ -29385,14 +28235,12 @@
 /area/site53/uhcz/medicalpost)
 "bjb" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/structure/closet/secure_closet/mtf/riotshotguns,
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice{
@@ -29616,8 +28464,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29636,8 +28483,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29664,8 +28510,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29689,8 +28534,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29714,14 +28558,12 @@
 /area/site53/uhcz/medicalpost)
 "bjw" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29739,8 +28581,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29756,14 +28597,12 @@
 	})
 "bjy" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -29781,8 +28620,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "HCZ Secure Armoury";
@@ -29942,8 +28780,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /obj/structure/cable{
@@ -30051,14 +28888,12 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/simulated/floor,
@@ -30208,8 +29043,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30278,8 +29112,7 @@
 	name = "UHCZ Checkpoint Gate 2"
 	},
 /obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "rwindow"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -30309,8 +29142,7 @@
 /area/space)
 "bko" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -30385,7 +29217,6 @@
 "bkE" = (
 /obj/machinery/computer/shuttle_control{
 	dir = 8;
-	icon_state = "computer";
 	name = "Heavy Containment Zone";
 	shuttle_tag = "Heavy Containment Tram"
 	},
@@ -30441,8 +29272,7 @@
 	})
 "blx" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -30488,13 +29318,11 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/vending/wallmed1{
 	layer = 3.3;
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white/monotile,
@@ -30566,16 +29394,13 @@
 /area/site53/lowertrams/hub)
 "bBS" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "bCi" = (
 /obj/effect/floor_decal/corner/yellow{
-	dir = 6;
-	icon_state = "corner_white"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/prototype/control)
@@ -30607,8 +29432,7 @@
 "bHX" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
@@ -30620,12 +29444,10 @@
 /area/site53/ulcz/generalpurpose)
 "bKj" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/camera/network/lcz{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -30681,21 +29503,17 @@
 "bUj" = (
 /obj/item/stool/padded,
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "bWR" = (
 /obj/effect/catwalk_plated/dark,
-/obj/machinery/door/airlock/highsecurity{
-	req_access = list()
-	},
+/obj/machinery/door/airlock/highsecurity,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
@@ -30712,7 +29530,6 @@
 /area/site53/ulcz/scp078)
 "bXP" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	network = list("Entrance Zone Network")
 	},
 /obj/machinery/fabricator,
@@ -30807,7 +29624,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -30820,8 +29636,7 @@
 "cnb" = (
 /obj/machinery/cryopod,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -30835,8 +29650,7 @@
 "cnC" = (
 /obj/structure/flora/pottedplant/floorleaf,
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -30866,8 +29680,7 @@
 /area/site53/llcz/scp066)
 "csb" = (
 /obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8;
-	icon_state = "bordercolorcorner"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -30900,8 +29713,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
@@ -31003,8 +29815,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -31099,8 +29910,7 @@
 "dhc" = (
 /obj/structure/catwalk,
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -31209,8 +30019,7 @@
 /area/site53/science/seniorresearcherb)
 "dDl" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -31367,8 +30176,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "evacbunkerblastdoor";
@@ -31536,14 +30344,12 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/monotile/white,
@@ -31607,8 +30413,7 @@
 	pixel_y = 3
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
@@ -31685,8 +30490,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
@@ -31784,8 +30588,7 @@
 	pixel_y = 3
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
@@ -31818,8 +30621,7 @@
 "fEN" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/site53/surface/bunker)
@@ -31832,7 +30634,6 @@
 "fIM" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8;
-	icon_state = "loadingarea";
 	name = "Exit Line"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -31862,8 +30663,7 @@
 "fNo" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
@@ -31875,9 +30675,7 @@
 "fSv" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
@@ -31886,8 +30684,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -31917,8 +30714,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -31975,9 +30771,7 @@
 "gfP" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
@@ -31996,15 +30790,13 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
 "gjy" = (
 /obj/machinery/camera/network/entrance{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
@@ -32019,8 +30811,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32049,8 +30840,7 @@
 	network = list("Engineering Network")
 	},
 /obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
@@ -32113,16 +30903,14 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
 "gzY" = (
 /obj/structure/cryofeed,
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
@@ -32141,8 +30929,7 @@
 /area/site53/uhcz/scp247observation)
 "gDo" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32158,8 +30945,7 @@
 /area/site53/lowertrams/restaurant)
 "gEx" = (
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -32175,8 +30961,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
@@ -32220,8 +31005,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
@@ -32267,8 +31051,7 @@
 /area/site53/uhcz/scp096)
 "gUk" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/structure/sign/directions/ez{
 	dir = 8;
@@ -32316,8 +31099,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106containment)
@@ -32358,9 +31140,7 @@
 	})
 "hlc" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
@@ -32437,7 +31217,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
@@ -32493,7 +31272,6 @@
 /area/site53/surface/bunker)
 "hDU" = (
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "096chamberlock2"
 	},
@@ -32576,8 +31354,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
@@ -32685,8 +31462,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/power/sensor{
 	name_tag = "#PRIMARY POWER GRID#"
@@ -32703,8 +31479,7 @@
 /area/site53/uhcz/medicalpost)
 "itu" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -32750,8 +31525,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/science{
 	name = "General Storage";
@@ -32764,8 +31538,7 @@
 /area/site53/uhcz/scp096)
 "iDm" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /obj/machinery/light/small/red{
 	dir = 1;
@@ -32850,8 +31623,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32862,9 +31634,7 @@
 /area/site53/uhcz/scp106containment)
 "iNV" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
@@ -32885,8 +31655,7 @@
 /area/site53/science/aicobservation)
 "iTk" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice{
@@ -32902,12 +31671,10 @@
 "iWp" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -32916,8 +31683,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/site53/ulcz/medicalpost)
@@ -32951,8 +31717,7 @@
 "iXE" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32960,8 +31725,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -33003,8 +31767,7 @@
 	dir = 9
 	},
 /obj/machinery/computer/power_monitor{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/engineering/engine_smes)
@@ -33029,8 +31792,7 @@
 /area/site53/llcz/scp066)
 "jnd" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -33088,8 +31850,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/surface/surface{
@@ -33145,9 +31906,7 @@
 "jDV" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
@@ -33180,15 +31939,13 @@
 /area/site53/upper_surface/serverfarmcontrol)
 "jKR" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
 "jML" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
@@ -33256,8 +32013,7 @@
 "jUv" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -33268,8 +32024,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -33288,8 +32043,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -33338,8 +32092,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -33377,8 +32130,7 @@
 	name = "trash bin"
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -33396,8 +32148,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -33489,8 +32240,7 @@
 /area/site53/engineering/primaryhallway)
 "kJi" = (
 /obj/structure/hygiene/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -33579,8 +32329,7 @@
 /area/site53/uhcz/scp8containment)
 "kXm" = (
 /obj/structure/hygiene/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -33592,8 +32341,7 @@
 /obj/structure/bed/roller,
 /obj/structure/iv_drip,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -33639,24 +32387,20 @@
 /obj/structure/table/standard,
 /obj/machinery/microwave,
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "lfX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 9;
-	icon_state = "intact"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/controlroom)
 "liT" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
@@ -33750,7 +32494,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(201)
 	},
@@ -33820,8 +32563,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -33840,9 +32582,7 @@
 "lAo" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
@@ -33865,8 +32605,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -33909,8 +32648,7 @@
 /area/site53/llcz/scp131)
 "lGM" = (
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/surface/bunker)
@@ -33945,8 +32683,7 @@
 /area/site53/uhcz/medicalpost)
 "lOF" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /turf/simulated/floor/lino,
 /area/site53/lowertrams/restaurant)
@@ -34003,7 +32740,6 @@
 	},
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8;
-	icon_state = "loadingarea";
 	name = "Exit Line"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -34129,8 +32865,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/camera/network/entrance,
 /turf/simulated/floor/tiled/white/monotile,
@@ -34139,8 +32874,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
@@ -34256,8 +32990,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/entrance{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/surface/bunker)
@@ -34294,8 +33027,7 @@
 /area/site53/uhcz/tramstation)
 "mPb" = (
 /obj/effect/floor_decal/corner/purple/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -34326,7 +33058,6 @@
 	req_access = list(list(203,304))
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "096chamberlock";
 	name = "Emergency Blast Door"
@@ -34455,8 +33186,7 @@
 /area/site53/lowertrams/orangeline)
 "ngB" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -34472,9 +33202,7 @@
 /area/site53/uhcz/scp106containment)
 "niH" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
@@ -34547,8 +33275,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/light/small/red{
 	dir = 1;
@@ -34558,8 +33285,7 @@
 /area/site53/surface/bunker)
 "nsr" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/button/blast_door{
 	dir = 4;
@@ -34588,8 +33314,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
@@ -34647,8 +33372,7 @@
 /area/site53/llcz/scp263research)
 "nAG" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
@@ -34660,8 +33384,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor,
@@ -34756,8 +33479,7 @@
 /area/site53/uhcz/hallways)
 "nTO" = (
 /obj/machinery/power/apc/hyper{
-	dir = 1;
-	icon_state = "apc0"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -34779,8 +33501,7 @@
 "nUn" = (
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurant)
@@ -34797,8 +33518,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
@@ -34819,8 +33539,7 @@
 "ogX" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
@@ -34854,8 +33573,7 @@
 	})
 "omz" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -34882,8 +33600,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
@@ -34895,16 +33612,13 @@
 "osy" = (
 /obj/structure/bed/chair,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "osz" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 10;
-	icon_state = "bordercolor"
+	dir = 10
 	},
 /obj/machinery/light/small/red{
 	dir = 8
@@ -34927,8 +33641,7 @@
 "ote" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
@@ -34947,7 +33660,6 @@
 "oxL" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "096chamberlock";
 	name = "Emergency Blast Door"
@@ -34965,8 +33677,7 @@
 /area/site53/uhcz/scp096)
 "oBq" = (
 /obj/structure/bed/chair{
-	dir = 4;
-	icon_state = "chair_preview"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
@@ -35010,8 +33721,7 @@
 /area/site53/lowertrams/restaurant)
 "oJB" = (
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
@@ -35049,7 +33759,6 @@
 "oLF" = (
 /obj/machinery/computer/operating{
 	dir = 4;
-	icon_state = "computer";
 	name = "Robotics Operating Computer"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -35065,8 +33774,7 @@
 "oNL" = (
 /obj/effect/floor_decal/corner/yellow/border,
 /obj/machinery/camera/network/lcz{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -35076,8 +33784,7 @@
 	name = "trash bin"
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -35155,19 +33862,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
-"pcU" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
-	},
-/obj/machinery/camera/autoname{
-	network = list("Heavy Containment Zone Network")
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "phs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/alternate/door/bolts{
@@ -35191,9 +33885,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/atmos_alert{
-	icon_state = "computer"
-	},
+/obj/machinery/computer/atmos_alert,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
@@ -35201,8 +33893,7 @@
 /area/site53/engineering/controlroom)
 "pjL" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -35251,8 +33942,7 @@
 	},
 /obj/structure/cable/green,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
@@ -35319,17 +34009,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
-"pAx" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "pCN" = (
 /obj/effect/paint_stripe/mauve,
 /obj/structure/sign/directions/ez,
@@ -35342,9 +34021,7 @@
 /area/site53/uhcz/scp247observation)
 "pFN" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/scp247observation)
@@ -35384,8 +34061,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
 /obj/machinery/light/small{
@@ -35397,9 +34073,7 @@
 "pQe" = (
 /obj/structure/bed/chair,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
@@ -35408,8 +34082,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -35424,7 +34097,6 @@
 "pVt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "scp8panic";
 	name = "SCP-008 Lockdown shutter"
@@ -35489,9 +34161,7 @@
 "qgn" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lowertrams/restaurantkitchenarea)
@@ -35504,8 +34174,7 @@
 /area/site53/lowertrams/janitoroffice)
 "qih" = (
 /obj/effect/floor_decal/corner/purple/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/camera/network/lcz{
 	dir = 8
@@ -35577,8 +34246,7 @@
 	network = list("Heavy Containment Zone Network")
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -35589,8 +34257,7 @@
 /area/site53/lowertrams/redline)
 "qtf" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -35617,12 +34284,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4;
-	icon_state = "intact"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -35673,9 +34338,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/dark,
-/obj/machinery/door/airlock/highsecurity{
-	req_access = list()
-	},
+/obj/machinery/door/airlock/highsecurity,
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "qLk" = (
@@ -35692,7 +34355,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "facilitylockdown";
 	name = "Exterior Lockdown Blast Door"
@@ -35705,8 +34367,7 @@
 	req_access = list()
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 5;
-	icon_state = "bordercolor"
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -35727,8 +34388,7 @@
 /area/site53/science/aicobservation)
 "qVh" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -35747,8 +34407,7 @@
 /area/site53/uhcz/hallways)
 "qWJ" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -35765,8 +34424,7 @@
 /area/site53/llcz/scp263research)
 "qYN" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	network = list("Light Containment Zone Network")
@@ -35819,8 +34477,7 @@
 	req_access = list(list(203,304))
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9;
-	pixel_y = 0
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -35892,8 +34549,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
@@ -35930,8 +34586,7 @@
 /area/site53/uhcz/medicalpost)
 "rvd" = (
 /obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 8;
-	icon_state = "bordercolorcorner"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
@@ -35949,8 +34604,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/medicalpost)
@@ -35981,8 +34635,7 @@
 /area/site53/surface/bunker)
 "rCk" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
@@ -36032,8 +34685,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
@@ -36045,7 +34697,6 @@
 "rMC" = (
 /obj/machinery/camera/network/lcz{
 	dir = 8;
-	icon_state = "camera";
 	name = "General Purpose Testing Laboratory"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -36075,24 +34726,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
-"rPO" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/checkequip{
-	name = "\improper ULCZ Checkpoint"
-	})
 "rWa" = (
 /obj/structure/table/standard,
 /obj/machinery/camera/network/hcz{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -36137,8 +34777,7 @@
 "sdX" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lowertrams/restaurantkitchenarea)
@@ -36173,16 +34812,13 @@
 /area/site53/lowertrams/brownline)
 "siU" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 6;
-	icon_state = "bordercolor"
+	dir = 6
 	},
 /obj/machinery/light/small/red,
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
 "sjc" = (
-/obj/machinery/computer/power_monitor{
-	icon_state = "computer"
-	},
+/obj/machinery/computer/power_monitor,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
@@ -36322,15 +34958,13 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/orange/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
 "sQE" = (
 /obj/machinery/camera/network/entrance{
-	dir = 1;
-	icon_state = "camera"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/site53/surface/bunker)
@@ -36341,8 +34975,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -36459,8 +35092,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/corner/yellow/bordercorner{
-	dir = 4;
-	icon_state = "bordercolorcorner"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -36493,8 +35125,7 @@
 "twN" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/effect/floor_decal/corner/orange/mono,
 /obj/structure/table/standard,
@@ -36503,7 +35134,6 @@
 "tza" = (
 /obj/machinery/power/apc/hyper{
 	dir = 1;
-	icon_state = "apc0";
 	req_access = list(501)
 	},
 /obj/structure/cable/green{
@@ -36646,9 +35276,7 @@
 /area/site53/lowertrams/restaurant)
 "ubt" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
@@ -36679,8 +35307,7 @@
 "ucY" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/structure/dogbed,
 /turf/simulated/floor/tiled/monotile/white,
@@ -36738,8 +35365,7 @@
 /area/site53/uhcz/scp106containment)
 "ulE" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
@@ -36767,8 +35393,7 @@
 /area/site53/llcz/scp263research)
 "uqB" = (
 /obj/structure/hygiene/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36781,8 +35406,7 @@
 /area/site53/uhcz/scp8containment)
 "urn" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36802,8 +35426,7 @@
 	req_access = list(201)
 	},
 /obj/effect/floor_decal/industrial/loading{
-	dir = 8;
-	icon_state = "loadingarea"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
@@ -36822,7 +35445,6 @@
 	req_access = list(list(203,304))
 	},
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "096chamberlock";
 	name = "Emergency Blast Door"
@@ -36899,7 +35521,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access = list(301)
 	},
@@ -36940,8 +35561,7 @@
 /area/site53/science/seniorresearchera)
 "uPL" = (
 /obj/effect/floor_decal/corner/purple/bordercorner{
-	dir = 1;
-	icon_state = "bordercolorcorner"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -36977,8 +35597,7 @@
 /area/site53/uhcz/scp106containment)
 "uWI" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -36998,8 +35617,7 @@
 "uYW" = (
 /obj/structure/catwalk,
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/cyan{
 	icon_state = "0-4"
@@ -37103,7 +35721,6 @@
 "vsb" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Entrance Zone Network")
 	},
 /obj/machinery/light{
@@ -37147,8 +35764,7 @@
 "vuH" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
@@ -37156,8 +35772,7 @@
 /area/site53/science/seniorresearcherb)
 "vuY" = (
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
@@ -37199,15 +35814,13 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lowertrams/orangeline)
 "vEH" = (
 /obj/structure/hygiene/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37221,7 +35834,6 @@
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	network = list("Engineering Network")
 	},
 /turf/simulated/floor/tiled/dark,
@@ -37254,8 +35866,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8;
-	icon_state = "map-supply"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/maintenancetunnel)
@@ -37268,7 +35879,6 @@
 /obj/machinery/alarm{
 	alarm_id = "petrov3";
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 21
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -37311,8 +35921,7 @@
 /area/site53/lowertrams/escape)
 "vNo" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	icon_state = "rwindow"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics{
@@ -37389,8 +35998,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
@@ -37402,8 +36010,7 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/uhcz/scp8containment)
@@ -37430,8 +36037,6 @@
 "vXr" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
-	icon_state = "sink";
-	pixel_x = 0;
 	pixel_y = 11
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -37442,8 +36047,7 @@
 /area/site53/uhcz/scp8containment)
 "vYs" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1;
-	icon_state = "bordercolor"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -37491,8 +36095,7 @@
 "wgY" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -37539,8 +36142,7 @@
 /obj/structure/bed/roller,
 /obj/structure/iv_drip,
 /obj/effect/floor_decal/corner/red/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
@@ -37595,8 +36197,7 @@
 /area/site53/lhcz/scp343room)
 "wtF" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white/monotile,
@@ -37606,7 +36207,6 @@
 /obj/machinery/alarm{
 	alarm_id = "petrov3";
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 21
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -37621,8 +36221,7 @@
 "wvc" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/rack,
 /obj/item/device/radio,
@@ -37675,8 +36274,7 @@
 /area/site53/uhcz/hallways)
 "wDh" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -37701,8 +36299,7 @@
 /area/site53/upper_surface/serverfarmtunnel)
 "wFa" = (
 /obj/structure/bed/chair{
-	dir = 1;
-	icon_state = "chair_preview"
+	dir = 1
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -37731,8 +36328,7 @@
 "wGn" = (
 /obj/structure/table/standard,
 /obj/machinery/camera/network/entrance{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
@@ -37759,8 +36355,7 @@
 /area/site53/surface/bunker)
 "wLC" = (
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 4
@@ -37812,16 +36407,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
-"wTz" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/reswing/robotics{
-	name = "\improper Research Wing Hallways"
-	})
 "wTY" = (
 /obj/structure/table/standard,
 /obj/structure/cable/green{
@@ -37842,12 +36427,10 @@
 /area/site53/llcz/scp066)
 "wVj" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 4;
-	icon_state = "bordercolor"
+	dir = 4
 	},
 /obj/machinery/camera/network/lcz{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -37874,8 +36457,7 @@
 /area/site53/ulcz/scp173)
 "xcy" = (
 /obj/machinery/camera/network/entrance{
-	dir = 4;
-	icon_state = "camera"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
@@ -37909,7 +36491,6 @@
 "xgc" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
-	icon_state = "camera";
 	network = list("Entrance Zone Network")
 	},
 /obj/structure/table/standard,
@@ -37934,8 +36515,7 @@
 /obj/structure/closet/crate/paper_refill,
 /obj/machinery/light{
 	dir = 8;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip{
@@ -38002,9 +36582,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
 "xsq" = (
-/obj/structure/closet/secure_closet/mtf/nco{
-	req_access = list(202)
-	},
+/obj/structure/closet/secure_closet/mtf/nco,
 /obj/effect/floor_decal/corner/red/border,
 /obj/item/clothing/suit/bio_suit/security,
 /obj/item/clothing/head/bio_hood/security,
@@ -38017,8 +36595,7 @@
 "xti" = (
 /obj/machinery/light{
 	dir = 1;
-	icon_state = "tube1";
-	pixel_y = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -38072,9 +36649,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
-	operating = 1;
 	pixel_y = -24
 	},
 /obj/structure/cable/green{
@@ -38138,8 +36713,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/orange/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/machinery/light_switch{
 	dir = 4;
@@ -38162,16 +36736,14 @@
 /area/site53/llcz/scp263research)
 "xQK" = (
 /obj/machinery/computer/rdservercontrol{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
 "xQS" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/camera/network/entrance{
-	dir = 8;
-	icon_state = "camera"
+	dir = 8
 	},
 /turf/simulated/floor/grass,
 /area/site53/lowertrams/brownline)
@@ -38226,8 +36798,7 @@
 /area/site53/ulcz/medicalpost)
 "xZp" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 9;
-	icon_state = "bordercolor"
+	dir = 9
 	},
 /obj/structure/sign/directions/ez{
 	pixel_x = -30
@@ -38243,30 +36814,16 @@
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/site53/surface/bunker)
-"ybu" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_z = 0
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "yfD" = (
 /obj/effect/floor_decal/corner/yellow/border{
-	dir = 8;
-	icon_state = "bordercolor"
+	dir = 8
 	},
 /obj/machinery/button/blast_door{
 	dir = 4;
@@ -38279,7 +36836,6 @@
 "yij" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/blast/regular/open{
-	dir = 1;
 	icon_state = "pdoor0";
 	id_tag = "096chamberlock";
 	name = "Emergency Blast Door"
@@ -39207,12 +37763,12 @@ azA
 azA
 azA
 azA
-aME
-aME
-aME
-aME
-aME
-aME
+aeC
+aeC
+aeC
+aeC
+aeC
+aeC
 aMC
 azA
 azA
@@ -39467,13 +38023,13 @@ azA
 azA
 azA
 azA
-aME
+aeC
 avx
 aMx
 aoN
 bhp
 bhp
-aME
+aeC
 azA
 azA
 azA
@@ -39727,13 +38283,13 @@ azA
 azA
 azA
 azA
-aME
+aeC
 aDI
 ahO
 ahO
 ahO
 bhq
-aME
+aeC
 azA
 azA
 azA
@@ -39987,13 +38543,13 @@ azA
 azA
 azA
 azA
-aME
+aeC
 aMu
 ahO
 aMQ
 ahO
 bhr
-aME
+aeC
 azA
 azA
 azA
@@ -40247,12 +38803,12 @@ azA
 azA
 azA
 azA
-aME
+aeC
 aMu
 ahO
-aNb
-bhn
-bht
+aew
+ahO
+bhr
 aeC
 azA
 azA
@@ -40507,13 +39063,13 @@ aTJ
 aTJ
 azA
 azA
-aME
+aeC
 aMv
 ahO
-aNc
+aNb
 bho
-bht
-aME
+bhq
+aeC
 azA
 azA
 azA
@@ -41564,7 +40120,7 @@ aHf
 aHf
 aMD
 sIQ
-rPO
+tBU
 riw
 aMP
 aVb
@@ -41810,7 +40366,7 @@ azA
 aHf
 aGo
 aKq
-bhk
+aFe
 aHC
 aGv
 aHf
@@ -42865,7 +41421,7 @@ aHf
 aMD
 aMV
 aMS
-rPO
+tBU
 aMS
 aVe
 aMS
@@ -43907,7 +42463,7 @@ aHQ
 aLl
 aGH
 aGp
-aXh
+aWJ
 aGM
 aGp
 aGH
@@ -47017,7 +45573,7 @@ aeP
 aeP
 aeP
 aeP
-aGw
+apj
 yfD
 aKW
 aGH
@@ -47030,7 +45586,7 @@ aeS
 aeS
 aeS
 aeS
-aGw
+apj
 aGH
 aLv
 aGH
@@ -47315,10 +45871,10 @@ aWJ
 aGH
 aGH
 aGH
-aXh
+aWJ
 aXf
 aGH
-aXh
+aWJ
 aXp
 aXv
 bcZ
@@ -47835,10 +46391,10 @@ aWJ
 aGF
 aGF
 aGF
-aXh
+aWJ
 aGF
 aGF
-aXh
+aWJ
 aXp
 bcY
 aXv
@@ -48363,7 +46919,7 @@ nDF
 aXp
 aXp
 aXp
-aXr
+bIm
 aXv
 aXE
 aXv
@@ -57235,14 +55791,14 @@ aqY
 aoS
 aoS
 asc
-aub
-aub
-aub
-aub
-aub
-aub
-aub
-aub
+aTw
+aTw
+aTw
+aTw
+aTw
+aTw
+aTw
+aTw
 azN
 aBR
 awW
@@ -61050,10 +59606,10 @@ acr
 acB
 ahG
 akO
-arQ
+azF
 ahL
 akO
-arQ
+azF
 aNV
 akO
 aOd
@@ -61310,10 +59866,10 @@ act
 acJ
 ahL
 akO
-arQ
+azF
 ahL
 akO
-arQ
+azF
 ahL
 akO
 azF
@@ -61830,7 +60386,7 @@ acv
 acB
 ahG
 akO
-arQ
+azF
 akO
 akO
 akO
@@ -67006,7 +65562,7 @@ ayF
 ayG
 ayK
 aAk
-aCU
+aBY
 aaJ
 abF
 aas
@@ -70135,7 +68691,7 @@ abu
 aav
 abH
 aOv
-aFY
+ahP
 acZ
 adp
 uIO
@@ -73004,7 +71560,7 @@ acZ
 acZ
 abx
 acc
-aEV
+lTp
 adN
 abY
 abW
@@ -73264,7 +71820,7 @@ aOv
 ahP
 abx
 acc
-aEV
+lTp
 acl
 abW
 aNY
@@ -73524,7 +72080,7 @@ lvx
 sWz
 abx
 acc
-aEV
+lTp
 acl
 abW
 acE
@@ -74044,17 +72600,17 @@ aLQ
 hnw
 abY
 acd
-aEV
+lTp
 acl
 abW
 acF
 acQ
 aem
 aes
-aew
+aEX
 aep
 aes
-aew
+aEX
 aFi
 aes
 aOP
@@ -74304,17 +72860,17 @@ abf
 gLb
 abY
 ace
-aEV
+lTp
 acl
 abW
 acG
 aec
 aep
 aes
-aew
+aEX
 aep
 aes
-aew
+aEX
 aep
 aes
 aEX
@@ -74564,7 +73120,7 @@ abf
 gLb
 abY
 aci
-aEV
+lTp
 acl
 abW
 acH
@@ -74824,14 +73380,14 @@ fnj
 aLR
 aAj
 acj
-aEV
+lTp
 acl
 abW
 acM
 acQ
 aem
 aes
-aew
+aEX
 aes
 aes
 aes
@@ -75045,7 +73601,7 @@ aaR
 aaR
 aaR
 aIz
-wTz
+afK
 ahc
 aLU
 fwd
@@ -75084,7 +73640,7 @@ ayq
 ayq
 aAj
 ack
-aEV
+lTp
 adN
 bTH
 acE
@@ -75344,7 +73900,7 @@ aCq
 aCp
 aCK
 aCX
-aEV
+lTp
 acl
 qrM
 adT
@@ -83411,7 +81967,7 @@ bdi
 bdi
 aYC
 ajR
-ybu
+ajT
 ajR
 aBT
 qWM
@@ -83671,7 +82227,7 @@ azA
 aBo
 aBA
 aBA
-ybu
+ajT
 aBA
 aBA
 aBo
@@ -84191,7 +82747,7 @@ azA
 azA
 azA
 aBo
-ybu
+ajT
 aBo
 azA
 azA
@@ -84451,7 +83007,7 @@ azA
 azA
 azA
 aBo
-ybu
+ajT
 aBo
 azA
 azA
@@ -84711,7 +83267,7 @@ azA
 azA
 azA
 aBo
-pAx
+uTI
 aBo
 azA
 azA
@@ -84971,7 +83527,7 @@ azA
 azA
 azA
 aBo
-ybu
+ajT
 aBo
 azA
 azA
@@ -85231,7 +83787,7 @@ azA
 azA
 azA
 aBo
-pcU
+ayW
 aBo
 azA
 azA
@@ -85491,7 +84047,7 @@ azA
 azA
 azA
 aBo
-ybu
+ajT
 aBo
 azA
 azA
@@ -85751,7 +84307,7 @@ azA
 azA
 azA
 aBo
-ybu
+ajT
 aBo
 azA
 azA
@@ -86271,7 +84827,7 @@ azA
 azA
 azA
 aBo
-ybu
+ajT
 aBo
 azA
 azA
@@ -86531,7 +85087,7 @@ azA
 azA
 azA
 aBo
-ybu
+ajT
 aBo
 azA
 azA
@@ -87051,7 +85607,7 @@ rqI
 kPM
 aBA
 xMB
-ybu
+ajT
 aBA
 aBA
 aBo
@@ -87311,7 +85867,7 @@ iKX
 kPM
 aBA
 ajR
-ybu
+ajT
 ajR
 eUI
 aBo
@@ -90431,7 +88987,7 @@ nJV
 riD
 kPM
 kPM
-ake
+bWR
 aAY
 aAY
 aAY
@@ -90444,7 +89000,7 @@ azA
 aAY
 aFL
 aFL
-ake
+bWR
 aFL
 aFL
 aAY
@@ -90690,7 +89246,7 @@ kPM
 nRo
 riD
 kPM
-aBz
+aYC
 ajT
 aBA
 aBA
@@ -90702,7 +89258,7 @@ azA
 azA
 azA
 aAY
-aBz
+aYC
 aBA
 ajT
 aBA


### PR DESCRIPTION
Replaces the Pepperspray Grenades w/ more Pistols & P90s. 

A Lethal armory w/ riot equipment is not needed for LCZ.

LCZ Already has a riot armory by CDZ.