### PR TITLE
Adds implant pad to designs

### DIFF
--- a/code/modules/research/designs/designs_implant.dm
+++ b/code/modules/research/designs/designs_implant.dm
@@ -53,3 +53,10 @@
 	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3, TECH_ESOTERIC = 4)
 	build_path = /obj/item/implantcase/explosive
 	sort_string = "MFAAG"
+
+/datum/design/item/implant/pad
+	name = "control pad"
+	id = "implant_pad"
+	req_tech = list(TECH_MATERIAL = 2, TECH_BIO = 3)
+	build_path = /obj/item/implantpad
+	sort_string = "MFAAH"


### PR DESCRIPTION
## About the Pull Request

Have YOU ever wanted to remake MK Ultra? Haven't been able to edit the directives on your IMPRINTING IMPLANT without being an ANTAG (disabled) and buying a IMPLANT PAD with TELECRYSTALS? Don't have the resources to use a SS13 cheat to do an href exploit on the implant to add directives? Luckily for you, you can now print it from the protolathe!

Tested and working.

## Why It's Good For The Game

You can actually edit implants without being an antag. It was impossible to edit literally any implant's shit without being an antag and getting the pad before. Don't see why this should be an antag-only item. The imprinting implant is legitimately pointless without this pad.

## Changelog

:cl:
add: The implant control pad can now be printed from the protolathe. This lets you add directives to the imprinting implant and edit the ID of the tracking implant.
/:cl:
