### PR TITLE
Fixes SCP-066 and SCP-263 not knowing the english language

### DIFF
--- a/code/modules/SCP/SCPs/SCP-066.dm
+++ b/code/modules/SCP/SCPs/SCP-066.dm
@@ -23,7 +23,7 @@
 
 
 /mob/living/simple_animal/cat/scp_066/Initialize()
-	add_language(/datum/language/english)
+	add_language(LANGUAGE_ENGLISH)
 
 
 		// emotes

--- a/code/modules/SCP/SCPs/SCP-263.dm
+++ b/code/modules/SCP/SCPs/SCP-263.dm
@@ -17,7 +17,7 @@
 	var/mob/living/carbon/human/target
 
 /mob/living/simple_animal/hostile/scp_263/Initialize()
-	add_language(/datum/language/english)
+	add_language(LANGUAGE_ENGLISH)
 
 	// emotes
 	add_verb(src, list(


### PR DESCRIPTION
## About the Pull Request

Fixes SCP-066 and SCP-263 not knowing english whilst they should

## Why It's Good For The Game

Bugfix

## Changelog

:cl:
fix: SCP-066 and SCP-263 have been given proper english language lessons. As such, they can now speak english.
/:cl:
