### PR TITLE
Fix dropping code and SCP-113

### DIFF
--- a/code/modules/SCP/SCPs/SCP-113.dm
+++ b/code/modules/SCP/SCPs/SCP-113.dm
@@ -8,39 +8,32 @@
 	throw_speed = 3
 //	candrop = 0
 	SCP = /datum/scp/scp_113
+	var/list/victims = list()
 
 /datum/scp/scp_113
 	name = "SCP-113"
 	designation = "113"
 	classification = SAFE
-	component = /datum/component/scp/scp_113
 
 /datum/scp/scp_113/isCompatible(atom/A)
 	if(isitem(A))
 		return 1
 
-/datum/component/scp/scp_113
-	signal_procs = list(COMSIG_PICKUP = .proc/pickup)
-	var/list/victims = list()
-
-/datum/component/scp/scp_113/proc/pickup(mob/living/user)
+/obj/item/device/scp113/pickup(mob/living/user)
 	if(!isliving(user))
-		return 1
-	if(!isitem(owner))
-		return
+		return ..()
 
 	var/mob/living/carbon/human/H = user
 	if(istype(H) && H.gloves)
-		return
-
-	var/obj/item/I = owner
-//	I.candrop = 0 //reset candrop for new pickup
+		return ..()
+	
+	canremove = 0 //reset candrop for new pickup
 
 	var/which_hand = BP_L_HAND //determine hand to burn
 	if(!user.hand)
 		which_hand = BP_R_HAND
 
-	to_chat(user, "<span class='warning'>The [I.name] begins to sear your hand, burning the skin on contact, and you feel yourself unable to drop it.</span>")
+	to_chat(user, "<span class='warning'>The [src] begins to sear your hand, burning the skin on contact, and you feel yourself unable to drop it.</span>")
 	var/damage_coeff = 1
 	if(user in victims)
 		damage_coeff = Clamp((5000-(world.time - victims[user]))/1000,1,5)
@@ -74,7 +67,7 @@
 		H.update_dna()
 		H.update_body()
 	spawn(350)
-		to_chat(user, "<span class='warning'>The burning begins to fade, and you feel your hand relax it's grip on the [I.name].</span>")
+		to_chat(user, "<span class='warning'>The burning begins to fade, and you feel your hand relax it's grip on the [src].</span>")
 	spawn(360)
-//		I.candrop = 1 //transformation finished, you can let go now
+		canremove = 1 //transformation finished, you can let go now
 		victims[user] = world.time

--- a/code/modules/SCP/SCPs/SCP-113.dm
+++ b/code/modules/SCP/SCPs/SCP-113.dm
@@ -1,12 +1,12 @@
 /obj/item/device/scp113
+	name = "SCP-113"
 	desc = "The red piece of quartz gleams with unnatural smoothness."
 	icon_state = "scp113"
 	force = 10.0
-	w_class = ITEM_SIZE_HUGE //temporary workaround until I can fix the nodrop code to include noplace in bags/tables
+	w_class = ITEM_SIZE_HUGE // temporary workaround until I can fix the nodrop code to include noplace in bags/tables
 	throwforce = 10.0
 	throw_range = 15
 	throw_speed = 3
-//	candrop = 0
 	SCP = /datum/scp/scp_113
 	var/list/victims = list()
 
@@ -27,13 +27,13 @@
 	if(istype(H) && H.gloves)
 		return ..()
 	
-	canremove = 0 //reset candrop for new pickup
+	canremove = 0 // reset canremove for new pickup
 
-	var/which_hand = BP_L_HAND //determine hand to burn
+	var/which_hand = BP_L_HAND // determine hand to burn
 	if(!user.hand)
 		which_hand = BP_R_HAND
 
-	to_chat(user, "<span class='warning'>The [src] begins to sear your hand, burning the skin on contact, and you feel yourself unable to drop it.</span>")
+	to_chat(user, "<span class='warning'>The [name] begins to sear your hand, burning the skin on contact, and you feel yourself unable to drop it.</span>")
 	var/damage_coeff = 1
 	if(user in victims)
 		damage_coeff = Clamp((5000-(world.time - victims[user]))/1000,1,5)
@@ -67,7 +67,7 @@
 		H.update_dna()
 		H.update_body()
 	spawn(350)
-		to_chat(user, "<span class='warning'>The burning begins to fade, and you feel your hand relax it's grip on the [src].</span>")
+		to_chat(user, "<span class='warning'>The burning begins to fade, and you feel your hand relax it's grip on the [name].</span>")
 	spawn(360)
 		canremove = 1 //transformation finished, you can let go now
 		victims[user] = world.time

--- a/code/modules/keybindings/living.dm
+++ b/code/modules/keybindings/living.dm
@@ -34,7 +34,12 @@
 
 /datum/keybinding/living/drop_item/down(client/user)
 	var/mob/living/L = user.mob
-	L.drop_item()
+	var/obj/item/hand = L.get_active_hand()
+	if(!hand)
+		to_chat(L, "<span class='warning'>You have nothing to drop in your hand.</span>")
+	else if(hand.can_be_dropped_by_client(L))
+		L.drop_item()
+
 	return TRUE
 
 /datum/keybinding/living/aim_mode


### PR DESCRIPTION
## About the Pull Request

Makes drop keybind actually respect whether or not an item is undroppable, and brings back the old "You have nothing to drop in your hand." text that used to be there before bay added a shitty keybind system

Tested and working
If you pick up SCP-113 more than once after the initial time it changes your gender, the burn damage is so severe it will instantly melt a hand off. This means it doesn't actually pick up and you can melt the other hand doing the same thing. Maybe add another variable that gets set to 1 while someone is using 113 meaning it can't be picked up even if it's on the ground? 

## Why It's Good For The Game

Makes SCP-113 actually work and undroppable items able to be added again

## Changelog

:cl:
fix: SCP-113 now actually works and is named correctly
fix: "You have nothing to drop in your hand" text returns, along with dropping respecting undroppable items
/:cl:
