### PR TITLE
Fix FBPs speaking no languages

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -144,6 +144,11 @@
 			H.set_species(species)
 			H.fully_replace_character_name(name)
 
+			// Add languages to human. MMI's can understand robot talk, so should FBP.
+			H.add_language(LANGUAGE_ENGLISH)
+			H.add_language(LANGUAGE_ROBOT_GLOBAL)
+			H.add_language(LANGUAGE_EAL)
+
 			// Remove all external organs other than chest and head..
 			for (var/O in list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG))
 				var/obj/item/organ/external/organ = H.organs_by_name[O]


### PR DESCRIPTION
## About the Pull Request

FBPs, on creation, currently speak no languages. This means admin intervention is usually required for an FBP to be able to do Fucking Anything because they can't talk or understand anyone. This gives FBPs English, EAL, and robot talk, just like MMI's.

Tested and working.

## Why It's Good For The Game

FBP's can talk.

## Changelog

:cl:
fix: Allows FBPs to speak English, Encoded Audio Language, and Robot Talk.
/:cl: