### PR TITLE
Fix species runtime

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -35,6 +35,9 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	else
 		transform = null
 	return
+/mob/living/carbon/human/scp049/New(new_loc, new_species)
+	new_species = "SCP-049"
+	. = ..()
 
 /mob/living/carbon/human/scp049/Initialize()
 	..()
@@ -46,7 +49,6 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	// fix names
 	fully_replace_character_name("SCP-049")
 
-	set_species("SCP-049")
 	GLOB.scp049s += src
 	verbs += /mob/living/carbon/human/proc/SCP_049_talk
 	verbs += /mob/living/carbon/human/proc/door_049

--- a/code/modules/SCP/SCPs/SCP-343.dm
+++ b/code/modules/SCP/SCPs/SCP-343.dm
@@ -16,6 +16,10 @@ GLOBAL_LIST_EMPTY(scp343s)
 /mob/living/carbon/human/scp343/IsAdvancedToolUser()
 	return FALSE
 
+/mob/living/carbon/human/scp343/New(new_loc, new_species)
+	new_species = "SCP-343"
+	. = ..()
+
 /mob/living/carbon/human/scp343/Initialize()
 	..()
 
@@ -27,7 +31,6 @@ GLOBAL_LIST_EMPTY(scp343s)
 	if(mind)
 		mind.name = real_name
 
-	set_species("SCP-343")
 	GLOB.scp343s += src
 
 	verbs += /mob/living/carbon/human/scp343/proc/phase_through_airlock


### PR DESCRIPTION
So since new happens before initalize, and defaults to human specices and human organs. on init it will have to re-set the specices qdelling old organs which causes runtimes. The 106 fix ill be in my rework PR