### PR TITLE
Re-adds security loadout customization items

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -9,7 +9,7 @@
 /datum/gear/accessory/tie
 	display_name = "tie selection"
 	path = /obj/item/clothing/accessory
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/accessory/tie/New()
 	..()
@@ -29,7 +29,7 @@
 	display_name = "colored tie"
 	path = /obj/item/clothing/accessory
 	flags = GEAR_HAS_COLOR_SELECTION
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/accessory/tie_color/New()
 	..()
@@ -37,7 +37,7 @@
 	ties["tie"] = /obj/item/clothing/accessory
 	ties["striped tie"] = /obj/item/clothing/accessory/long
 	gear_tweaks += new/datum/gear_tweak/path(ties)
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/accessory/locket
 	display_name = "locket"
@@ -51,13 +51,13 @@
 /datum/gear/accessory/bowtie
 	display_name = "bowtie, horrible"
 	path = /obj/item/clothing/accessory/bowtie/ugly
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/accessory/bowtie/color
 	display_name = "bowtie, colour select"
 	path = /obj/item/clothing/accessory/bowtie/color
 	flags = GEAR_HAS_COLOR_SELECTION
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /*/datum/gear/accessory/ntaward
 	display_name = "corporate award selection"

--- a/code/modules/client/preference_setup/loadout/lists/clothing.dm
+++ b/code/modules/client/preference_setup/loadout/lists/clothing.dm
@@ -4,7 +4,7 @@
 	category = /datum/gear/clothing/
 	slot = slot_tie
 	denied_roles = list(/datum/job/classd)
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 	//No reason for guards to wear hawaian shirts, is there? Researchers and office staff.. I mean, maybe.
 
 /datum/gear/clothing/flannel

--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -4,7 +4,6 @@
 	slot = slot_shoes
 	category = /datum/gear/shoes
 	denied_roles = list(/datum/job/classd)
-	allowed_branches = list(/datum/mil_branch/civilian)
 	// Reasoning : none of the options provided fits security branches. You don't want to see security officers with high heels or sandals on a high security facility. But it makes sense for civi staff.
 
 /datum/gear/shoes/athletic

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -9,7 +9,7 @@
 	display_name = "gloves, colored"
 	flags = GEAR_HAS_COLOR_SELECTION
 	path = /obj/item/clothing/gloves/color
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/gloves/latex
 	display_name = "gloves, latex"
@@ -24,13 +24,13 @@
 /datum/gear/gloves/rainbow
 	display_name = "gloves, rainbow"
 	path = /obj/item/clothing/gloves/rainbow
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/gloves/evening
 	display_name = "gloves, evening, colour select"
 	path = /obj/item/clothing/gloves/color/evening
 	flags = GEAR_HAS_COLOR_SELECTION
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/ring
 	display_name = "ring"
@@ -60,7 +60,7 @@
 	display_name = "gloves, botany"
 	path = /obj/item/clothing/gloves/thick/botany
 	cost = 3
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 
 /datum/gear/gloves/work
 	display_name = "gloves, work"

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -3,7 +3,7 @@
 	slot = slot_head
 	category = /datum/gear/head
 	denied_roles = list(/datum/job/classd)
-	allowed_branches = list(/datum/mil_branch/civilian)
+
 	//Same idea, eats the helmet slot which guards spawn with. With the exception of certain beret variations, no reason to wear any of these.
 
 /datum/gear/head/beret

--- a/code/modules/client/preference_setup/loadout/lists/storage.dm
+++ b/code/modules/client/preference_setup/loadout/lists/storage.dm
@@ -33,7 +33,6 @@
 	display_name = "storage belt selection"
 	path = /obj/item/storage/belt
 	slot = slot_belt
-	allowed_branches = list(/datum/mil_branch/civilian)
 	//Eats the belt slot which guards needs (holster)
 	cost = 2
 
@@ -44,7 +43,6 @@
 		/obj/item/storage/belt/utility
 	)
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(belts)
-	allowed_branches = list(/datum/mil_branch/civilian)
 	//same as before
 
 /datum/gear/storage/webbing
@@ -70,13 +68,11 @@
 	slot = slot_belt
 	cost = 2
 	flags = GEAR_HAS_COLOR_SELECTION
-	allowed_branches = list(/datum/mil_branch/civilian)
 
 /datum/gear/storage/waistpack/big
 	display_name = "large waist pack"
 	path = /obj/item/storage/belt/waistpack/big
 	cost = 4
-	allowed_branches = list(/datum/mil_branch/civilian)
 
 /datum/gear/accessory/wallet
 	display_name = "wallet, colour select"

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -3,7 +3,6 @@
 	sort_category = "Suits and Overwear"
 	category = /datum/gear/suit
 	denied_roles = list(/datum/job/classd)
-	allowed_branches = list(/datum/mil_branch/civilian)
 	//Reasoning : it eats the Armour slot of guards. Also, there's little justification for wearing one of these as a guard
 
 /datum/gear/suit/poncho

--- a/code/modules/client/preference_setup/loadout/lists/tactical.dm
+++ b/code/modules/client/preference_setup/loadout/lists/tactical.dm
@@ -4,18 +4,18 @@
 	slot = slot_tie
 	allowed_branches = list(/datum/mil_branch/security)
 
-// Not allowed because: access to non lore-friendly tags at the moment (as well as ability to choose Zone Commander tags etc)
-/*/datum/gear/tactical/armor_deco
+
+/datum/gear/tactical/armor_deco
 	display_name = "armor customization"
 	path = /obj/item/clothing/accessory/armor/tag
 	flags = GEAR_HAS_SUBTYPE_SELECTION
-*/
-//Some of the offered covers are non lore friendly. Also, kind of defeat the purpose of uniformization
-/*/datum/gear/tactical/helm_covers
+
+
+/datum/gear/tactical/helm_covers
 	display_name = "helmet covers"
 	path = /obj/item/clothing/accessory/armor/helmcover
 	flags = GEAR_HAS_SUBTYPE_SELECTION
-*/
+
 
 //Yes, why not
 /datum/gear/tactical/kneepads
@@ -23,18 +23,18 @@
 	path = /obj/item/clothing/accessory/kneepads
 	flags = GEAR_HAS_COLOR_SELECTION
 
-//Guard lockers already spawn with a thigh holster, and all of them spawn with a belt holster
-/* /datum/gear/tactical/holster
+
+ /datum/gear/tactical/holster
 	display_name = "holster selection"
 	path = /obj/item/clothing/accessory/storage/holster
 	cost = 3
-*/
 
-// Replaces belt slot, and useless
-/*datum/gear/tactical/sheath
+
+
+datum/gear/tactical/sheath
 	display_name = "machete sheath"
 	path = /obj/item/clothing/accessory/storage/holster/machete
-*/
+
 
 //Good option for guards
 /datum/gear/tactical/knife_sheath
@@ -43,12 +43,12 @@
 	path = /obj/item/clothing/accessory/storage/holster/knife
 	flags = GEAR_HAS_TYPE_SELECTION
 
-// No, not lore friendly and replaces basic uniform
-/*/datum/gear/tactical/tacticool
+
+/datum/gear/tactical/tacticool
 	display_name = "tacticool turtleneck"
 	path = /obj/item/clothing/under/syndicate/tacticool
 	slot = slot_w_uniform
-*/
+
 
 //Guards already spawn with one, but no harm leaving this here
 /datum/gear/tactical/balaclava

--- a/code/modules/client/preference_setup/loadout/lists/tactical.dm
+++ b/code/modules/client/preference_setup/loadout/lists/tactical.dm
@@ -23,8 +23,7 @@
 	path = /obj/item/clothing/accessory/kneepads
 	flags = GEAR_HAS_COLOR_SELECTION
 
-
- /datum/gear/tactical/holster
+/datum/gear/tactical/holster
 	display_name = "holster selection"
 	path = /obj/item/clothing/accessory/storage/holster
 	cost = 3

--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -3,7 +3,6 @@
 	slot = slot_w_uniform
 	category = /datum/gear/uniform
 	denied_roles = list(/datum/job/classd)
-	allowed_branches = list(/datum/mil_branch/civilian)
 	//Security shouldn't wear something else than their uniform
 
 /datum/gear/uniform/jumpsuit

--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -3,7 +3,6 @@
 	sort_category = "Utility"
 	category = /datum/gear/utility
 	denied_roles = list(/datum/job/classd)
-	//Security can use these, yeah
 
 /datum/gear/utility/briefcase
 	display_name = "briefcase"


### PR DESCRIPTION
## About the Pull Request

Reverts some of the changes implented by @CerberusHellHound in #353 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The changes implemented in that PR were somewhat rushed in, in my opinion, and are not really universally approved of at all by the community. A number of security players have raised issues in the Discord that it feels like customization and security outfit stuff is being policed with and messed with by a member of staff who is out of touch with the general community sentiment.

Related suggestion post:
![image](https://user-images.githubusercontent.com/6334647/179165254-f867fc30-b524-4480-be96-18d36a5a9e61.png)

I didn't want to do this, but I didn't realize that @CerberusHellHound had gone in and done this after we had a debate about this in developer chat. When I re-enabled sec loadout his response was go to and strip most of it out, which seems kinda underhanded tbh. Regardless, I'm open to input on this matter, which is why I'm proposing this semi-revert in the first place. These kinds of changes ought not to be shoe-horned in by one sole proponent, especially when they affect the amount of content a large amount of the community has access to. Given that @CerberusHellHound is neither a maintainer nor an archivist (lore role, I think?), the earlier change seems a little unfounded at well. This ought to be up to a community poll or at the very least given more attention by Lestat, and so I'd like to take the Wikipedia route and WP:STATUS_QUO this, so to speak, at least to raise issue with it and give everyone more of a chance to chime in on whether this is the best path.

## Did you test it?

<!--
Please describe if you ran local tests to ensure compilation. If that is not the case, please make it abundantly clear so a maintainer knows they need to run local checks.
Note that this can include own balancing/gameplay tests, but does not need to.
-->

Yes, works fine.

## Authorship

<!--
Please note down any individuals or otherwise inspirations/sources you have for this code if it is ported or adapted.
We recommend using the git blame.
-->

## Changelog

:cl:
tweak - Renables the vast majority of security loadout customization.
/:cl:

<!--
Common tags:

* tweak - Changing an existing feature.


Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->


