### PR TITLE
GOC Updates (Large BUFF to GOC-ERT)

### DIFF
--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -1406,45 +1406,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/lhcz/scp1102entrance)
-"iz" = (
-/obj/item/clothing/head/helmet/scp/goc,
-/obj/item/clothing/suit/armor/goc,
-/obj/structure/closet,
-/obj/item/storage/belt/holster/security,
-/obj/item/clothing/gloves/thick/swat,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/ert,
-/obj/item/clothing/glasses/night,
-/obj/item/device/radio/headset/goc,
-/obj/item/clothing/head/beret/scp/goc,
-/obj/item/rig/hazard/equipped{
-	name = "GOC whitesuit control module";
-	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
-	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
-	},
-/obj/item/storage/backpack/rucksack/blue,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/gun/projectile/automatic/assault_rifle{
-	desc = "The Rugged HK-417, perfect for the GOC"
-	},
-/obj/item/gun/projectile/pistol/military{
-	desc = "The Glock 19. Reliable, and efficient."
-	},
-/obj/item/gun/projectile/automatic/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/turf/simulated/floor/tiled/techfloor,
-/area/centcom/goc)
 "iA" = (
 /obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/tiled/techmaint,
@@ -2265,42 +2226,6 @@
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/exoplanet/snow,
 /area/centcom/chaos)
-"mc" = (
-/obj/item/clothing/head/helmet/scp/goc,
-/obj/item/clothing/suit/armor/goc,
-/obj/structure/closet,
-/obj/item/storage/belt/holster/security,
-/obj/item/clothing/gloves/thick/swat,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/ert,
-/obj/item/clothing/glasses/night,
-/obj/item/device/radio/headset/goc,
-/obj/item/clothing/head/beret/scp/goc,
-/obj/item/rig/hazard/equipped{
-	name = "GOC whitesuit control module";
-	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
-	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
-	},
-/obj/item/storage/backpack/rucksack/blue,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/gun/projectile/automatic/assault_rifle{
-	desc = "The Rugged HK-417, perfect for the GOC"
-	},
-/obj/item/gun/projectile/pistol/military{
-	desc = "The Glock 19. Reliable, and efficient."
-	},
-/obj/item/gun/projectile/automatic/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/turf/simulated/floor/tiled/techfloor,
-/area/centcom/goc)
 "mg" = (
 /turf/unsimulated/beach/sand,
 /area/beach)
@@ -2525,45 +2450,6 @@
 /obj/item/ammo_casing/rocket,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
-"nt" = (
-/obj/item/clothing/head/helmet/scp/goc,
-/obj/item/clothing/suit/armor/goc,
-/obj/structure/closet,
-/obj/item/storage/belt/holster/security,
-/obj/item/clothing/gloves/thick/swat,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/ert,
-/obj/item/clothing/glasses/night,
-/obj/item/device/radio/headset/goc,
-/obj/item/clothing/head/beret/scp/goc,
-/obj/item/rig/hazard/equipped{
-	name = "GOC whitesuit control module";
-	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
-	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
-	},
-/obj/item/storage/backpack/rucksack/blue,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/ammo_magazine/pistol/double,
-/obj/item/gun/projectile/automatic/assault_rifle{
-	desc = "The Rugged HK-417, perfect for the GOC"
-	},
-/obj/item/gun/projectile/automatic/assault_rifle{
-	desc = "The Rugged HK-417, perfect for the GOC"
-	},
-/obj/item/gun/projectile/pistol/military{
-	desc = "The Glock 19. Reliable, and efficient."
-	},
-/obj/item/gun/projectile/automatic/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/turf/simulated/floor/tiled/techfloor,
-/area/centcom/goc)
 "nu" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3832,14 +3718,16 @@
 /obj/item/ammo_magazine/pistol/double,
 /obj/item/ammo_magazine/pistol/double,
 /obj/item/ammo_magazine/pistol/double,
-/obj/item/gun/projectile/automatic/assault_rifle{
-	desc = "The Rugged HK-417, perfect for the GOC"
-	},
 /obj/item/gun/projectile/pistol/military{
 	desc = "The Glock 19. Reliable, and efficient."
 	},
 /obj/item/gun/projectile/automatic/scp/fnfal,
 /obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/clothing/accessory/storage/bandolier,
 /obj/item/ammo_magazine/scp/fnfal,
 /obj/item/ammo_magazine/scp/fnfal,
 /obj/item/ammo_magazine/scp/fnfal,
@@ -4330,18 +4218,11 @@
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
 	},
 /obj/item/storage/backpack/rucksack/blue,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = 0
-	},
 /obj/item/ammo_magazine/pistol/double,
 /obj/item/ammo_magazine/pistol/double,
 /obj/item/ammo_magazine/pistol/double,
 /obj/item/ammo_magazine/pistol/double,
 /obj/item/ammo_magazine/pistol/double,
-/obj/item/gun/projectile/automatic/assault_rifle{
-	desc = "The Rugged HK-417, perfect for the GOC"
-	},
 /obj/item/gun/projectile/pistol/military{
 	desc = "The Glock 19. Reliable, and efficient."
 	},
@@ -4351,6 +4232,16 @@
 /obj/item/ammo_magazine/scp/fnfal,
 /obj/item/ammo_magazine/scp/fnfal,
 /obj/item/ammo_magazine/scp/fnfal,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = 0
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "MW" = (
@@ -23061,7 +22952,7 @@ cw
 as
 eL
 lI
-mc
+MO
 kT
 kT
 kT
@@ -23267,7 +23158,7 @@ xV
 kT
 kL
 kT
-mc
+xV
 lI
 aF
 oz
@@ -23465,11 +23356,11 @@ cw
 as
 eL
 lI
-iz
+xV
 kT
 lK
 kT
-nt
+xV
 lI
 sS
 oz

--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -2450,20 +2450,6 @@
 /obj/item/ammo_casing/rocket,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
-"nt" = (
-/obj/item/clothing/head/helmet/scp/goc,
-/obj/item/clothing/suit/armor/goc,
-/obj/structure/closet,
-/obj/item/storage/belt/holster/security,
-/obj/item/gun/projectile/pistol,
-/obj/item/clothing/gloves/thick/swat,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/under/ert,
-/obj/item/clothing/glasses/night,
-/obj/item/device/radio/headset/goc,
-/obj/item/gun/projectile/shotgun/pump/combat,
-/turf/simulated/floor/tiled/techfloor,
-/area/centcom/goc)
 "nu" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3607,23 +3593,16 @@
 /area/supply/dock)
 "ws" = (
 /obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
-/obj/item/ammo_magazine/scp/fnfal,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 0
+	},
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
+/obj/item/grenade/smokebomb,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "wu" = (
@@ -3722,13 +3701,21 @@
 /obj/item/clothing/suit/armor/goc,
 /obj/structure/closet,
 /obj/item/storage/belt/holster/security,
-/obj/item/gun/projectile/pistol,
 /obj/item/clothing/gloves/thick/swat,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/under/ert,
 /obj/item/clothing/glasses/night,
 /obj/item/device/radio/headset/goc,
-/obj/item/gun/projectile/automatic/scp/fnfal,
+/obj/item/gun/energy/pulse_rifle/pistol,
+/obj/item/gun/energy/pulse_rifle,
+/obj/item/clothing/head/beret/scp/goc,
+/obj/item/rig/hazard/equipped{
+	name = "GOC whitesuit control module";
+	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
+	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
+	},
+/obj/item/storage/backpack/rucksack/blue,
+/obj/item/melee/energy/sword/blue,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "yh" = (
@@ -4118,12 +4105,12 @@
 	dir = 4;
 	pixel_x = 0
 	},
-/obj/item/ammo_magazine/shotholder/shell,
-/obj/item/ammo_magazine/shotholder/shell,
-/obj/item/ammo_magazine/shotholder/shell,
-/obj/item/ammo_magazine/shotholder/shell,
-/obj/item/ammo_magazine/shotholder/shell,
-/obj/item/ammo_magazine/shotholder/shell,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
+/obj/item/grenade/empgrenade,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "Kf" = (
@@ -4202,17 +4189,25 @@
 /obj/item/clothing/suit/armor/goc,
 /obj/structure/closet,
 /obj/item/storage/belt/holster/security,
-/obj/item/gun/projectile/pistol,
 /obj/item/clothing/gloves/thick/swat,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/clothing/under/ert,
 /obj/item/clothing/glasses/night,
+/obj/item/device/radio/headset/goc,
+/obj/item/gun/energy/pulse_rifle/pistol,
+/obj/item/gun/energy/pulse_rifle,
+/obj/item/clothing/head/beret/scp/goc,
+/obj/item/rig/hazard/equipped{
+	name = "GOC whitesuit control module";
+	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
+	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
+	},
+/obj/item/storage/backpack/rucksack/blue,
+/obj/item/melee/energy/sword/blue,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = 0
 	},
-/obj/item/device/radio/headset/goc,
-/obj/item/gun/projectile/automatic/scp/fnfal,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "MW" = (
@@ -4332,6 +4327,7 @@
 	dir = 5;
 	icon_state = "bordercolor"
 	},
+/obj/machinery/chemical_dispenser/ert,
 /turf/simulated/floor/tiled/monotile/white,
 /area/centcom/goc)
 "VH" = (
@@ -4395,22 +4391,16 @@
 /area/centcom/goc)
 "XQ" = (
 /obj/structure/table/rack,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
-/obj/item/ammo_magazine/scp,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 0
 	},
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/frag/high_yield,
+/obj/item/grenade/frag/high_yield,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "Ye" = (
@@ -4469,9 +4459,13 @@
 /area/site53/tram/car1)
 "Zu" = (
 /obj/structure/table/rack,
-/obj/item/grenade/frag,
-/obj/item/grenade/frag,
-/obj/item/grenade/frag,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
+/obj/item/grenade/flashbang,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "ZC" = (
@@ -23328,11 +23322,11 @@ cw
 as
 eL
 lI
-nt
+xV
 kT
 lK
 kT
-nt
+xV
 lI
 sS
 oz

--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -1406,6 +1406,45 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/lhcz/scp1102entrance)
+"iz" = (
+/obj/item/clothing/head/helmet/scp/goc,
+/obj/item/clothing/suit/armor/goc,
+/obj/structure/closet,
+/obj/item/storage/belt/holster/security,
+/obj/item/clothing/gloves/thick/swat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/ert,
+/obj/item/clothing/glasses/night,
+/obj/item/device/radio/headset/goc,
+/obj/item/clothing/head/beret/scp/goc,
+/obj/item/rig/hazard/equipped{
+	name = "GOC whitesuit control module";
+	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
+	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
+	},
+/obj/item/storage/backpack/rucksack/blue,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/gun/projectile/automatic/assault_rifle{
+	desc = "The Rugged HK-417, perfect for the GOC"
+	},
+/obj/item/gun/projectile/pistol/military{
+	desc = "The Glock 19. Reliable, and efficient."
+	},
+/obj/item/gun/projectile/automatic/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/turf/simulated/floor/tiled/techfloor,
+/area/centcom/goc)
 "iA" = (
 /obj/machinery/vending/sovietsoda,
 /turf/simulated/floor/tiled/techmaint,
@@ -2226,6 +2265,42 @@
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/exoplanet/snow,
 /area/centcom/chaos)
+"mc" = (
+/obj/item/clothing/head/helmet/scp/goc,
+/obj/item/clothing/suit/armor/goc,
+/obj/structure/closet,
+/obj/item/storage/belt/holster/security,
+/obj/item/clothing/gloves/thick/swat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/ert,
+/obj/item/clothing/glasses/night,
+/obj/item/device/radio/headset/goc,
+/obj/item/clothing/head/beret/scp/goc,
+/obj/item/rig/hazard/equipped{
+	name = "GOC whitesuit control module";
+	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
+	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
+	},
+/obj/item/storage/backpack/rucksack/blue,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/gun/projectile/automatic/assault_rifle{
+	desc = "The Rugged HK-417, perfect for the GOC"
+	},
+/obj/item/gun/projectile/pistol/military{
+	desc = "The Glock 19. Reliable, and efficient."
+	},
+/obj/item/gun/projectile/automatic/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/turf/simulated/floor/tiled/techfloor,
+/area/centcom/goc)
 "mg" = (
 /turf/unsimulated/beach/sand,
 /area/beach)
@@ -2450,6 +2525,45 @@
 /obj/item/ammo_casing/rocket,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
+"nt" = (
+/obj/item/clothing/head/helmet/scp/goc,
+/obj/item/clothing/suit/armor/goc,
+/obj/structure/closet,
+/obj/item/storage/belt/holster/security,
+/obj/item/clothing/gloves/thick/swat,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/under/ert,
+/obj/item/clothing/glasses/night,
+/obj/item/device/radio/headset/goc,
+/obj/item/clothing/head/beret/scp/goc,
+/obj/item/rig/hazard/equipped{
+	name = "GOC whitesuit control module";
+	desc = "A GOC hardsuit designed for prolonged EVA in dangerous environments.";
+	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
+	},
+/obj/item/storage/backpack/rucksack/blue,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/gun/projectile/automatic/assault_rifle{
+	desc = "The Rugged HK-417, perfect for the GOC"
+	},
+/obj/item/gun/projectile/automatic/assault_rifle{
+	desc = "The Rugged HK-417, perfect for the GOC"
+	},
+/obj/item/gun/projectile/pistol/military{
+	desc = "The Glock 19. Reliable, and efficient."
+	},
+/obj/item/gun/projectile/automatic/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/turf/simulated/floor/tiled/techfloor,
+/area/centcom/goc)
 "nu" = (
 /obj/machinery/light{
 	dir = 8;
@@ -3706,8 +3820,6 @@
 /obj/item/clothing/under/ert,
 /obj/item/clothing/glasses/night,
 /obj/item/device/radio/headset/goc,
-/obj/item/gun/energy/pulse_rifle/pistol,
-/obj/item/gun/energy/pulse_rifle,
 /obj/item/clothing/head/beret/scp/goc,
 /obj/item/rig/hazard/equipped{
 	name = "GOC whitesuit control module";
@@ -3715,7 +3827,24 @@
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
 	},
 /obj/item/storage/backpack/rucksack/blue,
-/obj/item/melee/energy/sword/blue,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/gun/projectile/automatic/assault_rifle{
+	desc = "The Rugged HK-417, perfect for the GOC"
+	},
+/obj/item/gun/projectile/pistol/military{
+	desc = "The Glock 19. Reliable, and efficient."
+	},
+/obj/item/gun/projectile/automatic/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "yh" = (
@@ -4194,8 +4323,6 @@
 /obj/item/clothing/under/ert,
 /obj/item/clothing/glasses/night,
 /obj/item/device/radio/headset/goc,
-/obj/item/gun/energy/pulse_rifle/pistol,
-/obj/item/gun/energy/pulse_rifle,
 /obj/item/clothing/head/beret/scp/goc,
 /obj/item/rig/hazard/equipped{
 	name = "GOC whitesuit control module";
@@ -4203,11 +4330,27 @@
 	armor = list("melee" = 50, "bullet" = 50, "laser" = 40, "energy" = 30, "bomb" = 60, "bio" = 100, "rad" = 100)
 	},
 /obj/item/storage/backpack/rucksack/blue,
-/obj/item/melee/energy/sword/blue,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = 0
 	},
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/ammo_magazine/pistol/double,
+/obj/item/gun/projectile/automatic/assault_rifle{
+	desc = "The Rugged HK-417, perfect for the GOC"
+	},
+/obj/item/gun/projectile/pistol/military{
+	desc = "The Glock 19. Reliable, and efficient."
+	},
+/obj/item/gun/projectile/automatic/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
+/obj/item/ammo_magazine/scp/fnfal,
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/goc)
 "MW" = (
@@ -22918,7 +23061,7 @@ cw
 as
 eL
 lI
-MO
+mc
 kT
 kT
 kT
@@ -23124,7 +23267,7 @@ xV
 kT
 kL
 kT
-xV
+mc
 lI
 aF
 oz
@@ -23322,11 +23465,11 @@ cw
 as
 eL
 lI
-xV
+iz
 kT
 lK
 kT
-xV
+nt
 lI
 sS
 oz


### PR DESCRIPTION
This makes the GOC more in line with their canon, giving them better armour and more weapons.

## About the Pull Request

Adds hazard suits to the GOC Base.
Adds more grenades to GOC Base in the stead of ammo.
Adds a proper chem dispenser to the GOC Base.

## Why It's Good For The Game

It's good for the gsme because:
A) GOC is rarely used
B) GOC is now more in line with the canon

## Changelog

:cl:
add: hardsuit in goc base
add: ert chem dispenser in goc base
balance: rebalanced goc, gives buffm makes more in line with canon

/:cl: