### PR TITLE
Tinkers CDZ medical, adds 2 floodlights for LCZ guards

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -376,6 +376,16 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/scp106parts)
+"be" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/structure/hygiene/sink{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/llcz/dclass/medicalpost)
 "bf" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -387,6 +397,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
+"bg" = (
+/obj/machinery/floodlight,
+/turf/simulated/floor,
+/area/site53/llcz/dclass/cellbubble)
 "bh" = (
 /obj/structure/barricade,
 /turf/simulated/floor/exoplanet/desert,
@@ -3190,9 +3204,7 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/assignmentbubble)
 "iN" = (
-/obj/structure/closet{
-	name = "D-Class Storage"
-	},
+/obj/structure/bed/chair/wheelchair,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "iO" = (
@@ -3459,6 +3471,7 @@
 /obj/machinery/camera/network/lcz{
 	dir = 1
 	},
+/obj/machinery/floodlight,
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cellbubble)
 "jy" = (
@@ -7781,15 +7794,27 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkpointoverlook)
 "tC" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/structure/hygiene/sink{
-	pixel_y = -23
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 7
-	},
+/obj/structure/closet,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "tD" = (
@@ -9031,9 +9056,6 @@
 "wt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "ww" = (
@@ -9750,13 +9772,13 @@
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/luxuryhall)
 "yp" = (
-/obj/machinery/camera/network/lcz{
-	dir = 4
-	},
-/obj/machinery/vitals_monitor,
-/obj/machinery/light,
+/obj/machinery/optable,
+/obj/item/clothing/suit/surgicalapron,
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 9
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/llcz/dclass/medicalpost)
@@ -10499,10 +10521,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp1102room)
 "As" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
+/obj/effect/paint_stripe/blue,
+/obj/structure/hygiene/sink{
+	pixel_y = -23
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/medicalpost)
 "At" = (
 /obj/structure/table/standard,
@@ -10797,8 +10820,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "Bj" = (
-/obj/machinery/light,
-/obj/structure/bed/chair/wheelchair,
+/obj/machinery/body_scanconsole{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 7
 	},
@@ -11082,7 +11106,9 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/llcz/dclass/medicalpost)
 "BX" = (
-/obj/structure/bed/chair/wheelchair,
+/obj/machinery/bodyscanner{
+	dir = 4
+	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 7
 	},
@@ -11579,9 +11605,8 @@
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
 "Do" = (
-/obj/structure/bed/chair/wheelchair,
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 10
+	dir = 7
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
@@ -11786,6 +11811,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
+"DL" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/medicalpost)
 "DM" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled,
@@ -12313,16 +12344,15 @@
 /turf/simulated/floor,
 /area/site53/llcz/dclass/luxurysleep)
 "Fe" = (
-/obj/machinery/optable,
-/obj/item/clothing/suit/surgicalapron,
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 1
+	dir = 9
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/structure/iv_drip,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "Ff" = (
 /obj/machinery/door/airlock/glass/medical{
-	name = "D-Class Confiscated Items";
+	name = "Medical Storage";
 	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -13309,22 +13339,18 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/window/southleft{
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "Ip" = (
-/obj/structure/hygiene/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
+/obj/structure/iv_drip,
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/llcz/dclass/medicalpost)
 "Iq" = (
@@ -13629,12 +13655,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/entrance_checkpoint)
 "IW" = (
-/obj/machinery/door/window/southleft{
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 6
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
@@ -15100,6 +15126,13 @@
 /obj/structure/closet/secure_closet/mtf/riotgear,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip)
+"Ov" = (
+/obj/machinery/vitals_monitor,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/llcz/dclass/medicalpost)
 "Ox" = (
 /obj/effect/floor_decal/industrial/firstaid{
 	dir = 8
@@ -15669,6 +15702,10 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/lhcz/scp049containment)
+"Rf" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/medicalpost)
 "Rh" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/railing/mapped,
@@ -16280,11 +16317,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/luxuryhall)
 "Um" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "Uo" = (
@@ -16584,6 +16621,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
+"VH" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/medicalpost)
 "VI" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/leafybush,
@@ -16938,12 +16980,28 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/scp8containment)
+"Xm" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/structure/iv_drip,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/medicalpost)
 "Xs" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/luxuryhall)
+"Xt" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/machinery/camera/network/lcz{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/llcz/dclass/medicalpost)
 "Xz" = (
 /obj/machinery/camera/network/lcz{
 	dir = 1
@@ -21518,16 +21576,16 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+ie
+ie
+ie
+ie
+ie
+ie
+ie
+ie
+ie
+ie
 kg
 kg
 kg
@@ -21776,15 +21834,15 @@ gq
 gq
 gq
 ie
+Ov
+Ip
+Xt
+Hh
 ie
-ie
-ie
-ie
-ie
-ie
-ie
-ie
-ie
+uD
+bk
+CR
+JX
 kg
 qR
 xK
@@ -22034,14 +22092,14 @@ gq
 gq
 ie
 yp
-Ip
-As
-Hh
+Bh
+Bh
+sR
 ie
-uD
-bk
-CR
-JX
+bM
+Bh
+Bh
+Kd
 kg
 xP
 xL
@@ -22290,15 +22348,15 @@ gq
 gq
 gq
 ie
-Fe
+rq
 Bh
 Bh
-sR
+Ah
 ie
-bM
+RJ
 Bh
 Bh
-Kd
+Ke
 kg
 xD
 xL
@@ -22547,15 +22605,15 @@ gq
 gq
 gq
 ie
-rq
+be
 Bh
 Bh
-Ah
+vq
 ie
-RJ
+Ae
 Bh
-Bh
-Ke
+JW
+Kg
 kg
 kg
 xM
@@ -22807,12 +22865,12 @@ ie
 rq
 Bh
 Bh
-vq
+Ah
 ie
-Ae
+CV
 Bh
-JW
-Kg
+Bh
+Kh
 kg
 kb
 bL
@@ -23061,15 +23119,15 @@ YX
 YX
 YX
 ie
-rq
+BW
 Bh
 Bh
-Ah
+sR
 ie
-CV
+jW
 Bh
 Bh
-Kh
+CW
 kg
 kb
 bL
@@ -23318,15 +23376,15 @@ IK
 IN
 YX
 ie
-BW
-Bh
-Bh
-sR
+TT
+iO
+vu
+tP
 ie
-jW
+CP
 Bh
-Bh
-CW
+NY
+Ew
 kg
 TI
 zE
@@ -23575,15 +23633,15 @@ QZ
 IO
 YX
 ie
-TT
-iO
-vu
-tP
 ie
-CP
-Bh
-NY
-Ew
+ie
+vB
+ie
+ie
+CO
+vu
+RQ
+rg
 kg
 kb
 hE
@@ -23832,15 +23890,15 @@ IL
 IP
 YX
 ie
+Fe
+Xm
+YC
+tE
+ie
+ze
+CT
 ie
 ie
-vB
-ie
-ie
-CO
-vu
-RQ
-rg
 kg
 kb
 Fi
@@ -24091,13 +24149,13 @@ YX
 ie
 Um
 wt
+rI
+yh
+za
 YC
 tE
 ie
-ze
-CT
-ie
-ie
+zp
 zp
 zp
 zp
@@ -24349,9 +24407,9 @@ ie
 tG
 vc
 rI
-yh
-za
-YC
+rI
+rI
+rI
 Do
 ie
 zp
@@ -24607,7 +24665,7 @@ vf
 Le
 rI
 Wv
-Wv
+rI
 rI
 Bj
 ie
@@ -24864,7 +24922,7 @@ tG
 vc
 rI
 tT
-tT
+rI
 rI
 BX
 ie
@@ -25123,7 +25181,7 @@ LD
 rI
 rI
 XA
-tC
+Do
 ie
 zp
 xX
@@ -27683,7 +27741,7 @@ cc
 cQ
 ie
 iN
-rI
+Rf
 ie
 ie
 ie
@@ -28453,8 +28511,8 @@ rV
 cc
 cQ
 ie
-iN
-rI
+DL
+Rf
 ie
 dA
 rI
@@ -28709,8 +28767,8 @@ cc
 fC
 cc
 cQ
-ie
-iN
+As
+rI
 rI
 ie
 wF
@@ -28967,8 +29025,8 @@ cQ
 cQ
 cQ
 ie
-iN
-rI
+VH
+tC
 ie
 wF
 em
@@ -31551,7 +31609,7 @@ tS
 sf
 rR
 nF
-nF
+bg
 jx
 cY
 EO


### PR DESCRIPTION
## About the Pull Request

Moved surgery sink to the middle, gave a iv to the other surgery table. Gave two new ivs to medical beds that were missing them. Spaced body-scanners so they're easier to access. Replaced "Confiscated D-Class Items" with another medical storage room. Moved wheelchairs and janitorial supplies to new storage room. Put a backup surgery kit in new storage room. Locker filled with replacement uniforms/shoes for class-d's now in back storage room. Replaced the weak windoors with secure(reinforced) ones since the other three were already reinforced but the two top ones were not.

Gave LCZ guards two emergency floodlights for when riots happen/some jackass breaks all the lights (hopefully this'll help)


## Why It's Good For The Game

CDZ Medbay scanners needed spaced, people complained. The un-reinforced medical windoors often got broken by rioting d-class, the other three bottom windoors were already reinforced so why weren't the top? D-Class confiscated items room was sadly never used, replacing it as storage is probably for the best.

CDZ usually is pitch-black maybe into the 40 or 50 minute mark due to class-d's, two emergency floodlights might help guards in controlling a riot.
## Changelog

:cl:
add: Reinforced windoors in replacement of the two weak ones.
add: Space between the two cdz body scanners.
add: Gave LCZ two floodlights for emergency usage. 
del: Removes D-Class confiscated items because it wasn't ever used.
add: New closet-type of storage in replacement of D-Class confiscated items (may you rest in peace)
/:cl:
