### PR TITLE
Adds concealable armor plate into the SD's locker

### DIFF
--- a/maps/site53/structures/closets/command.dm
+++ b/maps/site53/structures/closets/command.dm
@@ -13,6 +13,7 @@
 
 /obj/structure/closet/secure_closet/administration/facilityadmin/WillContain()
 	return list(
+		/obj/item/clothing/accessory/armorplate/sneaky,
 //		/obj/item/clothing/under/suittie,
 		/obj/item/clothing/shoes/dress,
 		/obj/item/device/radio,


### PR DESCRIPTION
Site director's now get a light armor plate that can be worn as a accessories over the shirt. No longer needs to steal armor or give up that formal outerwear. 