### PR TITLE
Changes mouse opacity to defines for readibility's sake

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -29,6 +29,11 @@
 #define SEE_INVISIBLE_MINIMUM 5
 #define INVISIBILITY_MAXIMUM 100
 
+//https://secure.byond.com/docs/ref/info.html#/atom/var/mouse_opacity
+#define MOUSE_OPACITY_TRANSPARENT 0
+#define MOUSE_OPACITY_ICON 1
+#define MOUSE_OPACITY_OPAQUE 2
+
 // Some arbitrary defines to be used by self-pruning global lists. (see master_controller)
 #define PROCESS_KILL 26 // Used to trigger removal from a processing list.
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -385,7 +385,7 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 	icon = 'icons/mob/screen_gen.dmi'
 	icon_state = "click_catcher"
 	plane = CLICKCATCHER_PLANE
-	mouse_opacity = 2
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	screen_loc = "CENTER-7,CENTER-7"
 
 /obj/screen/click_catcher/Destroy()

--- a/code/_onclick/hud/deity.dm
+++ b/code/_onclick/hud/deity.dm
@@ -28,7 +28,7 @@
 	for(var/i in 1 to D.control_types.len)
 		var/obj/screen/S = new()
 		S.SetName(null) //Don't want them to be able to actually right click it.
-		S.mouse_opacity = 0
+		S.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		S.icon_state = "blank"
 		desc_screens[D.control_types[i]] = S
 		S.maptext_width = 128

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -150,3 +150,4 @@
 /obj/screen/fullscreen/pain
 	icon_state = "brutedamageoverlay6"
 	alpha = 0
+	

--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -64,7 +64,7 @@
 	icon_state = "default"
 	screen_loc = "CENTER-7,CENTER-7"
 	plane = FULLSCREEN_PLANE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/severity = 0
 	var/allstate = 0 //shows if it should show up for dead people too
 

--- a/code/_onclick/hud/global_hud.dm
+++ b/code/_onclick/hud/global_hud.dm
@@ -18,7 +18,7 @@ GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new())
 	screen.screen_loc = "1,1"
 	screen.icon = 'icons/obj/hud_full.dmi'
 	screen.icon_state = icon_state
-	screen.mouse_opacity = 0
+	screen.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	return screen
 
@@ -37,4 +37,4 @@ GLOBAL_DATUM_INIT(global_hud, /datum/global_hud, new())
 	holomap.icon = null
 	holomap.layer = HUD_BASE_LAYER
 	holomap.screen_loc = UI_HOLOMAP
-	holomap.mouse_opacity = 0
+	holomap.mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/_onclick/hud/hud_alt.dm
+++ b/code/_onclick/hud/hud_alt.dm
@@ -24,7 +24,7 @@ var/list/global_huds = list(
 	screen.screen_loc = "1,1"
 	screen.icon = 'icons/obj/hud_full.dmi'
 	screen.icon_state = icon_state
-	screen.mouse_opacity = 0
+	screen.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	return screen
 
@@ -39,7 +39,7 @@ var/list/global_huds = list(
 	holomap.name = "holomap"
 	holomap.icon = null
 	holomap.screen_loc = ui_holomap
-	holomap.mouse_opacity = 0
+	holomap.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /*
 	The hud datum

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -301,7 +301,7 @@
 		H.fov.icon_state = "combat"
 		H.fov.name = " "
 		H.fov.screen_loc = "1,1"
-		H.fov.mouse_opacity = 0
+		H.fov.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		H.fov.layer = UNDER_HUD_LAYER
 		hud_elements |= H.fov
 

--- a/code/_onclick/hud/human_alt.dm
+++ b/code/_onclick/hud/human_alt.dm
@@ -322,7 +322,7 @@
 	mymob.pain.name = "pain"
 	mymob.pain.screen_loc = "WEST,SOUTH to EAST,NORTH"
 	mymob.pain.layer = UNDER_HUD_LAYER
-	mymob.pain.mouse_opacity = 0
+	mymob.pain.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	hud_elements |= mymob.pain
 
 	mymob.noise = new /obj/screen()
@@ -330,7 +330,7 @@
 	mymob.noise.icon_state = "[rand(1,9)]"
 	mymob.noise.name = " "
 	mymob.noise.screen_loc = "1,1 to 15,15"
-	mymob.noise.mouse_opacity = 0
+	mymob.noise.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	hud_elements |= mymob.noise
 
 	mymob.combat_icon = new /obj/screen()//combat mode
@@ -414,7 +414,7 @@
 		H.fov.icon_state = "combat"
 		H.fov.name = " "
 		H.fov.screen_loc = "1,1"
-		H.fov.mouse_opacity = 0
+		H.fov.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		H.fov.layer = UNDER_HUD_LAYER
 		hud_elements |= H.fov
 

--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	E.alpha = 0
 	E.name = "None"
 	E.maptext = null
-	E.mouse_opacity = 0
+	E.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	E.choice = null
 	E.next_page = FALSE
 
@@ -180,7 +180,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 
 	//Visuals
 	E.alpha = 255
-	E.mouse_opacity = 1
+	E.mouse_opacity = MOUSE_OPACITY_ICON
 	E.cut_overlays()
 	if(choice_id == NEXT_PAGE_ID)
 		E.name = "Next Page"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -25,7 +25,7 @@
 /obj/screen/text
 	icon = null
 	icon_state = null
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	screen_loc = "CENTER-7,CENTER-7"
 	maptext_height = 480
 	maptext_width = 480

--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -1,6 +1,6 @@
 /obj/skybox
 	name = "skybox"
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	anchored = TRUE
 	simulated = FALSE
 	screen_loc = "CENTER:-224,CENTER:-224"

--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -26,7 +26,7 @@ GLOBAL_DATUM_INIT(cinematic, /datum/cinematic, new)
 	cinematic_screen.icon_state = "station_intact"
 	cinematic_screen.plane = HUD_PLANE
 	cinematic_screen.layer = HUD_ABOVE_ITEM_LAYER
-	cinematic_screen.mouse_opacity = 0
+	cinematic_screen.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	cinematic_screen.screen_loc = "1,0"
 
 	//Let's not discuss how this worked previously.

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -100,7 +100,7 @@
 	src.max_progress = max_progress
 	src.actee = actee
 	bar = new()
-	bar.mouse_opacity = 0
+	bar.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	bar.icon = 'icons/effects/progressbar.dmi'
 	bar.icon_state = "prog_bar_0"
 	bar.pixel_x = (actee.x - actor.x) * WORLD_ICON_SIZE

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -27,7 +27,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	plane = DEFAULT_PLANE
 	layer = BASE_AREA_LAYER
 	luminosity = 0
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/lightswitch = 1
 
 	var/eject = null

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -126,7 +126,7 @@
 	if(!fire)
 		fire = 1	//used for firedoor checks
 		update_icon()
-		mouse_opacity = 0
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		if(!all_doors)
 			return
 		for(var/obj/machinery/door/firedoor/D in all_doors)
@@ -141,7 +141,7 @@
 	if (fire)
 		fire = 0	//used for firedoor checks
 		update_icon()
-		mouse_opacity = 0
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		if(!all_doors)
 			return
 		for(var/obj/machinery/door/firedoor/D in all_doors)
@@ -169,13 +169,13 @@
 	if (!( party ))
 		party = 1
 		update_icon()
-		mouse_opacity = 0
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	return
 
 /area/proc/partyreset()
 	if (party)
 		party = 0
-		mouse_opacity = 0
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		update_icon()
 		for(var/obj/machinery/door/firedoor/D in src)
 			if(!D.blocked)

--- a/code/game/gamemodes/cult/cultify/mob.dm
+++ b/code/game/gamemodes/cult/cultify/mob.dm
@@ -39,10 +39,10 @@
 	if((N.z == src.z)&&(get_dist(N,src) <= (N.consume_range+10)) && !(N in view(src)))
 		if(!narsimage) //Create narsimage
 			narsimage = image('icons/obj/narsie.dmi',src.loc,"narsie",9,1)
-			narsimage.mouse_opacity = 0
+			narsimage.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		if(!narglow) //Create narglow
 			narglow = image('icons/obj/narsie.dmi',narsimage.loc,"glow-narsie",12,1)
-			narglow.mouse_opacity = 0
+			narglow.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		//Else if no dir is given, simply send them the image of narsie
 		var/new_x = 32 * (N.x - src.x) + N.pixel_x
 		var/new_y = 32 * (N.y - src.y) + N.pixel_y

--- a/code/game/gamemodes/cult/ghosts.dm
+++ b/code/game/gamemodes/cult/ghosts.dm
@@ -281,9 +281,9 @@
 		to_chat(src, "<span class='info'>You are now invisible.</span>")
 		visible_message("<span class='emote'>It fades from sight...</span>")
 		set_invisibility(INVISIBILITY_OBSERVER)
-		mouse_opacity = 1
+		mouse_opacity = MOUSE_OPACITY_ICON
 	else
 		ghost_magic_cd = world.time + 60 SECONDS
 		to_chat(src, "<span class='info'>You are now visible.</span>")
 		set_invisibility(0)
-		mouse_opacity = 0 // This is so they don't make people invincible to melee attacks by hovering over them
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT // This is so they don't make people invincible to melee attacks by hovering over them

--- a/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
+++ b/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
@@ -20,7 +20,7 @@
 			else
 				apply_bluespaced(M)
 	for(var/mob/goast in GLOB.ghost_mob_list)
-		goast.mouse_opacity = 0	//can't let you click that Dave
+		goast.mouse_opacity = MOUSE_OPACITY_TRANSPARENT	//can't let you click that Dave
 		goast.set_invisibility(SEE_INVISIBLE_LIVING)
 		goast.alpha = 255
 	old_accessible_z_levels = GLOB.using_map.accessible_z_levels.Copy()

--- a/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
+++ b/code/game/gamemodes/endgame/nuclear_explosion/nuclear_explosion.dm
@@ -12,7 +12,7 @@
 	cinematic.icon_state = "station_intact"
 	cinematic.plane = HUD_PLANE
 	cinematic.layer = HUD_ABOVE_ITEM_LAYER
-	cinematic.mouse_opacity = 2
+	cinematic.mouse_opacity = MOUSE_OPACITY_OPAQUE
 	cinematic.screen_loc = "1,0"
 
 /datum/universal_state/nuclear_explosion/OnEnter()

--- a/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
+++ b/code/game/gamemodes/endgame/supermatter_cascade/portal.dm
@@ -76,7 +76,7 @@
 	if((R.z == get_z(T_mob)) && (get_dist(R,T_mob) <= (R.consume_range+10)) && !(R in view(T_mob)))
 		if(!riftimage)
 			riftimage = image('icons/obj/rift.dmi',T_mob,"rift",LIGHTING_LAYER+2,1)
-			riftimage.mouse_opacity = 0
+			riftimage.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 		var/new_x = 32 * (R.x - T_mob.x) + R.pixel_x
 		var/new_y = 32 * (R.y - T_mob.y) + R.pixel_y

--- a/code/game/gamemodes/gameticker.dm
+++ b/code/game/gamemodes/gameticker.dm
@@ -187,7 +187,7 @@ var/global/datum/controller/gameticker/ticker
 		cinematic.icon_state = "station_intact"
 		cinematic.plane = HUD_PLANE
 		cinematic.layer = HUD_ABOVE_ITEM_LAYER
-		cinematic.mouse_opacity = 0
+		cinematic.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		cinematic.screen_loc = "1,0"
 
 		var/obj/structure/bed/temp_buckle = new(src)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -310,7 +310,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	if(A)
 		if(A.holo_icon_malf == TRUE)
 			hologram.add_overlay(icon("icons/effects/effects.dmi", "malf-scanline"))
-	hologram.mouse_opacity = 0//So you can't click on it.
+	hologram.mouse_opacity = MOUSE_OPACITY_TRANSPARENT//So you can't click on it.
 	hologram.layer = ABOVE_HUMAN_LAYER //Above all the other objects/mobs. Or the vast majority of them.
 	hologram.anchored = TRUE//So space wind cannot drag it.
 	if(caller_id)

--- a/code/game/machinery/rotating_alarm.dm
+++ b/code/game/machinery/rotating_alarm.dm
@@ -7,7 +7,7 @@
 	var/_color = COLOR_ORANGE
 	plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	layer = EYE_GLOW_LAYER
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 
 /obj/effect/spinning_light/Initialize()

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -56,7 +56,7 @@ GLOBAL_LIST(end_titles)
 
 /obj/screen/credit
 	icon_state = "blank"
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	alpha = 0
 	screen_loc = "1,1"
 	plane = HUD_PLANE

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -9,7 +9,7 @@
 	anchored = TRUE
 	density = FALSE
 	layer = ABOVE_OBJ_LAYER
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	animate_movement = 0
 	var/amount = 3
 	var/expand = 1

--- a/code/game/objects/effects/chem/foam.dm
+++ b/code/game/objects/effects/chem/foam.dm
@@ -180,3 +180,4 @@
 	if(air_group)
 		return 0
 	return !density
+	

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -2,7 +2,7 @@
 	name = "water"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "extinguish"
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE
 
 /obj/effect/effect/water/New(loc)

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -29,7 +29,7 @@
 	gender = PLURAL
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "dirt"
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	persistent = TRUE
 
 /obj/effect/decal/cleanable/flour

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -5,7 +5,7 @@
 	icon_state = "arrow"
 	layer = POINTER_LAYER
 	anchored = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/decal/point/Initialize()
 	. = ..()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -9,7 +9,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 /obj/effect/effect
 	name = "effect"
 	icon = 'icons/effects/effects.dmi'
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	unacidable = TRUE
 	pass_flags = PASS_FLAG_TABLE | PASS_FLAG_GRILLE
 
@@ -99,7 +99,7 @@ steam.start() -- spawns the effect
 	icon = 'icons/effects/effects.dmi'
 	var/amount = 6.0
 	anchored = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/sparks/New()
 	..()
@@ -174,7 +174,7 @@ steam.start() -- spawns the effect
 	icon_state = "smoke"
 	opacity = 1
 	anchored = FALSE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/amount = 6.0
 	var/time_to_live = 100
 

--- a/code/game/objects/effects/explosion_particles.dm
+++ b/code/game/objects/effects/explosion_particles.dm
@@ -4,7 +4,7 @@
 	icon_state = "explosion_particle"
 	opacity = 1
 	anchored = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/expl_particles/New()
 	..()
@@ -36,7 +36,7 @@
 	icon_state = "explosion"
 	opacity = 1
 	anchored = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	pixel_x = -32
 	pixel_y = -32
 

--- a/code/game/objects/effects/explosion_particles.dm
+++ b/code/game/objects/effects/explosion_particles.dm
@@ -62,3 +62,4 @@
 	var/datum/effect/effect/system/smoke_spread/S = new/datum/effect/effect/system/smoke_spread()
 	S.set_up(5,0,location,null)
 	S.start()
+	

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -4,7 +4,7 @@
 	anchored = TRUE
 	simulated = FALSE
 	opacity = 0
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = FLY_LAYER
 	alpha = 0
 	color = COLOR_OCEAN
@@ -89,7 +89,7 @@
 // Permaflood overlay.
 /obj/effect/flood
 	name = ""
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = DEEP_FLUID_LAYER
 	color = COLOR_OCEAN
 	icon = 'icons/effects/liquids.dmi'

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -47,7 +47,7 @@
 	anchored = TRUE
 	density = TRUE
 	layer = ABOVE_TILE_LAYER
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/overlay/wallrot/New()
 	..()

--- a/code/game/objects/effects/particles/particles.dm
+++ b/code/game/objects/effects/particles/particles.dm
@@ -128,7 +128,7 @@
 /obj/particle_emitter
 	name = ""
 	anchored = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	appearance_flags = PIXEL_SCALE
 
 /obj/particle_emitter/Initialize(mapload, time, _color)
@@ -191,7 +191,7 @@
 /obj/particle_emitter/sparks_flare
 	plane = EFFECTS_ABOVE_LIGHTING_PLANE
 	particles = new/particles/flare_sparks
-	mouse_opacity = 1
+	mouse_opacity = MOUSE_OPACITY_ICON
 
 /obj/particle_emitter/sparks_flare/Initialize(mapload, time, _color)
 	. = ..()

--- a/code/game/objects/effects/projectile/projectile_effects.dm
+++ b/code/game/objects/effects/projectile/projectile_effects.dm
@@ -9,7 +9,7 @@
 	light_color = "#00ffff"
 	light_outer_range = 2
 	light_max_bright = 1
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	appearance_flags = 0
 	var/overlay_state
 	var/overlay_color

--- a/code/game/objects/effects/temporaray.dm
+++ b/code/game/objects/effects/temporaray.dm
@@ -3,7 +3,7 @@
 	icon_state = "nothing"
 	anchored = TRUE
 	layer = ABOVE_HUMAN_LAYER
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	simulated = FALSE
 	var/duration = 10 //in deciseconds
 

--- a/code/game/objects/effects/temporary_effect.dm
+++ b/code/game/objects/effects/temporary_effect.dm
@@ -3,7 +3,7 @@
 	icon = 'icons/effects/effects.dmi'
 	anchored = TRUE
 	unacidable = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	density = FALSE
 	layer = ABOVE_HUMAN_LAYER
 	var/duration = 30

--- a/code/game/objects/items/devices/t_scanner.dm
+++ b/code/game/objects/items/devices/t_scanner.dm
@@ -111,7 +111,7 @@
 			I.underlays += M.underlays
 
 		I.alpha = 128
-		I.mouse_opacity = 0
+		I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		. = I
 
 	// Add it to cache, cutting old entries if the list is too long

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -43,17 +43,17 @@
 
 	stored_start = new /obj //we just need these to hold the icon
 	stored_start.icon_state = "stored_start"
-	stored_start.mouse_opacity = 1
+	stored_start.mouse_opacity = MOUSE_OPACITY_ICON
 	stored_start.plane = FLOAT_PLANE
 	stored_start.layer = HUD_CLICKABLE_LAYER
 	stored_continue = new /obj
 	stored_continue.icon_state = "stored_continue"
-	stored_continue.mouse_opacity = 1
+	stored_continue.mouse_opacity = MOUSE_OPACITY_ICON
 	stored_continue.plane = FLOAT_PLANE
 	stored_continue.layer = HUD_CLICKABLE_LAYER
 	stored_end = new /obj
 	stored_end.icon_state = "stored_end"
-	stored_end.mouse_opacity = 1
+	stored_end.mouse_opacity = MOUSE_OPACITY_ICON
 	stored_end.plane = FLOAT_PLANE
 	stored_end.layer = HUD_CLICKABLE_LAYER
 

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -93,7 +93,7 @@
 
 	density = TRUE
 	opacity = 0
-	mouse_opacity = 1
+	mouse_opacity = MOUSE_OPACITY_ICON
 	anchored = TRUE
 	can_buckle = 0 //no manual buckling or unbuckling
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -246,7 +246,7 @@
 	icon_state = "mist"
 	layer = MOB_LAYER + 1
 	anchored = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/structure/hygiene/shower/attack_hand(var/mob/M)
 	on = !on

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -117,7 +117,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	//Icon for fire on turfs.
 
 	anchored = TRUE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	blend_mode = BLEND_ADD
 

--- a/code/modules/admin/buildmode/_overlay.dm
+++ b/code/modules/admin/buildmode/_overlay.dm
@@ -14,7 +14,7 @@
 	for (var/x = -size to size step 1)
 		for (var/y = -size to size step 1)
 			var/atom/movable/M = new
-			M.mouse_opacity = 0
+			M.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 			M.icon = 'icons/turf/overlays.dmi'
 			M.icon_state = icon_state
 			M.screen_loc = "CENTER[x < 0 ? "-" : "+"][abs(x)],CENTER[y < 0 ? "-" : "+"][abs(y)]"

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -8,7 +8,7 @@
 	density = TRUE
 	opacity = 1
 	anchored = TRUE
-	mouse_opacity = 2
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 	layer = BLOB_SHIELD_LAYER
 

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -41,7 +41,7 @@
 	icon = 'icons/obj/hydroponics_growing.dmi'
 	icon_state = ""
 	pass_flags = PASS_FLAG_TABLE
-	mouse_opacity = 1
+	mouse_opacity = MOUSE_OPACITY_ICON
 
 	var/health = 10
 	var/max_health = 100
@@ -86,7 +86,7 @@
 	name = seed.display_name
 	max_health = round(seed.get_trait(TRAIT_ENDURANCE)/2)
 	if(seed.get_trait(TRAIT_SPREAD) == 2)
-		mouse_opacity = 2
+		mouse_opacity = MOUSE_OPACITY_OPAQUE
 		max_growth = VINE_GROWTH_STAGES
 		growth_threshold = max_health/VINE_GROWTH_STAGES
 		growth_type = seed.get_growth_type()

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -1,7 +1,7 @@
 /var/total_lighting_overlays = 0
 /atom/movable/lighting_overlay
 	name = ""
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	simulated = FALSE
 	anchored = TRUE
 	icon = LIGHTING_ICON

--- a/code/modules/lighting/lighting_planemaster.dm
+++ b/code/modules/lighting/lighting_planemaster.dm
@@ -14,7 +14,7 @@
 			01, 01, 01, 01
 		)
 
-	mouse_opacity = 0    // nothing on this plane is mouse-visible
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT    // nothing on this plane is mouse-visible
 
 /obj/lighting_general
 	plane = LIGHTING_PLANE

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -147,7 +147,7 @@
 	plane = DEFAULT_PLANE
 	pixel_x = 8
 	pixel_y = 4
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/aura/mechshield/Initialize(var/maploading, var/obj/item/mech_equipment/shields/holder)
 	. = ..()
@@ -383,7 +383,7 @@
 	var/obj/item/mech_equipment/ballistic_shield/shield = null
 	layer = MECH_UNDER_LAYER
 	plane = DEFAULT_PLANE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/aura/mech_ballistic/Initialize(maploading, obj/item/mech_equipment/ballistic_shield/holder)
 	. = ..()

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -6,6 +6,7 @@ var/list/all_virtual_listeners = list()
 	see_in_dark = SEE_IN_DARK_DEFAULT
 	see_invisible = SEE_INVISIBLE_LIVING
 	sight = SEE_SELF
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	virtual_mob = null
 	no_z_overlay = TRUE

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -195,7 +195,7 @@
 // This thing holds the mimic appearance for non-OVERWRITE turfs.
 /atom/movable/openspace/turf_delegate
 	plane = OPENTURF_MAX_PLANE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	no_z_overlay = TRUE  // Only one of these should ever be visible at a time, the mimic logic will handle that.
 
 /atom/movable/openspace/turf_delegate/attackby(obj/item/W, mob/user)
@@ -217,7 +217,7 @@
 // A type for copying delegates' self-appearance.
 /atom/movable/openspace/delegate_copy
 	plane = OPENTURF_MAX_PLANE	// These *should* only ever be at the top?
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/turf/delegate
 
 /atom/movable/openspace/delegate_copy/Initialize(mapload, ...)

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -63,7 +63,7 @@
 		below.above = src
 
 	if (!(z_flags & ZM_MIMIC_OVERWRITE) && mouse_opacity)
-		mouse_opacity = 2
+		mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 	update_mimic(!mapload)	// Only recursively update if the map isn't loading.
 

--- a/code/modules/overmap/exoplanets/turfs.dm
+++ b/code/modules/overmap/exoplanets/turfs.dm
@@ -240,7 +240,7 @@
 
 	//Need to put a mouse-opaque overlay there to prevent people turning/shooting towards ACTUAL location of vis_content things
 	var/obj/effect/overlay/O = new(src)
-	O.mouse_opacity = 2
+	O.mouse_opacity = MOUSE_OPACITY_OPAQUE
 	O.name = "distant terrain"
 	O.desc = "You need to come over there to take a better look."
 

--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -8,7 +8,7 @@
 	light_max_bright = 1
 	light_color = "#ff00dc"
 
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 /obj/effect/projectile/proc/set_transform(var/matrix/M)
 	if(istype(M))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -10,7 +10,7 @@
 	unacidable = TRUE
 	anchored = TRUE //There's a reason this is here, Mport. God fucking damn it -Agouri. Find&Fix by Pete. The reason this is here is to stop the curving of emitter shots.
 	pass_flags = PASS_FLAG_TABLE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	randpixel = 0
 	var/bumped = 0		//Prevents it from hitting more than one guy at once
 	var/def_zone = ""	//Aiming at

--- a/code/modules/projectiles/targeting/targeting_overlay.dm
+++ b/code/modules/projectiles/targeting/targeting_overlay.dm
@@ -8,7 +8,7 @@
 	opacity = 0
 	layer = ABOVE_HUMAN_LAYER
 	simulated = FALSE
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	var/mob/living/aiming_at   // Who are we currently targeting, if anyone?
 	var/obj/item/aiming_with   // What are we targeting with?

--- a/code/modules/psionics/complexus/complexus.dm
+++ b/code/modules/psionics/complexus/complexus.dm
@@ -52,7 +52,7 @@
 	aura_image.alpha = 0
 	aura_image.pixel_x = -64
 	aura_image.pixel_y = -64
-	aura_image.mouse_opacity = 0
+	aura_image.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	aura_image.appearance_flags = 0
 	for(var/thing in SSpsi.processing)
 		var/datum/psi_complexus/psychic = thing

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -143,3 +143,4 @@
 	interact(user)
 
 // End panel.
+

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -55,7 +55,7 @@
 	icon_state = "button"
 	var/light_up = FALSE
 	var/datum/turbolift_floor/floor
-	mouse_opacity = 2 //No more eyestrain aiming at tiny pixels
+	mouse_opacity = MOUSE_OPACITY_OPAQUE //No more eyestrain aiming at tiny pixels
 
 /obj/structure/lift/button/Destroy()
 	if(floor && floor.ext_panel == src)
@@ -95,7 +95,7 @@
 /obj/structure/lift/panel
 	name = "elevator control panel"
 	icon_state = "panel"
-	mouse_opacity = 2 //No more eyestrain aiming at tiny pixels
+	mouse_opacity = MOUSE_OPACITY_OPAQUE //No more eyestrain aiming at tiny pixels
 
 
 /obj/structure/lift/panel/attack_ghost(var/mob/user)

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -90,7 +90,7 @@
 	icon_state = "generic"
 	layer = FIRE_LAYER
 	appearance_flags = RESET_COLOR
-	mouse_opacity = 0
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	var/gas_id
 
 /obj/effect/gas_overlay/proc/update_alpha_animation(var/new_alpha)

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -105,3 +105,4 @@
 	if(gas_data.tile_overlay[gas_id])
 		icon_state = gas_data.tile_overlay[gas_id]
 	color = gas_data.tile_overlay_color[gas_id]
+	


### PR DESCRIPTION
## About the Pull Request

Title + adds it to virtual mob

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Easier to read, should hopefully prevent these empty mobs from showing 

![image](https://user-images.githubusercontent.com/22431091/178839028-e41e2d92-63aa-44e6-b86d-431383308bb0.png)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Did you test it?

Totally

<!--
Please describe if you ran local tests to ensure compilation. If that is not the case, please make it abundantly clear so a maintainer knows they need to run local checks.
Note that this can include own balancing/gameplay tests, but does not need to.
-->

## Authorship

<!--
Please note down any individuals or otherwise inspirations/sources you have for this code if it is ported or adapted.
We recommend using the git blame.
-->

## Changelog

:cl:
bugfix: You should no longer be able to see blank mobs in right click menu
/:cl:

<!--
Common tags:
* rscadd - Adding a feature.
* rscdel - Removing a feature.
* tweak - Changing an existing feature.
* bugfix - Fixing an intended functionality that is not working, or correcting an oversight.
* maptweak - Changing something on a map, or adding a new away site. In 99% of cases, all map changes are maptweak.
* spellcheck - Spelling and grammar fixes.
Uncommon tags:
* admin - Adding, removing or changing administrative tools.
* balance - Changing an existing feature in such a way that it may broadly impact game balance; usually reserved for larger changes.
* soundadd - Adding new sounds, usually covered by rscadd unless you're only adding the sounds themselves.
* sounddel - Ditto as above with rscdel
* imageadd - Adding new icons; same situation as soundadd - usually you're adding something that uses these icons, so this isn't needed
* imagedel - Ditto as above.
* experiment - For experimental changes and tests that are intended to be temporary.
* wip - For works in progress. You probably won't get away with using this one.

Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
