### PR TITLE
Minor changes to SCRAMBLE goggles. Third time is the charm.

### DIFF
--- a/code/modules/SCP/SCPs/SCP-096.dm
+++ b/code/modules/SCP/SCPs/SCP-096.dm
@@ -214,6 +214,17 @@
 
 /mob/living/simple_animal/hostile/scp096/proc/specialexamine(var/userguy) //Snowflaked.
 	if (istype(userguy, /mob/living/carbon))
+		// Do not let blind folks examine 096. Doesn't make sense.
+		if(ishuman(userguy))
+			var/mob/living/carbon/human/H = userguy
+			if(H.equipment_tint_total == TINT_BLIND)
+				return
+		// Do not let unconscious or dead people examine 096.
+		// Dead as in ghost in dead body, not as in ghost
+		var/mob/M = userguy // we are sure he's atleast a mob
+		if(M.stat)
+			return
+
 		satisfied_urges += userguy
 		var/protected = (userguy in GLOB.scramble_hud_protected)
 		var/scramblehud = (userguy in GLOB.scramble_hud_users)

--- a/code/modules/SCP/SCPs/SCP-096.dm
+++ b/code/modules/SCP/SCPs/SCP-096.dm
@@ -212,45 +212,45 @@
 		return
 	..()
 
-/mob/living/simple_animal/hostile/scp096/proc/specialexamine(var/userguy) //Snowflaked.
-	if (istype(userguy, /mob/living/carbon))
-		// Do not let blind folks examine 096. Doesn't make sense.
-		if(ishuman(userguy))
-			var/mob/living/carbon/human/H = userguy
-			if(H.equipment_tint_total == TINT_BLIND)
-				return
-		// Do not let unconscious or dead people examine 096.
-		// Dead as in ghost in dead body, not as in ghost
-		var/mob/M = userguy // we are sure he's atleast a mob
-		if(M.stat)
-			return
-
-		satisfied_urges += userguy
-		var/protected = (userguy in GLOB.scramble_hud_protected)
-		var/scramblehud = (userguy in GLOB.scramble_hud_users)
-		if(scramblehud)
-			to_chat(userguy, scramble_desc)
-			if(protected)
-				return
-		if (!(userguy in kill_list))
-			kill_list += userguy
-			if(!scramblehud)
-				to_chat(userguy, target_desc_1)
-			if(userguy)
-				addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, userguy, "<span class='alert'>That was a mistake. Run</span>"), 20 SECONDS)
-				addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, userguy, "<span class='danger'>RUN</span>"), 30 SECONDS)
-		else if(!scramblehud)
-			to_chat(userguy, target_desc_2)
-
-		if(will_scream)
-			if(!buckled) dir = 2
-			visible_message("<span class='danger'>[src] SCREAMS!</span>")
-			playsound(get_turf(src), 'sound/voice/096-rage.ogg', 100)
-			screaming = 1
-			will_scream = 0
-			spawn(290)
-				screaming = 0
+/mob/living/simple_animal/hostile/scp096/proc/specialexamine(mob/userguy) //Snowflaked.
+	if (!iscarbon(userguy))
 		return
+	// Do not let blind folks examine 096. Doesn't make sense.
+	if(ishuman(userguy))
+		var/mob/living/carbon/human/H = userguy
+		if(H.equipment_tint_total == TINT_BLIND)
+			return
+	// Do not let unconscious or dead people examine 096.
+	// Dead as in ghost in dead body, not as in ghost
+	if(userguy.stat)
+		return
+
+	satisfied_urges += userguy
+	var/protected = (userguy in GLOB.scramble_hud_protected)
+	var/scramblehud = (userguy in GLOB.scramble_hud_users)
+	if(scramblehud)
+		to_chat(userguy, scramble_desc)
+		if(protected)
+			return
+	if (!(userguy in kill_list))
+		kill_list += userguy
+		if(!scramblehud)
+			to_chat(userguy, target_desc_1)
+		if(userguy)
+			addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, userguy, "<span class='alert'>That was a mistake. Run</span>"), 20 SECONDS)
+			addtimer(CALLBACK(GLOBAL_PROC, .proc/to_chat, userguy, "<span class='danger'>RUN</span>"), 30 SECONDS)
+	else if(!scramblehud)
+		to_chat(userguy, target_desc_2)
+
+	if(will_scream)
+		if(!buckled) dir = 2
+		visible_message("<span class='danger'>[src] SCREAMS!</span>")
+		playsound(get_turf(src), 'sound/voice/096-rage.ogg', 100)
+		screaming = 1
+		will_scream = 0
+		spawn(290)
+			screaming = 0
+	return
 
 /mob/living/simple_animal/hostile/scp096/proc/handle_target(var/mob/living/carbon/target)
 

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -121,7 +121,7 @@
 
 /obj/item/clothing/glasses/hud/scramble
 	name = "SCRAMBLE goggles"
-	desc = "State-of-the-art SCRAMBLE goggles. These things cost a fortune and apparently make you able to view SCP-096!"
+	desc = "State-of-the-art SCRAMBLE goggles. They work by obscuring the face of SCP-096 in software before the brain can register the image."
 	icon_state = "scramble"
 	item_state = "glasses"
 	origin_tech = null
@@ -145,7 +145,7 @@
 
 /obj/item/clothing/glasses/hud/scramble/experimental
 	name = "experimental SCRAMBLE goggles"
-	desc = "Experimental SCRAMBLE goggles. Designed to prevent the user from viewing the face of SCP-096."
+	desc = "Experimental SCRAMBLE goggles. Designed to prevent the user from viewing the face of SCP-096 by obscuring it before the brain can register the image."
 
 /obj/item/clothing/glasses/hud/scramble/experimental/Initialize()
 	. = ..()

--- a/code/modules/research/designs/designs_hud_optical.dm
+++ b/code/modules/research/designs/designs_hud_optical.dm
@@ -62,5 +62,5 @@
 	id = "scramble_goggles"
 	req_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 4)
 	materials = list(MATERIAL_STEEL = 150, MATERIAL_GLASS = 200, MATERIAL_SILVER = 100, MATERIAL_GOLD = 250)
-	build_path = /obj/item/clothing/glasses/hud/scramble
+	build_path = /obj/item/clothing/glasses/hud/scramble/experimental
 	sort_string = "GAAAD"


### PR DESCRIPTION
## About the Pull Request

Changes the variant of scramble goggles made in RnD (from normal to experimental, which have a chance of being faulty)
Changes the description of scramble goggles to be more formal, in-line with the setting
Prevents examining SCP-096 when blindfolded.

## Why It's Good For The Game

Makes getting convenient 096 protection atleast slightly risky
Description more formal to be in-line with the setting
You no longer anger 096 whilst blindfolded when you examine them.

## Did you test it?

Yes.

## Changelog

:cl:
tweak: Research and Development now makes experimental SCRAMBLE goggles instead of the normal variant.
tweak: Scramble goggle description changed to be more in-line with the setting.
bugfix: Being blindfolded and examing SCP-096 will no longer enrage him.
/:cl:

