### PR TITLE
MTF Fixes and Edits

### DIFF
--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(ert, /datum/antagonist/ert, new)
 		rules aside from those without explicit exceptions apply to the MTF.</b>"
 	leader_welcome_text = "You shouldn't see this"
 	landmark_id = "Response Team"
-	id_type = /obj/item/card/id/centcom/ERT
+	id_type = /obj/item/card/id/mtf
 
 	flags = ANTAG_OVERRIDE_JOB | ANTAG_HAS_LEADER | ANTAG_CHOOSE_NAME | ANTAG_RANDOM_EXCEPTED
 	antaghud_indicator = "hudloyalist"

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -202,3 +202,33 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	)
 
 	minimal_access = list()
+
+/datum/job/mtf
+	title = "Mobile Task Force Operative"
+	department = "Regional Dispatch"
+	department_flag = COM
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "O5 Regional Dispatch and O5 Command"
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/command/event/mtfbasic
+	hud_icon = "hudseniorenlistedadvisor"
+	access = list()
+	minimal_access = list()
+
+/datum/job/mtf/get_access()
+	return get_all_station_access()
+
+/datum/job/physics
+	title = "UNGOC Physics Operative"
+	department = "Regional Dispatch"
+	department_flag = COM
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "UNGOC Regional Dispatch and UNGOC Central Command"
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc
+	hud_icon = "hudseniorenlistedadvisor"
+	access = list()
+	minimal_access = list()
+
+/datum/job/physics/get_access()
+	return get_all_station_access()

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -267,14 +267,3 @@ for reference:
 	s.start()
 	visible_message("<span class='warning'>BZZzZZzZZzZT</span>")
 	return TRUE
-
-/obj/structure/lionstatue
-	name = "Lion statue"
-	desc = "A magnificent statue of a Lion. It looks proud."
-	icon = 'icons/obj/structures.dmi'
-	icon_state = "lion"
-	anchored = TRUE
-	density = TRUE
-	var/health = 99999
-	var/maxhealth = 99999
-	var/material/material

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -280,13 +280,13 @@
 
 /obj/item/ammo_magazine/box/machinegun
 	name = "magazine box"
-	icon_state = "machinegun"
+	icon_state = "usmc_box"
 	origin_tech = list(TECH_COMBAT = 2)
 	mag_type = MAGAZINE
 	caliber = CALIBER_RIFLE
 	matter = list(MATERIAL_STEEL = 4500)
 	ammo_type = /obj/item/ammo_casing/rifle
-	max_ammo = 80
+	max_ammo = 100
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/box/machinegun/empty

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -394,7 +394,7 @@
 
 /obj/item/gun/projectile/automatic/t12
 	name = "T12 rifle"
-	desc = "An assault rifle produced and used by TerraGov military. Highly lethal and capable of holding up to 50 rounds in its standard magazines."
+	desc = "An assault rifle produced and used by the Global Occult Coalition, rarely seen loaned to high-intensity Foundation units. Highly lethal and capable of holding up to 50 rounds in its standard magazines."
 	icon = 'icons/obj/guns/t12.dmi'
 	icon_state = "t12"
 	item_state = "t12"

--- a/maps/site53/items/cards_ids.dm
+++ b/maps/site53/items/cards_ids.dm
@@ -420,6 +420,22 @@
 	item_state = "Admin_ID"
 	job_access_type = /datum/job/captain
 
+// ERT CARDS
+
+/obj/item/card/id/mtf
+	name = " mobile task force ID"
+	desc = "A black ID. Looks like the person wearing this won't give it up easy."
+	icon_state = "adminlvl5"
+	item_state = "Admin_ID"
+	job_access_type = /datum/job/mtf
+
+/obj/item/card/id/physics
+	name = " military ID"
+	desc = "A dark purple ID. Looks like the person wearing this won't give it up easy."
+	icon_state = "securitylvl5"
+	item_state = "Sec_ID5"
+	job_access_type = /datum/job/physics
+
 // COMMS CARDS
 
 /obj/item/card/id/commslvl1

--- a/maps/site53/items/clothing/platecarriers.dm
+++ b/maps/site53/items/clothing/platecarriers.dm
@@ -5,13 +5,16 @@
 	icon_state = "armor_medium"
 	armor = list(melee = 40, bullet = 80, laser = 40, energy = 25, bomb = 30, bio = 0, rad = 0)
 
-/obj/item/clothing/head/helmet/mtfheavy
+/obj/item/clothing/head/helmet/mtfheavy //BULLDOZER IN THE HOUSE
 	name = "combined heavy assault helmet"
 	desc = "A quad-layered heavy composite helmet with titanium strut supports made solely so it doesn't crush one's heavy with the weight."
 	icon_state = "mtf-heavy-helmet"
-	armor = list(melee = 110, bullet = 110, laser = 90, energy = 90, bomb = 120, bio = 100, rad = 80)
+	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 100, bio = 100, rad = 100)
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	item_flags = ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_PHORONGUARD|ITEM_FLAG_AIRTIGHT
 	item_flags = ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_AIRTIGHT
 	body_parts_covered = HEAD|FACE|EYES
 	siemens_coefficient = 0.5
@@ -21,29 +24,45 @@
 	name = "tactical composite helmet"
 	desc = "An armored composite helmet with night vision goggles attached."
 	icon_state = "mtf-tactical-helmetON"
+	permeability_coefficient = 0
+	gas_transfer_coefficient = 0
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	item_flags = ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_PHORONGUARD|ITEM_FLAG_AIRTIGHT
 	armor = list(melee = 80, bullet = 83, laser = 50,energy = 25, bomb = 50, bio = 100, rad = 60)
 	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	item_flags = ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_AIRTIGHT
 	body_parts_covered = HEAD|FACE|EYES
 
-/obj/item/clothing/suit/armor/mtfheavy
+/obj/item/clothing/suit/armor/mtfheavy //YOU'RE UP AGAINST THE WALL AND *I AM THE FUCKING WALL*
 	name = "combined heavy assault suit"
-	desc = "A multi-layered composite armor suit with ballistic weave underpadding and a kevlar undersuit, fitted with it's own cooling unit. 'Nu-7' is emblazoned on the collar, and 'Hammer Down' is sewed into the back of it."
+	desc = "A multi-layered composite armor suit with ballistic weave underpadding and a kevlar undersuit, fitted with it's own cooling unit and exoskeleton supports. 'Nu-7' is emblazoned on the collar, and 'Hammer Down' is sewed into the back of it."
 	icon_state = "mtf-heavy"
-	item_state = "armor"
+	item_state = "mtf-heavy"
 	permeability_coefficient = 0
 	gas_transfer_coefficient = 0
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	armor = list(melee = 110, bullet = 110, laser = 90, energy = 90, bomb = 120, bio = 100, rad = 80)
+	cold_protection = HEAD
+	item_flags = ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_PHORONGUARD|ITEM_FLAG_AIRTIGHT
+	armor = list(melee = 100, bullet = 100, laser = 100, energy = 100, bomb = 100, bio = 100, rad = 100)
 
 /obj/item/clothing/suit/armor/mtftactical
 	name = "tactical armor suit"
 	desc = "An advanced multi-plated composite vest with kevlar lining and plenty of room to move. 'E-11' is sewn into the left pauldron, and 'Nine Tailed Fox' is sewn into the right."
 	icon_state = "mtf-tactical"
-	item_state = "armor"
+	item_state = "mtf-tactical"
 	permeability_coefficient = 0
+	gas_transfer_coefficient = 0
+	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	item_flags = ITEM_FLAG_THICKMATERIAL|ITEM_FLAG_PHORONGUARD|ITEM_FLAG_AIRTIGHT
 	armor = list(melee = 80, bullet = 85, laser = 65, energy = 15, bomb = 80, bio = 40, rad = 60)
 
 //GOC

--- a/maps/site53/job/jobs/command.dm
+++ b/maps/site53/job/jobs/command.dm
@@ -221,3 +221,33 @@ ut // COMMAND
 	)
 
 	minimal_access = list()
+
+/datum/job/mtf
+	title = "Mobile Task Force Operative"
+	department = "Regional Dispatch"
+	department_flag = COM
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "O5 Regional Dispatch and O5 Command"
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/command/event/mtfbasic
+	hud_icon = "hudseniorenlistedadvisor"
+	access = list()
+	minimal_access = list()
+
+/datum/job/mtf/get_access()
+	return get_all_station_access()
+
+/datum/job/physics
+	title = "UNGOC Physics Operative"
+	department = "Regional Dispatch"
+	department_flag = COM
+	total_positions = 0
+	spawn_positions = 0
+	supervisors = "UNGOC Regional Dispatch and UNGOC Central Command"
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc
+	hud_icon = "hudseniorenlistedadvisor"
+	access = list()
+	minimal_access = list()
+
+/datum/job/physics/get_access()
+	return get_all_station_access()

--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -769,7 +769,7 @@
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/gunner
-	name = OUTFIT_JOB_NAME("UNGOC PHYSICS Machinegunner")
+	name = OUTFIT_JOB_NAME("UNGOC PHYSICS Machinegunner") //I am heavy weapons guy
 	uniform = /obj/item/clothing/under/syndicate/combat
 	suit = /obj/item/clothing/suit/storage/vest
 	head = /obj/item/clothing/head/helmet/merc
@@ -779,14 +779,14 @@
 	shoes = /obj/item/clothing/shoes/combat
 	id_types = list(/obj/item/card/id/physics)
 	suit_store = null
-	r_hand = /obj/item/gun/projectile/automatic/l6_saw
+	r_hand = /obj/item/gun/projectile/automatic/l6_saw //and THIS... is my weapon
 	l_hand = null
 	l_pocket = /obj/item/grenade/frag
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
 	back = /obj/item/storage/backpack/rucksack
-	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/box/a556 = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
+	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1, /obj/item/ammo_magazine/box/machinegun = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/grenadier
 	name = OUTFIT_JOB_NAME("UNGOC PHYSICS Grenadier")

--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -538,6 +538,16 @@
 	l_ear = /obj/item/device/radio/headset/headset_cargo
 	back = /obj/item/storage/backpack/satchel/pocketbook
 
+/decl/hierarchy/outfit/job/site90/crew/command/event/mtfbasic
+	name = OUTFIT_JOB_NAME("MTF Epsilon-11 Agent")
+	uniform = /obj/item/clothing/under/ert
+	suit = /obj/item/clothing/suit/armor/mtftactical
+	head = /obj/item/clothing/head/helmet/mtftactical
+	gloves = /obj/item/clothing/gloves/thick/swat
+	shoes = /obj/item/clothing/shoes/swat
+	id_types = list(/obj/item/card/id/mtf)
+	l_ear = /obj/item/device/radio/headset/ert
+
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtf_epsilon1
 	name = OUTFIT_JOB_NAME("MTF Epsilon-6 Agent Alpha")
 	uniform = /obj/item/clothing/under/frontier
@@ -547,7 +557,7 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
 	shoes = /obj/item/clothing/shoes/jackboots
-	id_types = list(/obj/item/card/id/adminlvl5)
+	id_types = list(/obj/item/card/id/mtf)
 	suit_store = /obj/item/gun/projectile/automatic/scp/p90
 	r_hand = /obj/item/crowbar/red
 	l_hand = /obj/item/material/hatchet/tacknife
@@ -567,7 +577,7 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
 	shoes = /obj/item/clothing/shoes/jackboots
-	id_types = list(/obj/item/card/id/adminlvl5)
+	id_types = list(/obj/item/card/id/mtf)
 	suit_store = /obj/item/gun/projectile/shotgun/pump/combat
 	r_hand = /obj/item/crowbar/red
 	l_hand = /obj/item/material/hatchet
@@ -587,7 +597,7 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
 	shoes = /obj/item/clothing/shoes/jackboots
-	id_types = list(/obj/item/card/id/adminlvl5)
+	id_types = list(/obj/item/card/id/mtf)
 	suit_store = /obj/item/gun/projectile/automatic/scp/m16
 	r_hand = /obj/item/storage/box/syndie_kit/spy
 	l_hand = null
@@ -607,7 +617,7 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
 	shoes = /obj/item/clothing/shoes/jackboots
-	id_types = list(/obj/item/card/id/adminlvl5)
+	id_types = list(/obj/item/card/id/mtf)
 	suit_store = /obj/item/gun/projectile/automatic/scp/p90
 	r_hand = /obj/item/storage/firstaid/surgery
 	l_hand = /obj/item/crowbar/red
@@ -627,7 +637,7 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
 	shoes = /obj/item/clothing/shoes/jackboots
-	id_types = list(/obj/item/card/id/adminlvl5)
+	id_types = list(/obj/item/card/id/mtf)
 	suit_store = /obj/item/gun/projectile/automatic/scp/p90
 	r_hand = /obj/item/crowbar/red
 	l_hand = /obj/item/material/hatchet/tacknife
@@ -647,7 +657,7 @@
 	glasses = /obj/item/clothing/glasses/sunglasses
 	gloves = /obj/item/clothing/gloves/tactical/scp
 	shoes = /obj/item/clothing/shoes/jackboots
-	id_types = list(/obj/item/card/id/adminlvl5)
+	id_types = list(/obj/item/card/id/mtf)
 	suit_store = /obj/item/gun/projectile/automatic/scp/p90
 	r_hand = /obj/item/crowbar/red
 	l_hand = /obj/item/material/hatchet/tacknife
@@ -658,10 +668,30 @@
 	back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/clothing/mask/gas = 1)
 
+/decl/hierarchy/outfit/job/site90/crew/command/event/hammerdown //if this ever sees use, an admin really wants someone dead
+	name = OUTFIT_JOB_NAME("MTF Nu-7 Soldier")
+	uniform = /obj/item/clothing/under/tactical
+	suit = /obj/item/clothing/suit/armor/mtfheavy
+	mask = /obj/item/clothing/mask/gas
+	head = /obj/item/clothing/head/helmet/mtfheavy
+	gloves = /obj/item/clothing/gloves/thick/combat
+	glasses = /obj/item/clothing/glasses/tacgoggles
+	shoes = /obj/item/clothing/shoes/combat
+	id_types = list(/obj/item/card/id/mtf)
+	suit_store = null
+	r_hand = /obj/item/gun/projectile/automatic/t12
+	l_hand = null
+	l_pocket = /obj/item/grenade/frag
+	r_pocket = /obj/item/grenade/flashbang/clusterbang //gods must be strong
+	l_ear = /obj/item/device/radio/headset/ert
+	belt = /obj/item/storage/belt/holster/security/tactical
+	back = /obj/item/storage/backpack/rucksack
+	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/ammo_magazine/t12 = 15) //all you need is kill
+
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_soldier
 	name = OUTFIT_JOB_NAME("Chaos Insurgency Soldier")
 	uniform = /obj/item/clothing/under/scp/utility/chaos
-//	suit = /obj/item/clothing/suit/armor/vest/scp/medarmorchaos -- armor doesnt exist
+	suit = /obj/item/clothing/suit/armor/vest/scp/medarmor/chaos
 	head = /obj/item/clothing/head/helmet/scp/chaos
 	mask = /obj/item/clothing/mask/balaclava/tactical
 	glasses = /obj/item/clothing/glasses/night
@@ -681,7 +711,7 @@
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_soldier_alt
 	name = OUTFIT_JOB_NAME("Chaos Insurgency Heavy Soldier")
 	uniform = /obj/item/clothing/under/scp/utility/chaos
-//	suit = /obj/item/clothing/suit/armor/vest/scp/medarmorchaos
+	suit = /obj/item/clothing/suit/armor/vest/scp/medarmor/chaos
 	head = /obj/item/clothing/head/helmet/scp/chaos
 	mask = /obj/item/clothing/mask/balaclava/tactical
 	glasses = /obj/item/clothing/glasses/night
@@ -701,7 +731,7 @@
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_leader
 	name = OUTFIT_JOB_NAME("Chaos Insurgency Squad Leader")
 	uniform = /obj/item/clothing/under/scp/utility/chaos
-//	suit = /obj/item/clothing/suit/armor/vest/scp/medarmorchaos
+	suit = /obj/item/clothing/suit/armor/vest/scp/medarmor/chaos
 	head = /obj/item/clothing/head/beret/solgov/fleet/security
 	mask = /obj/item/clothing/mask/balaclava/tactical
 	glasses = /obj/item/clothing/glasses/night
@@ -727,16 +757,16 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/thick/combat
 	shoes = /obj/item/clothing/shoes/combat
-	id_types = list(/obj/item/card/id/adminlvl4)
-	suit_store = /obj/item/gun/projectile/automatic/scp/ak74
-	r_hand = null
+	id_types = list(/obj/item/card/id/physics)
+	suit_store = null
+	r_hand = /obj/item/gun/projectile/automatic/scp/ak74
 	l_hand = /obj/item/grenade/frag
 	l_pocket = /obj/item/ammo_magazine/scp
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
-	belt = /obj/item/gun/energy/stunrevolver/rifle
+	belt = /obj/item/storage/belt/holster/security/tactical
 	back = /obj/item/storage/backpack/rucksack
-	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak = 5,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
+	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/gunner
 	name = OUTFIT_JOB_NAME("UNGOC PHYSICS Machinegunner")
@@ -747,16 +777,16 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/thick/combat
 	shoes = /obj/item/clothing/shoes/combat
-	id_types = list(/obj/item/card/id/adminlvl4)
-	suit_store = /obj/item/gun/projectile/automatic/l6_saw
-	r_hand = /obj/item/ammo_magazine/box/a556
-	l_hand = /obj/item/ammo_magazine/box/a556
+	id_types = list(/obj/item/card/id/physics)
+	suit_store = null
+	r_hand = /obj/item/gun/projectile/automatic/l6_saw
+	l_hand = null
 	l_pocket = /obj/item/grenade/frag
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
-	belt = /obj/item/gun/energy/stunrevolver/rifle
+	belt = /obj/item/storage/belt/holster/security/tactical
 	back = /obj/item/storage/backpack/rucksack
-	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/box/machinegun = 5,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
+	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/box/a556 = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/grenadier
 	name = OUTFIT_JOB_NAME("UNGOC PHYSICS Grenadier")
@@ -767,16 +797,16 @@
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/thick/combat
 	shoes = /obj/item/clothing/shoes/combat
-	id_types = list(/obj/item/card/id/adminlvl4)
-	suit_store = /obj/item/gun/launcher/grenade // LEEEET'S DO IIIT
-	r_hand = /obj/item/clothing/accessory/storage/bandolier
+	id_types = list(/obj/item/card/id/physics)
+	suit_store = null
+	r_hand = /obj/item/gun/launcher/grenade // LEEEET'S DO IIIT
 	l_hand = /obj/item/material/hatchet/tacknife
 	l_pocket = /obj/item/plastique
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
 	back = /obj/item/storage/backpack/rucksack
-	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/fragshells = 6,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
+	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/fragshells = 8,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1,/obj/item/clothing/accessory/storage/bandolier = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/leader
 	name = OUTFIT_JOB_NAME("UNGOC PHYSICS Team Leader")
@@ -786,16 +816,16 @@
 	gloves = /obj/item/clothing/gloves/thick/combat
 	glasses = /obj/item/clothing/glasses/thermal/plain/jensen
 	shoes = /obj/item/clothing/shoes/combat
-	id_types = list(/obj/item/card/id/adminlvl5)
-	suit_store = /obj/item/gun/projectile/automatic/scp/ak742
-	r_hand = null
+	id_types = list(/obj/item/card/id/physics)
+	suit_store = null
+	r_hand = /obj/item/gun/projectile/automatic/scp/ak742
 	l_hand = /obj/item/material/hatchet/tacknife
 	l_pocket = /obj/item/grenade/frag
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
-	belt = /obj/item/gun/energy/stunrevolver/rifle
+	belt = /obj/item/storage/belt/holster/security/tactical
 	back = /obj/item/storage/backpack/rucksack
-	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak/big = 5,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
+	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak/big = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 // FULLY GEARED (for zombies)
 
@@ -804,13 +834,13 @@
 	uniform = /obj/item/clothing/under/scp/whiteuniform
 	suit = /obj/item/clothing/suit/armor/vest/scp/medarmor
 	head = /obj/item/clothing/head/helmet/scp/security
-	back = null
 	shoes = /obj/item/clothing/shoes/dutyboots
 	belt = /obj/item/storage/belt/holster/security/tactical
 	id_types = list(/obj/item/card/id/junseclvl2lcz)
 	l_pocket = /obj/item/device/radio
 	r_pocket = /obj/item/ammo_magazine/scp/p90_mag
 	suit_store = /obj/item/gun/projectile/automatic/scp/p90
+	back = null
 	l_hand = null
 	r_hand = null
 
@@ -822,7 +852,9 @@
 	id_types = list(/obj/item/card/id/sciencelvl1)
 	gloves = /obj/item/clothing/gloves/latex
 	l_ear = /obj/item/device/radio/headset/headset_sci
-	back = /obj/item/storage/backpack/satchel
+	back = null
+	l_hand = null
+	r_hand = null
 
 /decl/hierarchy/outfit/job/site90/crew/science/scientist/geared
 	name = OUTFIT_JOB_NAME("Scientist")
@@ -832,6 +864,9 @@
 	id_types = list(/obj/item/card/id/sciencelvl2)
 	gloves = /obj/item/clothing/gloves/latex
 	l_ear = /obj/item/device/radio/headset/headset_sci
+	back = null
+	l_hand = null
+	r_hand = null
 
 /decl/hierarchy/outfit/job/ds90/medical/medicaldoctor/geared
 	name = OUTFIT_JOB_NAME("Medical Doctor")
@@ -841,7 +876,9 @@
 	id_types = list(/obj/item/card/id/doctor)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	back = /obj/item/storage/backpack/medic
+	back = null
+	l_hand = null
+	r_hand = null
 
 /decl/hierarchy/outfit/job/site90/crew/civ/classd/geared
 	name = OUTFIT_JOB_NAME("Class D")
@@ -852,6 +889,8 @@
 	id_types = list(/obj/item/card/id/classd)
 	l_ear = null
 	back = null
+	l_hand = null
+	r_hand = null
 
 
 /decl/hierarchy/outfit/job/site90/crew/civ/officeworker
@@ -865,4 +904,6 @@
 	r_ear = /obj/item/pen
 	l_pocket = /obj/item/material/clipboard
 	r_pocket = /obj/item/folder
-
+	back = null
+	l_hand = null
+	r_hand = null


### PR DESCRIPTION
Fixes faulty MTF item_state vars for their armor suits, making sure they now have the proper onmob sprites, whilst also giving them and PHYSICS unique ID card subtypes with specific jobs, plus more useful outfits including Nu-7.