### PR TITLE
Access vars into strings because the mapdiffbot is whining

### DIFF
--- a/maps/site53/job/access.dm
+++ b/maps/site53/job/access.dm
@@ -108,31 +108,31 @@
 
 // ENGINEERING
 
-/var/const/access_engineeringlvl1 = "ACCESS_ENGINEERING_LEVEL_1" //Junior Engineer
+/var/const/access_engineeringlvl1 = "ACCESS_ENGINEERING_LEVEL1" //Junior Engineer
 /datum/access/engineeringlvl1
 	id = access_engineeringlvl1
 	desc = "Engineering Level 1"
 	region = ACCESS_REGION_ENGINEERING
 
-/var/const/access_engineeringlvl2 = "ACCESS_ENGINEERING_LEVEL_2" // Engineer
+/var/const/access_engineeringlvl2 = "ACCESS_ENGINEERING_LEVEL2" // Engineer
 /datum/access/engineeringlvl2
 	id = access_engineeringlvl2
 	desc = "Engineering Level 2"
 	region = ACCESS_REGION_ENGINEERING
 
-/var/const/access_engineeringlvl3 = "ACCESS_ENGINEERING_LEVEL_3" // Senior Engineer, Comms Programmer
+/var/const/access_engineeringlvl3 = "ACCESS_ENGINEERING_LEVEL3" // Senior Engineer, Comms Programmer
 /datum/access/engineeringlvl3
 	id = access_engineeringlvl3
 	desc = "Engineering Level 3"
 	region = ACCESS_REGION_ENGINEERING
 
-/var/const/access_engineeringlvl4 = "ACCESS_ENGINEERING_LEVEL_4" // Containment Engineer
+/var/const/access_engineeringlvl4 = "ACCESS_ENGINEERING_LEVEL4" // Containment Engineer
 /datum/access/engineeringlvl4
 	id = access_engineeringlvl4
 	desc = "Engineering Level 4"
 	region = ACCESS_REGION_ENGINEERING
 
-/var/const/access_engineeringlvl5 = "ACCESS_ENGINEERING_LEVEL_5" //Chief Engineer
+/var/const/access_engineeringlvl5 = "ACCESS_ENGINEERING_LEVEL5" //Chief Engineer
 /datum/access/engineeringlvl5
 	id = access_engineeringlvl5
 	desc = "Engineering Level 5"

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -2,7 +2,7 @@
 "aa" = (
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor/northleft{
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /turf/simulated/floor/carpet/purple,
@@ -220,7 +220,7 @@
 	id_tag = "106cycle";
 	name = "Chamberlock Door Cycle button";
 	pixel_y = 23;
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/button/femur_breaker{
@@ -451,7 +451,7 @@
 "bB" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentline)
@@ -470,7 +470,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "D-Class Reward Room";
 	name = "D-Class Reward Room";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/titanium,
@@ -551,7 +551,7 @@
 	id_tag = "HCZ High Security Lock";
 	name = "HCZ High Security Lock";
 	pixel_y = -32;
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/scp106parts)
@@ -661,7 +661,7 @@
 "ck" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Common Cell";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -876,7 +876,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -1034,7 +1034,7 @@
 /area/site53/llcz/dclass/assignment)
 "dA" = (
 /obj/machinery/vending/medical{
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -1154,7 +1154,7 @@
 /obj/machinery/door/airlock/multi_tile/glass/security{
 	icon_state = "closed";
 	name = "Guard Hallway";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
@@ -1220,7 +1220,7 @@
 "dZ" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkcryo)
@@ -1399,7 +1399,7 @@
 "ez" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Chamber Intake";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -1424,7 +1424,7 @@
 "eC" = (
 /obj/machinery/button/crematorium{
 	id_tag = "Reeducation Cremator";
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -1592,7 +1592,7 @@
 "eW" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "LCZ Cryo";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1613,7 +1613,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -1771,7 +1771,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Lower LCZ Maint Access";
 	name = "Lower LCZ Maint Access";
-	req_access = list(access_engineeringlvl1,access_adminlvl3)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1","ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/wall/prepainted,
 /area/site53/engineering/maintenance/llczmaint)
@@ -1795,7 +1795,7 @@
 "fr" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Kitchen";
-	req_access = list(list(access_securitylvl2,access_dclasskitchen))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_DCLASS_KITCHEN"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/kitchen)
@@ -1923,7 +1923,7 @@
 "fI" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "LCZ Armoury";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1957,7 +1957,7 @@
 "fM" = (
 /obj/machinery/door/airlock/hatch{
 	name = "LLCZ Maintenance";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
@@ -2312,7 +2312,7 @@
 "gK" = (
 /obj/machinery/button/crematorium{
 	id_tag = "Reeducation Cremator 2";
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -2631,7 +2631,7 @@
 "hG" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Janitorial Closet";
-	req_access = list(access_securitylvl1,access_dclassjanitorial)
+	req_access = list("ACCESS_SECURITY_LEVEL1","ACCESS_DCLASS_JANITORIAL")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/janitorial)
@@ -2753,7 +2753,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Lower LCZ Checkpoint West Access";
 	name = "Lower LCZ Checkpoint West Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -2785,7 +2785,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Lower LCZ Checkpoint East Access";
 	name = "Lower LCZ Checkpoint East Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -2993,7 +2993,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/hallways)
@@ -3004,7 +3004,7 @@
 "it" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "High Security Cell";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/cellbubble)
@@ -3054,7 +3054,7 @@
 	},
 /obj/machinery/door/window/brigdoor/eastright{
 	name = "Level 2 Clearance Shelf";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3091,7 +3091,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -3139,7 +3139,7 @@
 "iH" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3180,7 +3180,7 @@
 "iM" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/brigdoor/southright{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/window/brigdoor/northleft,
 /obj/machinery/door/blast/shutters{
@@ -3209,14 +3209,14 @@
 "iP" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Chamber Departure";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/reeducation)
 "iQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/brigdoor/southright{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/window/brigdoor/northleft,
 /obj/machinery/door/blast/shutters{
@@ -3358,7 +3358,7 @@
 	},
 /obj/machinery/vending/medical{
 	dir = 1;
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
@@ -3439,7 +3439,7 @@
 	},
 /obj/machinery/door/window/brigdoor/westright{
 	name = "Level 3 Clearance Shelf";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertram/archive)
@@ -3515,7 +3515,7 @@
 /area/site53/uhcz/scp106parts)
 "jH" = (
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3529,7 +3529,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Security Bubble Lockdown";
 	name = "Security Bubble Lockdown";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -3559,7 +3559,7 @@
 "jL" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Kitchen";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/kitchen)
@@ -3597,7 +3597,7 @@
 	},
 /obj/machinery/door/airlock/civilian{
 	name = "Kitchen";
-	req_access = list(list(access_securitylvl2,access_dclasskitchen))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_DCLASS_KITCHEN"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/kitchen)
@@ -3605,7 +3605,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Lower LCZ Checkpoint Maintenance Access";
 	name = "Lower LCZ Checkpoint Maintenance Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -3617,7 +3617,7 @@
 "jS" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/northleft{
-	req_access = list(access_sciencelvl1,access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/machinery/door/blast/shutters/open{
 	id_tag = "Kitchen Access";
@@ -3687,7 +3687,7 @@
 "jY" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "D-Cells Checkpoint";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3807,7 +3807,7 @@
 "kp" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Body Disposal";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -3895,7 +3895,7 @@
 "ky" = (
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	name = "Mining";
-	req_access = list(list(access_securitylvl2,access_dclassmining))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_DCLASS_MINING"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -3934,7 +3934,7 @@
 	id_tag = "106cycle";
 	locked = 1;
 	name = "SCP-106";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/uhcz/scp106parts)
@@ -3949,7 +3949,7 @@
 /obj/machinery/door/window{
 	dir = 4;
 	name = "Interior Door";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -4004,7 +4004,7 @@
 /area/site53/llcz/dclass/primaryhallway)
 "kK" = (
 /obj/machinery/door/airlock/multi_tile/security{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4041,7 +4041,7 @@
 	id_tag = "dclasscells";
 	name = "Cell Lock";
 	pixel_y = -32;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/reinforced,
@@ -4054,7 +4054,7 @@
 "kP" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/northright{
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/machinery/door/blast/shutters/open{
 	id_tag = "Kitchen Access";
@@ -4107,7 +4107,7 @@
 "kW" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/llcz/dclass/canteenbubble)
@@ -4230,7 +4230,7 @@
 "lj" = (
 /obj/machinery/door/airlock/security{
 	name = "D-Class Assignments";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4242,14 +4242,14 @@
 "lk" = (
 /obj/machinery/door/airlock/security{
 	name = "D-Class Assignments";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/llcz/dclass/assignmentbubble)
 "ll" = (
 /obj/structure/table/steel_reinforced,
 /obj/machinery/door/window/brigdoor/southright{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/window/brigdoor/northleft,
 /obj/machinery/door/blast/shutters{
@@ -4275,7 +4275,7 @@
 	id_tag = "line1";
 	name = "Line Shutters";
 	pixel_y = 32;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentbubble)
@@ -4321,7 +4321,7 @@
 	id_tag = "line2";
 	name = "Line Shutters";
 	pixel_y = 32;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentbubble)
@@ -4330,7 +4330,7 @@
 	id_tag = "line3";
 	name = "Line Shutters";
 	pixel_y = 32;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentbubble)
@@ -4414,7 +4414,7 @@
 	id_tag = "LLCZ Maintenance (NO ENTRY)";
 	name = "LLCZ Maintenance (NO ENTRY)";
 	pixel_y = 32;
-	req_access = list(access_securitylvl5)
+	req_access = list("ACCESS_SECURITY_LEVEL5")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/hallways)
@@ -4438,7 +4438,7 @@
 	id_tag = "Reeducation Shutter";
 	name = "Reeducation Shutter";
 	pixel_x = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/dclass/reeducation)
@@ -4634,7 +4634,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Self-Destruct Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -4647,7 +4647,7 @@
 "mn" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Self-Destruct Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4720,7 +4720,7 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/lowernukeladders)
@@ -4764,7 +4764,7 @@
 "mB" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Self-Destruct Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -4943,7 +4943,7 @@
 "mS" = (
 /obj/machinery/door/airlock/vault{
 	name = "Self Destruct Room";
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4959,7 +4959,7 @@
 "mT" = (
 /obj/machinery/door/airlock/vault{
 	name = "Self Destruct Room";
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/dark,
@@ -4985,7 +4985,7 @@
 "mX" = (
 /obj/machinery/door/airlock/vault{
 	name = "Self Destruct Room";
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5001,7 +5001,7 @@
 "mY" = (
 /obj/machinery/door/airlock/vault{
 	name = "Self Destruct Room";
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/dark,
@@ -5031,7 +5031,7 @@
 "nb" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Self-Destruct Maintenance";
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5109,7 +5109,7 @@
 "nm" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 28;
-	req_access = list(access_sciencelvl4,access_engineeringlvl4,access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
@@ -5228,7 +5228,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/blackgrid,
 /area/site53/engineering/selfdestruct)
@@ -5347,7 +5347,7 @@
 	id_tag = "HCZ High Security Lock";
 	name = "HCZ High Security Lock";
 	pixel_y = -32;
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/scp106parts)
@@ -5356,7 +5356,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "D-Class Breakroom";
 	name = "D-Class Breakroom";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/luxuryhall)
@@ -5392,7 +5392,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor,
 /area/site53/engineering/maintenance/lowerselfdestruct)
@@ -5426,7 +5426,7 @@
 	id_tag = "isolationcell4";
 	name = "Cell 4 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
@@ -5435,7 +5435,7 @@
 	dir = 8;
 	icon_state = "closed";
 	name = "Sector 7";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/isolation)
@@ -5444,7 +5444,7 @@
 	id_tag = "Common Window Shutter";
 	name = "Common Window Shutter";
 	pixel_y = 32;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -5556,7 +5556,7 @@
 "ox" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "LHCZ Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5575,7 +5575,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Lower LCZ Checkpoint Windows";
 	name = "Lower LCZ Checkpoint Windows";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -5705,7 +5705,7 @@
 "oQ" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "Stasis Bay";
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/tiled/monotile,
@@ -5718,7 +5718,7 @@
 "oS" = (
 /obj/machinery/door/airlock/science{
 	name = "Observation";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5738,7 +5738,7 @@
 	id_tag = "Control Subject Area";
 	name = "Control Subject Area";
 	pixel_x = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
@@ -5752,7 +5752,7 @@
 "oW" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Center";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -5929,7 +5929,7 @@
 "pt" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp8containment)
@@ -6085,7 +6085,7 @@
 "pP" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "D-Cells Checkpoint";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/blast/regular/open{
@@ -6102,7 +6102,7 @@
 "pR" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Chamber";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -6142,7 +6142,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "dchecknorth";
 	name = "North Blastdoors";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -6210,7 +6210,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
@@ -6286,7 +6286,7 @@
 "qm" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-049";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6328,11 +6328,11 @@
 	id_tag = "Reeducation Shutter";
 	name = "Reeducation Shutter";
 	pixel_x = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/window/northleft{
 	name = "Reeducation Separator";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -6343,7 +6343,7 @@
 "qs" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "LHCZ Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6414,7 +6414,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "106cycle";
 	name = "SCP-106";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/lhcz/hallway)
@@ -6424,7 +6424,7 @@
 	},
 /obj/machinery/door/window/brigdoor/eastleft{
 	name = "Level 1 Clearance Shelf";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/wall/prepainted,
 /area/site53/lowertram/archive)
@@ -6788,7 +6788,7 @@
 "rp" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "SCP-895 Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6813,7 +6813,7 @@
 /area/site53/lhcz/hallway)
 "rs" = (
 /obj/machinery/door/window/brigdoor/southleft{
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertram/archive)
@@ -6901,7 +6901,7 @@
 "rC" = (
 /obj/machinery/door/airlock/security{
 	name = "D-Class Prep";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/prep)
@@ -7117,7 +7117,7 @@
 "sb" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "D-Cells Checkpoint";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/blast/regular/open{
@@ -7138,7 +7138,7 @@
 "sd" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "SCP-895 Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7205,14 +7205,14 @@
 "sl" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "Stasis Bay";
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/medicalpost)
 "sm" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Equipment";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -7283,7 +7283,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -7312,7 +7312,7 @@
 "sA" = (
 /obj/machinery/door/airlock/science{
 	name = "Airlock";
-	req_access = list(access_securitylvl3,access_sciencelvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/lhcz/scp895)
@@ -7339,7 +7339,7 @@
 "sE" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "SCP-106 Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7391,7 +7391,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "LCZ Checkpoint Cubicle 2";
 	name = "LCZ Checkpoint Cubicle 2";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -7424,7 +7424,7 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkpointoverlook)
@@ -7466,7 +7466,7 @@
 "sV" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "D-Cells Checkpoint";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7544,7 +7544,7 @@
 /area/site53/lowertram/archive)
 "tc" = (
 /obj/machinery/door/window/brigdoor/southright{
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertram/archive)
@@ -7569,7 +7569,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/structure/closet/secure_closet/medical3{
 	name = "paramedic's locker";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
@@ -7687,7 +7687,7 @@
 	id_tag = "cell2door";
 	name = "Cell 2 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/primaryhallway)
@@ -7698,7 +7698,7 @@
 	id_tag = "cell1door";
 	name = "Cell 1 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/camera/network/lcz{
 	dir = 1
@@ -7757,7 +7757,7 @@
 /area/site53/llcz/dclass/cells)
 "tz" = (
 /obj/machinery/door/window/southleft{
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
@@ -7775,7 +7775,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "dchecksouth";
 	name = "South Blastdoors";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -8105,7 +8105,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "DCZ Entrance Windows";
 	name = "DCZ Entrance Windows";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -8133,7 +8133,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "LCZ Checkpoint Cubicle 1";
 	name = "LCZ Checkpoint Cubicle 1";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/entrance_checkpoint)
@@ -8147,7 +8147,7 @@
 	id_tag = "Isocell 1 shutter";
 	name = "Isocell 1 shutter";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8241,7 +8241,7 @@
 	id_tag = "Research Arena Entrance";
 	name = "Research Arena Entrance";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/light{
 	dir = 4
@@ -8370,14 +8370,14 @@
 	id_tag = "cell10door";
 	name = "Cell 10 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
 "uQ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Body Disposal";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
@@ -8527,7 +8527,7 @@
 /area/site53/llcz/dclass/medicalpost)
 "vq" = (
 /obj/structure/closet/crate/secure/biohazard{
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/white/monotile,
@@ -8642,7 +8642,7 @@
 "vB" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "Surgery";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/medicalpost)
@@ -8650,7 +8650,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "LCZ Checkpoint Cubicle 2";
 	name = "LCZ Checkpoint Cubicle 2";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -8741,7 +8741,7 @@
 "vM" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Chamber Intake";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -8750,7 +8750,7 @@
 	id_tag = "cell4door";
 	name = "Cell 4 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -8769,7 +8769,7 @@
 	id_tag = "cell3door";
 	name = "Cell 3 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
@@ -8780,7 +8780,7 @@
 	id_tag = "cell6door";
 	name = "Cell 6 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/camera/network/lcz{
 	dir = 1
@@ -8794,7 +8794,7 @@
 	id_tag = "cell5door";
 	name = "Cell 5 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
@@ -8856,7 +8856,7 @@
 	id_tag = "cell8door";
 	name = "Cell 8 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
@@ -8881,7 +8881,7 @@
 	id_tag = "cell7door";
 	name = "Cell 7 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor,
@@ -8900,7 +8900,7 @@
 	id_tag = "cell9door";
 	name = "Cell 9 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
@@ -8952,7 +8952,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Mining Access Gate 1";
 	name = "Mining Access Gate 1";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -8961,7 +8961,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Mining Access Gate 2";
 	name = "Mining Access Gate 2";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -8970,7 +8970,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Botany Access";
 	name = "Botany Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -8979,7 +8979,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Mining Access Gate 3";
 	name = "Mining Access Gate 3";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -9055,7 +9055,7 @@
 "wA" = (
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	name = "Assignments & Recreation";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/isolation)
@@ -9070,7 +9070,7 @@
 	id_tag = "lczairlock1";
 	name = "Door Lock";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/railing/mapped{
 	dir = 8
@@ -9108,7 +9108,7 @@
 "wF" = (
 /obj/structure/closet/secure_closet/medical1{
 	anchored = 1;
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
@@ -9148,7 +9148,7 @@
 	id_tag = "lczairlock1";
 	name = "Door Lock";
 	pixel_x = 27;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
@@ -9219,14 +9219,14 @@
 	id_tag = "isolationcell1";
 	name = "Cell 1 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
 "wZ" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -9241,7 +9241,7 @@
 	id_tag = "isolationcell2";
 	name = "Cell 2 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
@@ -9251,7 +9251,7 @@
 	id_tag = "isolationcell3";
 	name = "Cell 3 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
@@ -9281,7 +9281,7 @@
 	id_tag = "isolationcell5";
 	name = "Cell 5 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
@@ -9292,7 +9292,7 @@
 	id_tag = "isolationcell6";
 	name = "Cell 6 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
@@ -9380,7 +9380,7 @@
 "xr" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9436,7 +9436,7 @@
 	id_tag = "cell13door";
 	name = "Cell 13 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/luxurysleep)
@@ -9480,7 +9480,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "D Block Access";
 	name = "D Block Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -9533,7 +9533,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Mining Checkpoint Window";
 	name = "Mining Checkpoint Window";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -9648,7 +9648,7 @@
 	id_tag = "cell11door";
 	name = "Cell 11 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/camera/network/lcz,
 /obj/structure/cable/green{
@@ -9706,7 +9706,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Mining Lockdown";
 	name = "Mining Lockdown";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -9848,7 +9848,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "D-Class Reward Room";
 	name = "D-Class Reward Room";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/luxuryhall)
@@ -10035,7 +10035,7 @@
 "ze" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "Chemistry";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/medicalpost)
@@ -10351,7 +10351,7 @@
 "zW" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
@@ -10596,7 +10596,7 @@
 /area/site53/lhcz/scp1102room)
 "AI" = (
 /obj/machinery/door/airlock/security{
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp1102room)
@@ -10666,7 +10666,7 @@
 /area/site53/llcz/dclass/botany)
 "AT" = (
 /obj/machinery/door/airlock/security{
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10906,7 +10906,7 @@
 "Bw" = (
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /obj/item/reagent_containers/food/drinks/glass2/coffeecup/foundation,
 /turf/simulated/floor/carpet/purple,
@@ -11037,7 +11037,7 @@
 	dir = 8;
 	icon_state = "closed";
 	name = "Guard Hallway";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/isolation)
@@ -11045,7 +11045,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "D Recreation Access";
 	name = "D Recreation Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -11059,7 +11059,7 @@
 "BU" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -11097,7 +11097,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Shower checkpoint windows";
 	name = "Shower checkpoint windows";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -11157,7 +11157,7 @@
 	id_tag = "Isocell 2 shutter";
 	name = "Isocell 2 shutter";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -11243,14 +11243,14 @@
 "Cq" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Euclid & Safe Archive";
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertram/archive)
 "Cr" = (
 /obj/machinery/door/airlock/science{
 	name = "Keter Archive";
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertram/archive)
@@ -11283,7 +11283,7 @@
 "Cy" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Restricted Archive";
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/lowertram/archive)
@@ -11329,7 +11329,7 @@
 "CH" = (
 /obj/machinery/door/airlock/multi_tile/glass/civilian{
 	name = "Botany";
-	req_access = list(list(access_securitylvl2,access_dclassbotany))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_DCLASS_BOTANY"))
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -11434,7 +11434,7 @@
 /area/site53/llcz/dclass/medicalpost)
 "CT" = (
 /obj/machinery/smartfridge/secure/medbay{
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/paint_stripe/green,
 /turf/simulated/wall/titanium,
@@ -11474,7 +11474,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "DCZ Entrance Lockdown";
 	name = "DCZ Entrance Lockdown";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -11658,7 +11658,7 @@
 	},
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -11736,14 +11736,14 @@
 	id_tag = "lczairlock2";
 	name = "Door Lock";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
 "DE" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -11782,7 +11782,7 @@
 	id_tag = "lczairlock3";
 	name = "Door Lock";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
@@ -11796,7 +11796,7 @@
 	id_tag = "lczairlock2";
 	name = "Door Lock";
 	pixel_x = 29;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
@@ -11811,7 +11811,7 @@
 	id_tag = "lczairlock3";
 	name = "Door Lock";
 	pixel_x = -29;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/recreationhallway)
@@ -11859,7 +11859,7 @@
 	id_tag = "cell12door";
 	name = "Cell 12 Control";
 	pixel_y = 30;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/luxurysleep)
@@ -12021,7 +12021,7 @@
 	id_tag = "isolationcell7";
 	name = "Cell 7 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
@@ -12086,7 +12086,7 @@
 	},
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Bubble";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
@@ -12124,7 +12124,7 @@
 	dir = 4;
 	id_tag = "CDZ Conference Door";
 	name = "CDZ Conference Door";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled,
@@ -12323,7 +12323,7 @@
 "Ff" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "D-Class Confiscated Items";
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
@@ -12372,7 +12372,7 @@
 	},
 /obj/machinery/door/airlock/glass/medical{
 	name = "Medical Storage";
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/medicalpost)
@@ -12501,7 +12501,7 @@
 "Gc" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Iso 1";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -12517,7 +12517,7 @@
 "Gd" = (
 /obj/machinery/door/window/northleft{
 	name = "Reeducation Separator";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -12525,7 +12525,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "DCZ Entrance Lockdown";
 	name = "DCZ Entrance Lockdown";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -12607,7 +12607,7 @@
 	id_tag = "Isocell 3 shutter";
 	name = "Isocell 3 shutter";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
@@ -12689,7 +12689,7 @@
 	id_tag = "dclasscells";
 	name = "Cell Lock";
 	pixel_y = 32;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/reinforced,
@@ -12740,7 +12740,7 @@
 	id_tag = "CDZ Conference Door";
 	name = "CDZ Conference Door";
 	pixel_x = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/luxuryhall)
@@ -12753,7 +12753,7 @@
 	id_tag = "Armoury Equipment";
 	name = "Armoury Equipment";
 	pixel_y = 32;
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/closet/secure_closet/mtf/riotshotguns,
 /turf/simulated/floor/tiled/monotile/white,
@@ -12793,7 +12793,7 @@
 	dir = 4;
 	id_tag = "CDZ Conference Window";
 	name = "CDZ Conference Window";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled,
@@ -12841,7 +12841,7 @@
 	id_tag = "cell14door";
 	name = "Cell 14 Control";
 	pixel_y = -26;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/luxurysleep)
@@ -13233,7 +13233,7 @@
 "Ig" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/westleft{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentbubble)
@@ -13310,7 +13310,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/southleft{
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/corner/blue/border,
@@ -13470,7 +13470,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Lower LCZ Checkpoint West Access";
 	name = "Lower LCZ Checkpoint West Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/standard,
 /obj/structure/cable/green{
@@ -13630,7 +13630,7 @@
 /area/site53/llcz/dclass/entrance_checkpoint)
 "IW" = (
 /obj/machinery/door/window/southleft{
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/corner/blue/border{
@@ -13654,7 +13654,7 @@
 "IZ" = (
 /obj/machinery/door/airlock/security{
 	name = "Commisionary";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentbubble)
@@ -13736,7 +13736,7 @@
 	id_tag = "Mining Checkpoint Lockdown";
 	name = "Mining Checkpoint Lockdown";
 	pixel_y = 32;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/recreationhallway)
@@ -13744,7 +13744,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Security Bubble Windows";
 	name = "Security Bubble Windows";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -13753,7 +13753,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Security Bubble Lockdown";
 	name = "Security Bubble Lockdown";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -13768,7 +13768,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Kitchen Access";
 	name = "Kitchen Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -13776,7 +13776,7 @@
 "Jm" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Chamber Departure";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/site53/llcz/dclass/reeducation)
@@ -13784,7 +13784,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Kitchen Bubble Shutter";
 	name = "Kitchen Bubble Shutter";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -13796,7 +13796,7 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -13819,7 +13819,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Mess Hall Access";
 	name = "Mess Hall Access";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -13841,7 +13841,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "Lower LCZ Maint Access";
 	name = "Lower LCZ Maint Access";
-	req_access = list(access_engineeringlvl1,access_adminlvl3)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1","ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/wall/prepainted,
 /area/site53/lowertram/archive)
@@ -14009,7 +14009,7 @@
 "JK" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Iso 2";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -14041,7 +14041,7 @@
 "JN" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Reeducation Iso 3";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -14094,7 +14094,7 @@
 	id_tag = "Reeducation Lockdown";
 	name = "Reeducation Lockdown";
 	pixel_y = 32;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/power/apc{
 	dir = 8
@@ -14179,7 +14179,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/glass/security{
-	req_access = list(list(access_securitylvl2,access_medicallvl2));
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"));
 	name = "CDZ Medbay"
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -14198,7 +14198,7 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/westleft{
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -14257,7 +14257,7 @@
 /area/site53/llcz/dclass/reeducation)
 "Kk" = (
 /obj/machinery/door/window/brigdoor/westleft{
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -14282,7 +14282,7 @@
 	id_tag = "cdzmed";
 	name = "D-Class Entry button";
 	pixel_y = -23;
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 4
@@ -14299,7 +14299,7 @@
 "Kp" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "SCP-106 Maintenance";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated/dark,
@@ -14327,7 +14327,7 @@
 	id_tag = "cdzmed";
 	name = "D-Class Entry button";
 	pixel_y = -23;
-	req_access = list(list(access_securitylvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -14469,7 +14469,7 @@
 	dir = 1;
 	id_tag = "scp8_airlock";
 	pixel_y = -25;
-	req_access = list(list(access_securitylvl3,access_sciencelvl4));
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"));
 	tag_exterior_door = "scp8_exterior";
 	tag_interior_door = "scp8_interior"
 	},
@@ -14671,7 +14671,7 @@
 	},
 /obj/machinery/door/window/brigdoor/westleft{
 	name = "Level 4 Clearance Shelf";
-	req_access = list(access_sciencelvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -14899,7 +14899,7 @@
 /area/site53/uhcz/scp8containment)
 "Ng" = (
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /obj/structure/table/rack,
 /turf/simulated/floor/wood/walnut,
@@ -15013,7 +15013,7 @@
 /obj/structure/closet/secure_closet/freezer{
 	icon = 'icons/obj/closets/fridge.dmi';
 	name = "Secure Freezer";
-	req_access = list(access_sciencelvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /obj/item/reagent_containers/glass/beaker/vial/scp008,
 /obj/item/reagent_containers/glass/beaker/vial/scp008,
@@ -15053,7 +15053,7 @@
 "Oc" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Containment Chamber Access Chamberlock";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lhcz/scp049containment)
@@ -15164,7 +15164,7 @@
 	id_tag = "Control Subject Preparation";
 	name = "Control Subject Preparation";
 	pixel_x = 24;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
@@ -15205,7 +15205,7 @@
 "OT" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp8containment)
@@ -15213,7 +15213,7 @@
 /obj/effect/catwalk_plated/white,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15358,7 +15358,7 @@
 /obj/machinery/button/crematorium{
 	id_tag = "scp8crem";
 	pixel_y = -24;
-	req_access = list(access_sciencelvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /obj/structure/crematorium{
 	dir = 8;
@@ -15369,7 +15369,7 @@
 "PH" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Primary Containment Compartment";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -15407,7 +15407,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
@@ -15466,7 +15466,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lhcz/scp049containment)
@@ -15554,7 +15554,7 @@
 "QB" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "Infected Subject Area";
@@ -15832,7 +15832,7 @@
 /area/site53/uhcz/scp8containment)
 "RT" = (
 /obj/machinery/door/airlock/security{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
@@ -15882,7 +15882,7 @@
 "Sl" = (
 /obj/machinery/door/airlock/research{
 	name = "Containment Chamber";
-	req_access = list(access_securitylvl3,access_sciencelvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3")
 	},
 /obj/machinery/door/blast/regular{
 	dir = 8;
@@ -15945,7 +15945,7 @@
 /area/site53/uhcz/scp8containment)
 "SH" = (
 /obj/machinery/door/window/brigdoor/northleft{
-	req_access = list(access_adminlvl3)
+	req_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /obj/structure/table/rack,
 /turf/simulated/floor/wood/walnut,
@@ -16129,7 +16129,7 @@
 /obj/machinery/button/crematorium{
 	id_tag = "scp8crem";
 	pixel_y = -24;
-	req_access = list(access_sciencelvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/uhcz/scp8containment)
@@ -16361,7 +16361,7 @@
 "UL" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-008";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
@@ -16443,7 +16443,7 @@
 /obj/structure/closet/secure_closet/freezer{
 	icon = 'icons/obj/closets/fridge.dmi';
 	name = "Secure Freezer";
-	req_access = list(access_sciencelvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /obj/item/reagent_containers/glass/beaker/vial/scp008,
 /obj/item/reagent_containers/glass/beaker/vial/scp008,
@@ -16627,7 +16627,7 @@
 "VT" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Maintenance Closet";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/lhcz/maintenance)
@@ -16683,7 +16683,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-1102-RU";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -16695,7 +16695,7 @@
 	master_tag = "scp8_airlock";
 	pixel_x = 25;
 	pixel_y = -25;
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 14
@@ -16983,7 +16983,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -17026,7 +17026,7 @@
 "XN" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Surgical Compartment";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -17155,7 +17155,7 @@
 "Yt" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "LHCZ Maintenance";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17200,7 +17200,7 @@
 	master_tag = "scp8_airlock";
 	pixel_x = -25;
 	pixel_y = 25;
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -17213,7 +17213,7 @@
 "YB" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "Control Subject Area";
@@ -17370,7 +17370,7 @@
 "Zp" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17414,7 +17414,7 @@
 	id_tag = "247lockdown";
 	name = "Containment Unit Lockdown button";
 	pixel_y = 24;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/scp8containment)
@@ -17474,7 +17474,7 @@
 "ZM" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "Control Subject Area";
@@ -17498,7 +17498,7 @@
 "ZQ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-008";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3,access_medicallvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "SCP 008 Storage";

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -325,7 +325,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
@@ -358,7 +358,7 @@
 "abb" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/monotile,
@@ -661,7 +661,7 @@
 /obj/structure/bed/chair,
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled/monotile,
@@ -674,7 +674,7 @@
 "acb" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenobiology Laboratory";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/reswing/xenobiology)
@@ -996,7 +996,7 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Xenobiology Laboratory";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/reswing/xenobiology)
@@ -1070,7 +1070,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -1235,7 +1235,7 @@
 "adD" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
@@ -1493,7 +1493,7 @@
 "aee" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1547,7 +1547,7 @@
 "aek" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1721,7 +1721,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(list(access_securitylvl3,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -1744,7 +1744,7 @@
 "aeK" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Red Line";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/plating,
 /area/site53/tram/hcz)
@@ -1811,7 +1811,7 @@
 "aeZ" = (
 /obj/machinery/door/airlock/research{
 	name = "Production Room";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
@@ -1939,7 +1939,7 @@
 "afs" = (
 /obj/machinery/door/airlock/research{
 	name = "Surgical Theatre";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
@@ -2083,7 +2083,7 @@
 "afP" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	name = "Chemistry Laboratory";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics)
@@ -2913,7 +2913,7 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Research Wing";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
@@ -2952,7 +2952,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3061,7 +3061,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "ULCZ Maintenance";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3129,7 +3129,7 @@
 "aih" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Research Wing";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
@@ -3282,7 +3282,7 @@
 /obj/item/aiModule/purge,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(access_sciencelvl5,access_adminlvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL5","ACCESS_ADMIN_LEVEL4")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
@@ -3420,7 +3420,7 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/door/window/brigdoor/southleft{
-	req_access = list(access_engineeringlvl3)
+	req_access = list("ACCESS_ENGINEERING_LEVEL3")
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3428,7 +3428,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -3529,7 +3529,7 @@
 "aiY" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -3646,7 +3646,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Self-Destruct Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3913,7 +3913,7 @@
 "ajX" = (
 /obj/structure/closet/secure_closet/engineering_personal{
 	name = "Containment Engineer's locker";
-	req_access = list(access_engineeringlvl4)
+	req_access = list("ACCESS_ENGINEERING_LEVEL4")
 	},
 /obj/machinery/camera/autoname{
 	dir = 8;
@@ -4107,7 +4107,7 @@
 "aku" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Control Room";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/controlroom)
@@ -4121,7 +4121,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Control Room";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/controlroom)
@@ -4264,7 +4264,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	name = "Break Room";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/breakroom)
@@ -4276,7 +4276,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Self-Destruct Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4320,7 +4320,7 @@
 /obj/structure/closet/radiation,
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techmaint,
@@ -4334,7 +4334,7 @@
 "akU" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Dorms";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/sleeproom)
@@ -4343,7 +4343,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	name = "Dorms";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4359,7 +4359,7 @@
 "akY" = (
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Containment Engineer's Office";
-	req_access = list(access_engineeringlvl4)
+	req_access = list("ACCESS_ENGINEERING_LEVEL4")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -4373,7 +4373,7 @@
 /area/site53/engineering/containment_engineer)
 "ala" = (
 /obj/structure/closet/secure_closet/engineering_welding{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/monotile,
@@ -4393,7 +4393,7 @@
 /area/site53/upper_surface/serverfarmtunnel)
 "ale" = (
 /obj/structure/closet/secure_closet/engineering_welding{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -4479,7 +4479,7 @@
 	id_tag = "ULCZ Secure Armoury";
 	name = "ULCZ Secure Armoury";
 	pixel_x = -22;
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -4500,7 +4500,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-895";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4577,7 +4577,7 @@
 /obj/structure/closet/radiation,
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
@@ -4804,7 +4804,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/item/device/flashlight{
 	pixel_y = 15
@@ -4908,7 +4908,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/item/device/flashlight{
 	pixel_y = 15
@@ -4961,7 +4961,7 @@
 "amu" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 32;
-	req_access = list(access_sciencelvl4,access_engineeringlvl4,access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techfloor,
@@ -5041,7 +5041,7 @@
 "amG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Communications Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5094,7 +5094,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/item/device/flashlight{
 	pixel_y = 15
@@ -5132,7 +5132,7 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/janitorial)
@@ -5217,7 +5217,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "selfdestruct";
 	pixel_y = 24;
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -5320,7 +5320,7 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/primaryhallway)
@@ -5414,7 +5414,7 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/auxstorage)
@@ -5575,7 +5575,7 @@
 "anL" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -5625,7 +5625,7 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/item/device/flashlight{
 	pixel_y = 15
@@ -5826,7 +5826,7 @@
 "aoq" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5926,7 +5926,7 @@
 "aoJ" = (
 /obj/machinery/door/airlock/command{
 	name = "AIC Access";
-	req_access = list(access_sciencelvl4,access_adminlvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/science/aicobservation)
@@ -5987,7 +5987,7 @@
 	id_tag = "ULCZ Secure Armoury";
 	name = "ULCZ Secure Armoury";
 	pixel_x = -22;
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
@@ -6027,7 +6027,7 @@
 /area/site53/engineering/primaryhallway)
 "aoR" = (
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
 /obj/item/device/flashlight{
@@ -6053,7 +6053,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Main Reactor";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/vacant/prototype/engine)
@@ -6118,7 +6118,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/airlock/engineering{
 	name = "Atmos";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6218,7 +6218,7 @@
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
 /obj/structure/closet/secure_closet/engineering_personal{
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/item/device/flashlight{
 	pixel_y = 15
@@ -6301,7 +6301,7 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/prototype/control)
@@ -6338,7 +6338,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/prototype/control)
@@ -6670,7 +6670,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -6748,7 +6748,7 @@
 /area/site53/engineering/primaryhallway)
 "aqy" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6973,7 +6973,7 @@
 "aqS" = (
 /obj/machinery/power/apc/high{
 	dir = 1;
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -7625,7 +7625,7 @@
 "asb" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Main Reactor";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/control)
@@ -7943,7 +7943,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Lockers Room";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/locker_room)
@@ -7951,7 +7951,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	name = "Lockers Room";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/locker_room)
@@ -7959,7 +7959,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
@@ -8041,7 +8041,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	name = "Fire Closet";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/primaryhallway)
@@ -8050,7 +8050,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/engineering{
 	name = "Secure Storage";
-	req_access = list(access_engineeringlvl3)
+	req_access = list("ACCESS_ENGINEERING_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8120,7 +8120,7 @@
 "ati" = (
 /obj/machinery/door/airlock/vault{
 	name = "Secure Storage";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -8299,7 +8299,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -8362,7 +8362,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Workshop";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -8370,7 +8370,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/engineering{
 	name = "Workshop";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -8506,7 +8506,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Main Reactor";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/control)
@@ -8565,7 +8565,7 @@
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_welding{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -8574,7 +8574,7 @@
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_electrical{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -8587,7 +8587,7 @@
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_electrical{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -8650,7 +8650,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Main Reactor";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
@@ -8742,7 +8742,7 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -8757,7 +8757,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/engineering{
 	name = "Battery Bank";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/cyan{
@@ -8808,7 +8808,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/vault{
 	name = "Secure Storage";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -9027,7 +9027,7 @@
 	},
 /obj/machinery/suit_storage_unit/engineering{
 	islocked = 0;
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -9422,7 +9422,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
@@ -9598,7 +9598,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Control Room";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable/cyan{
 	icon_state = "1-2"
@@ -9773,7 +9773,7 @@
 	},
 /obj/machinery/suit_storage_unit/engineering{
 	islocked = 0;
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -9849,7 +9849,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	name = "Main Reactor";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/control)
@@ -10022,7 +10022,7 @@
 "axp" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Control Room";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10132,7 +10132,7 @@
 	},
 /obj/machinery/door/airlock/engineering{
 	name = "Atmos";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -10211,7 +10211,7 @@
 "axK" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/flora/pottedplant/flower,
 /obj/effect/floor_decal/corner/yellow/half{
@@ -10449,7 +10449,7 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/vacant/prototype/engine)
@@ -10594,7 +10594,7 @@
 "ayv" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/orange/mono,
 /obj/structure/flora/pottedplant/floorleaf,
@@ -10669,7 +10669,7 @@
 "ayG" = (
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Engineering Tram";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -11137,14 +11137,14 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Logistics Storage Area";
-	req_access = list(access_engineeringlvl1,access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1","ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/plating,
 /area/site53/logistics/logistics)
 "azL" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Underground Storage";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -11152,7 +11152,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Underground Storage";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -11245,7 +11245,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "check3";
 	pixel_y = 24;
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -11424,7 +11424,7 @@
 "aAv" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Main Reactor";
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/vacant/prototype/engine)
@@ -11553,7 +11553,7 @@
 "aAK" = (
 /obj/machinery/door/airlock/science{
 	name = "Elevator Access";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11628,7 +11628,7 @@
 "aAS" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -12226,7 +12226,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -12268,7 +12268,7 @@
 "aCn" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "SCP-106 Elevator Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12549,7 +12549,7 @@
 "aCK" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13068,7 +13068,7 @@
 "aEc" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "SCP-106 Elevator Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13210,7 +13210,7 @@
 "aEu" = (
 /obj/machinery/door/airlock/security{
 	name = "Zone Commander's Office";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13401,7 +13401,7 @@
 "aET" = (
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Orange Line";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -13453,7 +13453,7 @@
 "aFa" = (
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Orange Line";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -13588,7 +13588,7 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -13944,7 +13944,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "check3";
 	pixel_y = 24;
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -14238,7 +14238,7 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/engineering/engine_smes)
@@ -14484,7 +14484,7 @@
 "aHJ" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -14529,7 +14529,7 @@
 "aHP" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Containment Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14564,7 +14564,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -14584,7 +14584,7 @@
 "aHV" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-078 Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
@@ -14679,7 +14679,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Research Wing Substation";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint)
@@ -14796,14 +14796,14 @@
 /obj/machinery/door/window/brigdoor/northleft,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/door/window/brigdoor/southright{
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/reswing/xenobiology)
 "aIC" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "General Purpose Laboratory";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/reswing/robotics)
@@ -15025,7 +15025,7 @@
 "aJb" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15079,7 +15079,7 @@
 /obj/machinery/door/window/brigdoor/westleft,
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/machinery/door/window/brigdoor/eastleft{
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/reswing/xenobiology)
@@ -15122,7 +15122,7 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15155,7 +15155,7 @@
 "aJB" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-151";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -15187,7 +15187,7 @@
 "aJF" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-151 Containment Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15206,7 +15206,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15264,14 +15264,14 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/ulcz/scp173)
 "aJT" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-173 Containment Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15334,7 +15334,7 @@
 "aKc" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "General Purpose Laboratory";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15644,7 +15644,7 @@
 "aKJ" = (
 /obj/machinery/door/airlock/science{
 	name = "Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
@@ -15668,7 +15668,7 @@
 "aKM" = (
 /obj/machinery/door/airlock/science{
 	name = "Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -15757,7 +15757,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -15955,7 +15955,7 @@
 "aLA" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-173";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16355,7 +16355,7 @@
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
@@ -16387,7 +16387,7 @@
 "aMI" = (
 /obj/machinery/door/airlock/research{
 	name = "Containment Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16447,7 +16447,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor,
 /area/site53/lowertrams/redline)
@@ -16647,7 +16647,7 @@
 	id_tag = "ULCZ Checkpoint Booth Exit";
 	name = "ULCZ Checkpoint Booth Exit";
 	pixel_x = 24;
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/item/device/toner,
 /obj/item/device/toner,
@@ -17333,7 +17333,7 @@
 	dir = 1;
 	id_tag = "selfdestruct";
 	pixel_y = -23;
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/uppernukeladders)
@@ -17584,7 +17584,7 @@
 "aPr" = (
 /obj/machinery/door/airlock/glass/civilian{
 	name = "Unused SCP Containment Chamber ";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -17632,7 +17632,7 @@
 "aPv" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-263";
-	req_access = list(list(access_securitylvl2,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17815,7 +17815,7 @@
 "aPV" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Experimentation Center";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
@@ -17970,7 +17970,7 @@
 /obj/effect/paint_stripe/red,
 /obj/machinery/door/airlock/engineering{
 	name = "Communication Engineers";
-	req_access = list(access_engineeringlvl3)
+	req_access = list("ACCESS_ENGINEERING_LEVEL3")
 	},
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -18050,7 +18050,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/maintenance{
 	name = "Logistics Storage Area";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/barricade,
 /turf/simulated/floor/plating,
@@ -18125,7 +18125,7 @@
 "aRb" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
@@ -18196,7 +18196,7 @@
 "aRz" = (
 /obj/machinery/suit_storage_unit/engineering{
 	islocked = 0;
-	req_access = list(access_engineeringlvl2)
+	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
@@ -18209,7 +18209,7 @@
 "aRC" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -18266,7 +18266,7 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/machinery/computer/rcon{
 	dir = 8
@@ -18312,7 +18312,7 @@
 "aRO" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Communication Engineers";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -18512,7 +18512,7 @@
 "aSC" = (
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Chemistry Laboratory";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics)
@@ -18656,7 +18656,7 @@
 "aTj" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-173 Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -18701,7 +18701,7 @@
 "aTs" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "LCZ Security Center";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -18846,7 +18846,7 @@
 	id_tag = "173emerg";
 	name = "Observation Emergency Blast Doors button";
 	pixel_y = 25;
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
@@ -19025,7 +19025,7 @@
 "aUF" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Locker Room";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -19155,7 +19155,7 @@
 "aVg" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-078 Containment Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -19172,7 +19172,7 @@
 "aVi" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Checkpoint Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
@@ -19238,7 +19238,7 @@
 /area/site53/llcz/checkequip)
 "aVr" = (
 /obj/machinery/door/window/brigdoor/eastright{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -19253,7 +19253,7 @@
 /area/site53/llcz/checkequip)
 "aVu" = (
 /obj/machinery/door/window/brigdoor/westleft{
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19290,7 +19290,7 @@
 /obj/effect/catwalk_plated/white,
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Center";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -19325,7 +19325,7 @@
 	id_tag = "173";
 	name = "Chamber Blast Doors button";
 	pixel_y = 25;
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
@@ -19424,7 +19424,7 @@
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "HCZ Secure Armoury";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/machinery/door/blast/regular{
 	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
@@ -19474,7 +19474,7 @@
 "aWd" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-078 Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19515,7 +19515,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/science{
 	name = "SCP-173 Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -19578,7 +19578,7 @@
 "aWq" = (
 /obj/machinery/door/airlock/science{
 	name = "General Purpose Containment  Chamber";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose)
@@ -19633,7 +19633,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -19653,7 +19653,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -19706,7 +19706,7 @@
 "aWI" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-013";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -19750,7 +19750,7 @@
 	},
 /obj/machinery/door/airlock/science{
 	name = "SCP-113";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp113)
@@ -19808,7 +19808,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/scp343entrance)
@@ -19824,7 +19824,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -19839,7 +19839,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -20025,7 +20025,7 @@
 "aXw" = (
 /obj/machinery/door/airlock/science{
 	name = "General Purpose Testing Chamber";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
@@ -20350,7 +20350,7 @@
 "aYr" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Communication Engineers";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -20904,7 +20904,7 @@
 /area/site53/uhcz/hallways)
 "bag" = (
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/machinery/door/blast/regular{
 	id_tag = "15"
@@ -20956,7 +20956,7 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-035";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/plating,
 /area/site53/lhcz/scp035room)
@@ -20985,7 +20985,7 @@
 	dir = 8;
 	id_tag = "16";
 	pixel_x = 23;
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -21037,7 +21037,7 @@
 /area/site53/lhcz/scp035room)
 "bav" = (
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/machinery/door/blast/regular{
 	id_tag = "16"
@@ -21364,7 +21364,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(list(access_securitylvl3,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/plating,
 /area/site53/lhcz/scp343entrance)
@@ -21419,7 +21419,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1);
+	req_access = list("ACCESS_SCIENCE_LEVEL1");
 	desc = "Seems more like a decoration than anyhting."
 	},
 /obj/structure/cable/green{
@@ -21894,7 +21894,7 @@
 	id_tag = "livingenclosure";
 	locked = 1;
 	name = "SCP-247 Enclosure";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp247observation)
@@ -21913,7 +21913,7 @@
 "bdg" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "RIOT CONTROL";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
@@ -21989,7 +21989,7 @@
 "bdu" = (
 /obj/machinery/alarm{
 	pixel_y = 23;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/table/standard,
 /obj/item/toy/plushie/lizard{
@@ -22583,7 +22583,7 @@
 /area/site53/surface/explorers)
 "bfD" = (
 /obj/machinery/door/airlock{
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/wood,
 /area/site53/surface/explorers)
@@ -22890,7 +22890,7 @@
 	id_tag = "UHCZ Lockdown";
 	name = "UHCZ Lockdown";
 	pixel_y = 23;
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine,
@@ -22903,7 +22903,7 @@
 	id_tag = "ULCZ Checkpoint Booth";
 	name = "ULCZ Checkpoint Booth";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -22925,7 +22925,7 @@
 	id_tag = "ULCZ Checkpoint Primary Entrance";
 	name = "ULCZ Checkpoint Primary Entrance";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "ULCZ Booth Window 1";
@@ -22948,7 +22948,7 @@
 	id_tag = "ULCZ Exit Line Cycle";
 	name = "ULCZ Exit Line Cycle";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
@@ -22973,21 +22973,21 @@
 	id_tag = "ULCZ Checkpoint Secondary Entrance";
 	name = "ULCZ Checkpoint Secondary Entrance";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/button/blast_door{
 	dir = 8;
 	id_tag = "ULCZ Interior Booth Window";
 	name = "ULCZ Checkpoint Booth Exit";
 	pixel_x = 24;
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "bgI" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Checkpoint Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
@@ -23000,11 +23000,11 @@
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor{
 	name = "Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "ULCZ Booth Window 1";
@@ -23152,7 +23152,7 @@
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
@@ -23162,7 +23162,7 @@
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	pixel_x = 24;
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
@@ -23217,7 +23217,7 @@
 	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
 	pixel_x = 24;
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
@@ -23309,7 +23309,7 @@
 "bhi" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "ULCZ Secure Armoury";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
@@ -23689,7 +23689,7 @@
 "bhU" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Zone Gate Security Post";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -23779,7 +23779,7 @@
 	id_tag = "HCZ Secure Armoury";
 	name = "HCZ Secure Armoury";
 	pixel_x = -22;
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -23805,7 +23805,7 @@
 "bid" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "HCZ Secure Armoury";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/machinery/door/blast/regular/open{
 	begins_closed = 1;
@@ -23895,7 +23895,7 @@
 /area/site53/ulcz/generalpurpose2)
 "bin" = (
 /obj/machinery/door/airlock/multi_tile/research{
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -23998,7 +23998,7 @@
 	id_tag = "UHCZ Booth Window 2";
 	name = "UHCZ Booth Window 2";
 	pixel_y = 23;
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -24010,7 +24010,7 @@
 	id_tag = "UHCZ Booth Window 1";
 	name = "UHCZ Booth Window 1";
 	pixel_y = 23;
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -24041,7 +24041,7 @@
 	id_tag = "HCZ Secure Armoury";
 	name = "HCZ Secure Armoury";
 	pixel_x = -22;
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -24153,11 +24153,11 @@
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor{
 	name = "Booth";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Booth";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
@@ -24294,14 +24294,14 @@
 	id_tag = "UHCZ Checkpoint Control Room 2";
 	name = "UHCZ Checkpoint Control Room 2";
 	pixel_y = -23;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "bjd" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Equipment";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24316,7 +24316,7 @@
 "bje" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Zone Gate Security Post";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -24488,7 +24488,7 @@
 	name = "HCZ Armory Door bolt";
 	pixel_x = 24;
 	pixel_y = 23;
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24505,7 +24505,7 @@
 	id_tag = "hczguns";
 	locked = 1;
 	name = "HCZ Armory";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24556,7 +24556,7 @@
 "bjz" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "HCZ Secure Armoury";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24607,7 +24607,7 @@
 	id_tag = "UHCZ Checkpoint Control Room";
 	name = "UHCZ Checkpoint Control Room";
 	pixel_x = 24;
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -24620,7 +24620,7 @@
 "bjE" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Zone Gate Security Post";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
@@ -24731,7 +24731,7 @@
 "bjP" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -24747,7 +24747,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -24773,14 +24773,14 @@
 	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
 	name = "UHCZ Secure Maintenance Tunnel Lockdown";
 	pixel_x = 24;
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bjU" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -24972,7 +24972,7 @@
 "bks" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Center";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/maintenance)
@@ -25009,7 +25009,7 @@
 /obj/effect/catwalk_plated/white,
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Center";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
@@ -25357,7 +25357,7 @@
 	},
 /obj/machinery/power/apc/hyper{
 	dir = 1;
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -25468,7 +25468,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -25500,7 +25500,7 @@
 /area/site53/ulcz/medicalpost)
 "coZ" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25525,7 +25525,7 @@
 "cvQ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-247";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25552,7 +25552,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "895entry";
 	pixel_y = 23;
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp895)
@@ -25664,7 +25664,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
 	name = "Containment chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
@@ -25861,7 +25861,7 @@
 "dsY" = (
 /obj/machinery/door/airlock/research{
 	name = "Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -25957,7 +25957,7 @@
 	},
 /obj/machinery/door/airlock/glass/research{
 	name = "Senior Researcher Office B";
-	req_access = list(access_sciencelvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/science/seniorresearcherb)
@@ -25992,7 +25992,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/science{
 	name = "Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
@@ -26113,7 +26113,7 @@
 	id_tag = "foodenclosure";
 	locked = 1;
 	name = "SCP-247 Enclosure";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp247observation)
@@ -26138,7 +26138,7 @@
 "ecq" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Communication Engineers";
-	req_access = list(access_engineeringlvl3)
+	req_access = list("ACCESS_ENGINEERING_LEVEL3")
 	},
 /obj/machinery/door/firedoor{
 	dir = 4
@@ -26179,7 +26179,7 @@
 	id_tag = "evacbunkerblastdoor";
 	name = "Evacuation Bunker Blast Door button";
 	pixel_y = 25;
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
@@ -26213,14 +26213,14 @@
 "eqH" = (
 /obj/machinery/door/airlock/science{
 	name = "Tranqilizer Storage";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "erj" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-096";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/blast/regular{
 	id_tag = "096chamberlock2"
@@ -26322,7 +26322,7 @@
 	},
 /obj/machinery/door/airlock/glass/command{
 	name = "AIC Observation";
-	req_access = list(access_sciencelvl4,access_adminlvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/science/aicobservation)
@@ -26369,7 +26369,7 @@
 "eQX" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-106 Observation";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -26874,7 +26874,7 @@
 	},
 /obj/machinery/door/airlock/science{
 	name = "Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
@@ -27222,7 +27222,7 @@
 "hmB" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-247 Staff Training";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
@@ -27282,7 +27282,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -27346,7 +27346,7 @@
 	dir = 1;
 	id_tag = "check3";
 	pixel_y = -22;
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
@@ -27388,7 +27388,7 @@
 /area/site53/uhcz/scp247containment)
 "hFl" = (
 /obj/machinery/power/rad_collector{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -27433,7 +27433,7 @@
 	},
 /obj/machinery/door/airlock/research{
 	name = "SCP-513";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27469,7 +27469,7 @@
 "hTt" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-247 Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -27493,7 +27493,7 @@
 /obj/machinery/door/window{
 	dir = 8;
 	name = "DANGER: LEADS TO SCP-012 CHAMBER";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
@@ -27679,7 +27679,7 @@
 	},
 /obj/machinery/door/airlock/science{
 	name = "General Storage";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/genstorage1)
@@ -27897,7 +27897,7 @@
 "jgH" = (
 /obj/machinery/door/airlock/glass/civilian{
 	name = "Unused SCP Containment Chamber ";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27939,7 +27939,7 @@
 "jmX" = (
 /obj/machinery/door/airlock/glass/science{
 	name = "SCP-066 Containment Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
@@ -27981,7 +27981,7 @@
 "jsp" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-529";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
@@ -28267,7 +28267,7 @@
 "kiO" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "General Purpose Chamber";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -28313,7 +28313,7 @@
 "ktI" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-247 Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
@@ -28339,7 +28339,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-066 Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -28370,7 +28370,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity/bolted{
-	req_access = list(access_sciencelvl5,access_adminlvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL5","ACCESS_ADMIN_LEVEL4")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/science/aiccore)
@@ -28676,7 +28676,7 @@
 "ltv" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Brown Line";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2,access_medicallvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/tram/lcz)
@@ -28707,7 +28707,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -28919,7 +28919,7 @@
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-106";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106containment)
@@ -29210,7 +29210,7 @@
 "mDz" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-078";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
@@ -29305,7 +29305,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "scp96chamber";
 	name = "SCP-096";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -29484,7 +29484,7 @@
 "nmB" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Senior Researcher Office A";
-	req_access = list(access_sciencelvl4)
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -29516,7 +29516,7 @@
 	dir = 4;
 	id_tag = "16";
 	pixel_x = -23;
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp035room)
@@ -29977,7 +29977,7 @@
 	id_tag = "evaccell";
 	name = "Bunker Brig Cell bolt button";
 	pixel_x = -25;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
@@ -30085,7 +30085,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/high{
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
@@ -30185,7 +30185,7 @@
 "pnC" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "AIC Observation";
-	req_access = list(access_sciencelvl4,access_adminlvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/science/aicobservation)
@@ -30607,7 +30607,7 @@
 "qEi" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Red Line";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -30665,7 +30665,7 @@
 "qLk" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Communication Engineers";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -30770,14 +30770,14 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
 "raR" = (
 /obj/machinery/door/airlock/science{
 	name = "General Purpose Testing Chamber";
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
@@ -30836,7 +30836,7 @@
 "rlV" = (
 /obj/machinery/door/airlock/vault{
 	name = "Containment Chamber";
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp106containment)
@@ -30987,7 +30987,7 @@
 	},
 /obj/machinery/door/airlock/command{
 	name = "AIC Access";
-	req_access = list(access_sciencelvl4,access_adminlvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/science/aicobservation)
@@ -31123,7 +31123,7 @@
 "sek" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Checkpoint holding cell";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
 /area/site53/llcz/entrance_checkpoint)
@@ -31233,7 +31233,7 @@
 "swJ" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-263 Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
@@ -31602,7 +31602,7 @@
 "tGo" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Robotics Laboratory";
-	req_access = list(access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
@@ -31704,11 +31704,11 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	name = "Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/window/brigdoor/westleft{
 	name = "Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
@@ -31736,7 +31736,7 @@
 "ugg" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Red Line";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
@@ -31839,7 +31839,7 @@
 	id_tag = "livingenclosure";
 	locked = 1;
 	name = "SCP-247 Enclosure";
-	req_access = list(list(access_securitylvl2,access_sciencelvl3))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31871,7 +31871,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	id_tag = "scp96observation";
 	name = "SCP-096";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -31956,7 +31956,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 2;
@@ -32000,7 +32000,7 @@
 "uQr" = (
 /obj/machinery/door/airlock/glass/civilian{
 	name = "SCP-529";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500{
@@ -32073,14 +32073,14 @@
 	id_tag = "066";
 	name = "SCP-066 Containment Chamber Lock button";
 	pixel_y = 24;
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/button/blast_door{
 	dir = 8;
 	id_tag = "066shutter";
 	name = "SCP-066 Containment Chamber Shutter button";
 	pixel_x = 24;
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
@@ -32088,7 +32088,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-263 Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
@@ -32111,11 +32111,11 @@
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor{
 	name = "Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Booth";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "ULCZ Booth Window 2";
@@ -32213,7 +32213,7 @@
 	dir = 1
 	},
 /obj/machinery/door/window/brigdoor/eastright{
-	req_access = list(access_adminlvl4,access_adminlvl4)
+	req_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor,
@@ -32824,7 +32824,7 @@
 "wGH" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-106 Observation";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
@@ -32879,7 +32879,7 @@
 	},
 /obj/machinery/door/airlock/science{
 	name = "SCP-106 Observation";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
@@ -32940,7 +32940,7 @@
 "wUk" = (
 /obj/machinery/door/airlock/research{
 	name = "Observation";
-	req_access = list(list(access_securitylvl2,access_sciencelvl2))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
@@ -33258,7 +33258,7 @@
 "xQv" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-263 Containment Chamber";
-	req_access = list(list(access_securitylvl2,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
@@ -33279,7 +33279,7 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "evaccell";
 	name = "Bunker Brig Cell";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
@@ -33366,7 +33366,7 @@
 	},
 /obj/machinery/door/airlock/highsecurity{
 	name = "SCP-096";
-	req_access = list(list(access_securitylvl3,access_sciencelvl4))
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -95,7 +95,7 @@
 "ao" = (
 /obj/machinery/door/airlock/command{
 	name = "Main Control Room";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -301,7 +301,7 @@
 /area/site53/maintenance/surfacewest)
 "aR" = (
 /obj/machinery/door/airlock/engineering{
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -334,7 +334,7 @@
 /area/site53/surface/cryogenicsprimary)
 "aV" = (
 /obj/machinery/door/airlock/engineering{
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -386,7 +386,7 @@
 /obj/item/clothing/accessory/stethoscope,
 /obj/item/clothing/suit/armor/pcarrier/light,
 /obj/structure/closet/secure_closet/paramedic{
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/item/storage/firstaid/adv,
 /obj/item/crowbar/prybar,
@@ -564,7 +564,7 @@
 /area/site53/surface/surface)
 "bx" = (
 /obj/structure/closet/crate/secure/biohazard{
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -734,7 +734,7 @@
 "ca" = (
 /obj/machinery/door/airlock/security{
 	name = "Communications Tower";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/commstower)
@@ -768,7 +768,7 @@
 "cm" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Reception";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1020,7 +1020,7 @@
 "dn" = (
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Emergency Treatment Center";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1097,7 +1097,7 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/virology{
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/button/alternate/door/bolts{
@@ -1249,7 +1249,7 @@
 "dP" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1293,7 +1293,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -1412,7 +1412,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
 	name = "Medical Reception";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
@@ -1492,7 +1492,7 @@
 /area/site53/medical/mentalhealth/isolation)
 "ez" = (
 /obj/structure/closet/secure_closet/medical3{
-	req_access = list(access_medicallvl3)
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
 	},
 /obj/item/device/flashlight/pen,
 /obj/item/clothing/accessory/stethoscope,
@@ -1569,7 +1569,7 @@
 "eJ" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psychiatry";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
@@ -1728,7 +1728,7 @@
 /obj/machinery/button/crematorium{
 	id_tag = "medicalcrema";
 	pixel_x = -22;
-	req_access = list(access_medicallvl3)
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
 	},
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/bodybags,
@@ -1737,14 +1737,14 @@
 "ff" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Break Room";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "fg" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Equipment Room";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
@@ -1839,7 +1839,7 @@
 /obj/machinery/door/airlock/glass/virology{
 	id_tag = "virocell1";
 	name = "Virology Isolation Cell 1";
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/virology)
@@ -1868,7 +1868,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -1881,7 +1881,7 @@
 /obj/effect/floor_decal/corner/green/full,
 /obj/machinery/smartfridge/secure/virology{
 	pixel_y = -32;
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/virology)
@@ -1939,13 +1939,13 @@
 /obj/machinery/door/airlock/glass/virology{
 	id_tag = "virocell4";
 	name = "Virology Isolation Cell 4";
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/virology)
 "fB" = (
 /obj/machinery/vending/medical{
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1977,7 +1977,7 @@
 /area/site53/medical/virology)
 "fH" = (
 /obj/machinery/vending/medical{
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
@@ -2121,7 +2121,7 @@
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	id_tag = "medbaydoor";
 	name = "Medical Bay";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2162,7 +2162,7 @@
 "ge" = (
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Surgical Ward";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2280,7 +2280,7 @@
 "gs" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Helipad";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -2458,7 +2458,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
 	name = "Medical Reception";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
@@ -2524,7 +2524,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical{
 	name = "Mortuary";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2551,7 +2551,7 @@
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Operating Room 2";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2828,7 +2828,7 @@
 "hL" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psychiatric Isolation";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/mentalhealth/isolation)
@@ -2975,7 +2975,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -3011,7 +3011,7 @@
 "ij" = (
 /obj/structure/closet/secure_closet/medical3{
 	name = "surgeon's locker";
-	req_access = list(access_medicallvl3)
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
 	},
 /obj/item/clothing/head/surgery/blue,
 /obj/item/clothing/suit/surgicalapron,
@@ -3046,7 +3046,7 @@
 /area/site53/medical/surgery/op1)
 "ip" = (
 /obj/structure/closet/crate/secure/biohazard{
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -3074,13 +3074,13 @@
 /obj/machinery/door/airlock/glass/virology{
 	id_tag = "virocell3";
 	name = "Virology Isolation Cell 3";
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/virology)
 "iu" = (
 /obj/machinery/smartfridge/chemistry{
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/effect/paint_stripe/paleblue,
 /turf/simulated/wall/prepainted,
@@ -3215,7 +3215,7 @@
 /area/site53/uez/mcrsubstation)
 "iK" = (
 /obj/machinery/vending/medical{
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
@@ -3225,7 +3225,7 @@
 "iL" = (
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Mental Isolation";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmary)
@@ -3296,7 +3296,7 @@
 /obj/item/clothing/suit/bio_suit/general,
 /obj/item/clothing/head/bio_hood/general,
 /obj/structure/closet/secure_closet/medical3{
-	req_access = list(access_medicallvl3)
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
 	},
 /obj/item/storage/firstaid/adv,
 /obj/machinery/light{
@@ -3523,7 +3523,7 @@
 "jo" = (
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Chemistry Laboratory";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3708,7 +3708,7 @@
 	dir = 4;
 	icon_state = "closed";
 	name = "Virology";
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -3747,7 +3747,7 @@
 /area/site53/medical/mentalhealth/isolation)
 "jU" = (
 /obj/structure/closet/secure_closet/chemical{
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/item/clothing/glasses/science,
 /obj/effect/floor_decal/corner/purple/mono,
@@ -3755,7 +3755,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -3831,7 +3831,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -3950,7 +3950,7 @@
 "kq" = (
 /obj/machinery/door/airlock/medical{
 	name = "Psychiatrist's Office";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4000,7 +4000,7 @@
 /obj/item/clothing/suit/bio_suit/general,
 /obj/item/clothing/head/bio_hood/general,
 /obj/structure/closet/secure_closet/medical3{
-	req_access = list(access_medicallvl3)
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
 	},
 /obj/machinery/camera/network/medbay{
 	c_tag = "Medical Equipment Room"
@@ -4023,10 +4023,10 @@
 "kB" = (
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor/westleft{
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/machinery/door/window/eastleft{
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception)
@@ -4380,7 +4380,7 @@
 "lu" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Post";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4443,7 +4443,7 @@
 "lD" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Post";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/securitypost)
@@ -4787,7 +4787,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -4826,7 +4826,7 @@
 /area/site53/entrancezone/hallway)
 "mK" = (
 /obj/machinery/door/window/brigdoor/northleft{
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -4901,7 +4901,7 @@
 "mS" = (
 /obj/machinery/door/airlock/multi_tile/security{
 	name = "\improper Entrance Zone Guard Equipment";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -4911,7 +4911,7 @@
 "mW" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -5122,7 +5122,7 @@
 "nR" = (
 /obj/machinery/door/airlock/multi_tile/glass/command{
 	name = "Administration Offices";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
@@ -5185,7 +5185,7 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -5203,7 +5203,7 @@
 	dir = 8;
 	icon_state = "closed";
 	name = "Substation";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/substation)
@@ -5531,7 +5531,7 @@
 	},
 /obj/machinery/door/airlock/medical{
 	name = "Operating Room 1";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5820,7 +5820,7 @@
 "qS" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Logistics";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/logistics/logistics)
@@ -5903,7 +5903,7 @@
 	},
 /obj/machinery/door/airlock/command{
 	name = "O5 Representative's Office";
-	req_access = list(access_adminlvl2)
+	req_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/o5repoffice)
@@ -6088,7 +6088,7 @@
 "rI" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Loading Docks";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -6117,7 +6117,7 @@
 "rL" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Primary Storage";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -6137,7 +6137,7 @@
 /area/site53/logistics/logistics)
 "rO" = (
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
@@ -6157,7 +6157,7 @@
 "rR" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Helipad";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -6206,7 +6206,7 @@
 "rX" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Cargo Center";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
@@ -6261,7 +6261,7 @@
 "sg" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Cargo Center";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6282,7 +6282,7 @@
 "sl" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Logistics";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -6328,7 +6328,7 @@
 "sq" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Loading Docks";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6345,7 +6345,7 @@
 "ss" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Loading Docks";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
@@ -6353,7 +6353,7 @@
 "st" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Primary Storage";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
@@ -6505,7 +6505,7 @@
 /area/site53/zonecommanderoffice)
 "sS" = (
 /obj/structure/closet/secure_closet/mtf/co{
-	req_access = list(access_sciencelvl2)
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
 	},
 /obj/item/crowbar/red,
 /obj/item/clothing/head/bio_hood/security,
@@ -6586,7 +6586,7 @@
 	},
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/effect/floor_decal/corner/blue/borderfull,
 /turf/simulated/floor/tiled/monotile,
@@ -6759,7 +6759,7 @@
 	id_tag = "ezguns";
 	locked = 1;
 	name = "\improper Entrance Zone Armoury";
-	req_access = list(access_securitylvl2);
+	req_access = list("ACCESS_SECURITY_LEVEL2");
 	secured_wires = 1
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -6831,7 +6831,7 @@
 "tR" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Center";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -6873,7 +6873,7 @@
 "tZ" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Center";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7075,7 +7075,7 @@
 "uO" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Cargo Center";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/logistics/logistics)
@@ -7312,7 +7312,7 @@
 "vz" = (
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Recovery Ward";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7608,7 +7608,7 @@
 	id_tag = "ezguns";
 	name = "EZ Armory Access button";
 	pixel_x = -23;
-	req_access = list(access_securitylvl4)
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/effect/landmark/start{
 	name = "EZ Agent"
@@ -7640,7 +7640,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical{
 	name = "Corpse Disposal";
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
@@ -7655,7 +7655,7 @@
 /obj/item/reagent_containers/ivbag/amnesticsd,
 /obj/item/reagent_containers/ivbag/amnesticsd,
 /obj/structure/closet/secure_closet/psychiatry{
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/item/storage/pill_bottle/amnesticsb,
 /obj/item/storage/pill_bottle/amnesticsa,
@@ -7757,7 +7757,7 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "ezcell";
 	name = "Holding Cell";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -8019,7 +8019,7 @@
 "Dg" = (
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Staff Area";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8080,7 +8080,7 @@
 /area/site53/maintenance/surfaceeast)
 "Ed" = (
 /obj/machinery/door/window/brigdoor/northright{
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/table/standard,
 /obj/structure/window/reinforced{
@@ -8113,7 +8113,7 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "ezcell3";
 	name = "Holding Cell 3";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -8157,7 +8157,7 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "ezcell2";
 	name = "Holding Cell 2";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -8367,7 +8367,7 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Forensics Laboratory";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8463,7 +8463,7 @@
 /obj/item/clothing/accessory/stethoscope,
 /obj/item/clothing/suit/armor/pcarrier/light,
 /obj/structure/closet/secure_closet/paramedic{
-	req_access = list(access_medicallvl2)
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
 /obj/machinery/light,
 /obj/item/storage/firstaid/adv,
@@ -8528,7 +8528,7 @@
 "Lb" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Helipad";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable{
@@ -8729,7 +8729,7 @@
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
 /obj/machinery/door/window/brigdoor/northleft{
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/logistics/logistics)
@@ -8972,7 +8972,7 @@
 "Si" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Helipad";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -9228,7 +9228,7 @@
 	dir = 8;
 	icon_state = "closed";
 	name = "Guard Hallway";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -9294,7 +9294,7 @@
 "VK" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Equipment Room";
-	req_access = list(access_medicallvl1)
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9311,7 +9311,7 @@
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "ezcell1";
 	name = "Holding Cell 1";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -9358,7 +9358,7 @@
 	dir = 4;
 	icon_state = "closed";
 	name = "Virology";
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9428,7 +9428,7 @@
 /obj/machinery/door/airlock/glass/virology{
 	id_tag = "virocell2";
 	name = "Virology Isolation Cell 2";
-	req_access = list(access_medicallvl4)
+	req_access = list("ACCESS_MEDICAL_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/virology)

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -96,7 +96,7 @@
 "aq" = (
 /obj/machinery/door/airlock/command{
 	name = "Main Control Room";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroom)
@@ -219,7 +219,7 @@
 "aG" = (
 /obj/machinery/computer/shuttle_control{
 	name = "Heavy Containment Zone";
-	req_access = list(access_adminlvl2);
+	req_access = list("ACCESS_ADMIN_LEVEL2");
 	shuttle_tag = "Heavy Containment Tram"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -227,14 +227,14 @@
 "aH" = (
 /obj/machinery/computer/shuttle_control{
 	name = "Light Containment Tram control console";
-	req_access = list(access_adminlvl2);
+	req_access = list("ACCESS_ADMIN_LEVEL2");
 	shuttle_tag = "Light Containment Tram"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroom)
 "aI" = (
 /obj/machinery/computer/shuttle_control/engineering{
-	req_access = list(access_adminlvl2)
+	req_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroom)
@@ -283,7 +283,7 @@
 /area/site53/uez/bridge)
 "aP" = (
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(access_adminlvl4)
+	req_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /obj/machinery/door/blast/regular{
 	id_tag = "sitedirect"
@@ -302,7 +302,7 @@
 "aS" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "Tram Control Room";
-	req_access = list(access_adminlvl2)
+	req_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroom)
@@ -431,7 +431,7 @@
 "bm" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "Main Control Room";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -528,7 +528,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -561,7 +561,7 @@
 "bB" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Maintenance";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -589,7 +589,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Maintenance";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
@@ -629,7 +629,7 @@
 /area/site53/uez/hallway)
 "bM" = (
 /obj/structure/closet/crate/secure/biohazard{
-	req_access = list(access_sciencelvl1)
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
@@ -669,7 +669,7 @@
 /area/site53/uez/hallway)
 "bV" = (
 /obj/structure/closet/secure_closet/hop{
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/hallway)
@@ -717,7 +717,7 @@
 "ce" = (
 /obj/machinery/keycard_auth{
 	pixel_y = 28;
-	req_access = list(access_sciencelvl4,access_engineeringlvl4,access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
 	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
@@ -833,7 +833,7 @@
 /area/site53/uez/hallway)
 "cy" = (
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/machinery/door/blast/regular{
 	id_tag = "sitedirect"
@@ -854,13 +854,13 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Upper Entrance Zone Substation";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/substation)
 "cB" = (
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/machinery/door/blast/regular/open{
 	id_tag = "sitedirect"
@@ -970,7 +970,7 @@
 "cS" = (
 /obj/machinery/door/airlock/command{
 	name = "Site Director's Office";
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/machinery/door/blast/regular/open{
 	id_tag = "sitedirect"
@@ -999,7 +999,7 @@
 	id_tag = "sitedirect"
 	},
 /obj/machinery/door/airlock/highsecurity{
-	req_access = list(access_adminlvl4)
+	req_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
@@ -1009,7 +1009,7 @@
 	icon_state = "tube1"
 	},
 /obj/machinery/door/window/holowindoor{
-	req_access = list(access_adminlvl5)
+	req_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/hallway)
@@ -1097,7 +1097,7 @@
 "dl" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -28;
-	req_access = list(access_sciencelvl4,access_engineeringlvl4,access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
 	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
@@ -1170,7 +1170,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "MCR Substation";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -1319,7 +1319,7 @@
 	dir = 8;
 	icon_state = "closed";
 	name = "Research Director";
-	req_access = list(access_sciencelvl5)
+	req_access = list("ACCESS_SCIENCE_LEVEL5")
 	},
 /obj/machinery/door/blast/regular/open{
 	id_tag = "sitedirect"
@@ -1329,7 +1329,7 @@
 "dU" = (
 /obj/machinery/door/airlock/command{
 	name = "Security Commander's Office";
-	req_access = list(access_securitylvl5)
+	req_access = list("ACCESS_SECURITY_LEVEL5")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/hallway)
@@ -1339,7 +1339,7 @@
 "dX" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "Chief Medical Officer";
-	req_access = list(access_medicallvl5)
+	req_access = list("ACCESS_MEDICAL_LEVEL5")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/hallway)
@@ -1360,7 +1360,7 @@
 "eb" = (
 /obj/machinery/door/airlock/multi_tile/glass/command{
 	name = "Admin Canteen";
-	req_access = list(access_adminlvl2)
+	req_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1372,7 +1372,7 @@
 "ec" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "Chief Engineer";
-	req_access = list(access_engineeringlvl5)
+	req_access = list("ACCESS_ENGINEERING_LEVEL5")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/hallway)
@@ -1526,7 +1526,7 @@
 "ey" = (
 /obj/machinery/door/airlock/multi_tile/glass/command{
 	name = "Admin Canteen";
-	req_access = list(access_adminlvl2)
+	req_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
@@ -1766,7 +1766,7 @@
 "fk" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 28;
-	req_access = list(access_sciencelvl4,access_engineeringlvl4,access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
 	},
 /turf/simulated/floor/carpet/red,
 /area/site53/uez/hallway)
@@ -1811,7 +1811,7 @@
 	},
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Upper Entrance Zone Substation";
-	req_access = list(access_engineeringlvl1)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/substation)
@@ -1935,7 +1935,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -2297,7 +2297,7 @@
 "gB" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -28;
-	req_access = list(access_sciencelvl4,access_engineeringlvl4,access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
 	},
 /turf/simulated/floor/carpet/green,
 /area/site53/uez/hallway)
@@ -2315,7 +2315,7 @@
 "gF" = (
 /obj/machinery/keycard_auth{
 	pixel_y = -28;
-	req_access = list(access_sciencelvl4,access_engineeringlvl4,access_sciencelvl3)
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/uez/hallway)
@@ -2413,7 +2413,7 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "secure evidence locker";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
@@ -2642,7 +2642,7 @@
 "im" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Break Room";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2654,7 +2654,7 @@
 "in" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Break Room";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
@@ -2681,7 +2681,7 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24;
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 1
@@ -2734,7 +2734,7 @@
 "iA" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "Logistics Officer";
-	req_access = list(access_adminlvl2)
+	req_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -3002,7 +3002,7 @@
 "jr" = (
 /obj/machinery/computer/shuttle_control{
 	name = "Heavy Containment Zone";
-	req_access = list(access_engineeringlvl3);
+	req_access = list("ACCESS_ENGINEERING_LEVEL3");
 	shuttle_tag = "Heavy Containment Tram"
 	},
 /obj/effect/floor_decal/corner/red/mono,
@@ -3010,7 +3010,7 @@
 /area/site53/upper_surface/commstower)
 "js" = (
 /obj/machinery/computer/shuttle_control/engineering{
-	req_access = list(access_engineeringlvl3)
+	req_access = list("ACCESS_ENGINEERING_LEVEL3")
 	},
 /obj/effect/floor_decal/corner/orange/mono,
 /turf/simulated/floor/tiled/monotile/white,
@@ -3431,7 +3431,7 @@
 "kR" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Maintenance";
-	req_access = list(access_engineeringlvl1,access_adminlvl4)
+	req_access = list("ACCESS_ENGINEERING_LEVEL1","ACCESS_ADMIN_LEVEL4")
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -3500,14 +3500,14 @@
 	id_tag = "dchecknorth";
 	name = "North CDZ Blastdoors";
 	pixel_x = -6;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/button/blast_door{
 	dir = 4;
 	id_tag = "dchecksouth";
 	name = "South CDZ Blastdoors";
 	pixel_x = 4;
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
@@ -3717,7 +3717,7 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "secure evidence locker";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
@@ -3780,7 +3780,7 @@
 /obj/machinery/button/blast_door{
 	id_tag = "controlroom";
 	name = "Control Room Lockdown button";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/item/crowbar/emergency_forcing_tool,
 /turf/simulated/floor/tiled/monotile,
@@ -3966,7 +3966,7 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "secure evidence locker";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
@@ -3998,7 +3998,7 @@
 	dir = 4;
 	id_tag = "controlroom";
 	name = "Control Room Lockdown button";
-	req_access = list(access_adminlvl1)
+	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
@@ -4046,7 +4046,7 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "secure evidence locker";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
@@ -4065,7 +4065,7 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "secure evidence locker";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
@@ -4115,7 +4115,7 @@
 	anchored = 0;
 	id_tag = "facilitylockdown";
 	name = "Facility Lockdown button";
-	req_access = list(access_adminlvl4)
+	req_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroom)
@@ -4289,7 +4289,7 @@
 "Ny" = (
 /obj/machinery/computer/shuttle_control{
 	name = "Light Containment Tram control console";
-	req_access = list(access_engineeringlvl3);
+	req_access = list("ACCESS_ENGINEERING_LEVEL3");
 	shuttle_tag = "Light Containment Tram"
 	},
 /obj/effect/floor_decal/corner/brown/mono,
@@ -4357,14 +4357,14 @@
 	id_tag = "hczeast";
 	name = "East HCZ Entry Blast Doors";
 	pixel_x = 4;
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/machinery/button/blast_door{
 	dir = 4;
 	id_tag = "hczwest";
 	name = "West HCZ Entry Blast Doors";
 	pixel_x = -6;
-	req_access = list(access_securitylvl3)
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
@@ -4443,7 +4443,7 @@
 	dir = 4;
 	id_tag = "facilitylockdown";
 	name = "Facility Lockdown button";
-	req_access = list(access_adminlvl4)
+	req_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /obj/structure/window/basic/full{
 	anchored = 0;
@@ -4499,7 +4499,7 @@
 "Ts" = (
 /obj/machinery/door/airlock/command{
 	name = "Communications Tower";
-	req_access = list(access_adminlvl2)
+	req_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
@@ -4512,7 +4512,7 @@
 	},
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
@@ -4611,7 +4611,7 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "secure evidence locker";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)

--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -136,7 +136,7 @@
 "bU" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Holding Cell";
-	req_access = list(access_securitylvl2)
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -174,7 +174,7 @@
 /area/site53/tram/mtf)
 "cl" = (
 /obj/machinery/door/airlock/vault{
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -428,7 +428,7 @@
 "eG" = (
 /obj/machinery/door/airlock/vault{
 	name = "Mobile Task Force Garage";
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -1667,7 +1667,7 @@
 "jz" = (
 /obj/machinery/door/airlock/vault{
 	name = "Beta-7";
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -1728,7 +1728,7 @@
 "jL" = (
 /obj/machinery/door/airlock/security{
 	name = "Holding Cells";
-	req_access = list(access_securitylvl1)
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -2915,7 +2915,7 @@
 "oQ" = (
 /obj/machinery/door/airlock/vault{
 	name = "Eta-10";
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -2990,7 +2990,7 @@
 	},
 /obj/machinery/vending/security{
 	dir = 1;
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3005,7 +3005,7 @@
 "po" = (
 /obj/machinery/door/airlock/vault{
 	name = "Omega-1";
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3127,7 +3127,7 @@
 "qh" = (
 /obj/machinery/door/airlock/vault{
 	name = "Alpha-1";
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3363,7 +3363,7 @@
 	},
 /obj/machinery/vending/security{
 	dir = 4;
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3708,7 +3708,7 @@
 	icon_state = "corner_white"
 	},
 /obj/machinery/vending/security{
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3747,7 +3747,7 @@
 "yE" = (
 /obj/machinery/door/airlock/vault{
 	name = "Epislon-9";
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3780,7 +3780,7 @@
 	},
 /obj/machinery/vending/security{
 	dir = 4;
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3800,7 +3800,7 @@
 "yS" = (
 /obj/machinery/door/airlock/vault{
 	name = "Epislon-11";
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -3865,7 +3865,7 @@
 	dir = 9
 	},
 /obj/structure/closet/crate/secure/biohazard{
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -4032,7 +4032,7 @@
 	},
 /obj/machinery/vending/security{
 	dir = 4;
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -4062,7 +4062,7 @@
 	dir = 5
 	},
 /obj/machinery/vending/security{
-	req_access = list(access_mtf)
+	req_access = list("ACCESS_MTF")
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -4489,7 +4489,7 @@
 "ZY" = (
 /obj/machinery/computer/shuttle_control{
 	name = "MTF Helicopter";
-	req_access = list(access_medicallvl2,access_sciencelvl2);
+	req_access = list("ACCESS_MEDICAL_LEVEL2","ACCESS_SCIENCE_LEVEL2");
 	shuttle_tag = "MTF Helicopter"
 	},
 /turf/simulated/floor/shuttle/black,


### PR DESCRIPTION
## About the Pull Request

- `access_science_lvl1 => "ACCESS_SCIENCE_LEVEL1"`

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Diffbot working is nice

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
code: turned access vars into strings because diffbot was whining
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
