### PR TITLE
Adjusts Engineering ID Card  and Air Alarm Access

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -56,7 +56,7 @@
 	idle_power_usage = 80
 	active_power_usage = 1000 //For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
 	power_channel = ENVIRON
-	req_access = list(list(access_atmospherics, access_engine_equip))
+	req_access = list(list(access_securitylvl1, access_atmospherics, access_engine_equip)) //access_securitylvl1 added since mapper air alarms have it configured.
 	clicksound = "button"
 	clickvol = 30
 

--- a/maps/site53/job/jobs/engineering.dm
+++ b/maps/site53/job/jobs/engineering.dm
@@ -46,7 +46,7 @@
 		"Damage Control Technician",
 		"Electrician"
 		)
-	outfit_type = /decl/hierarchy/outfit/job/ds90/crew/engineering/juneng
+	outfit_type = /decl/hierarchy/outfit/job/ds90/crew/engineering/eng
 	allowed_branches = list(/datum/mil_branch/civilian)
 	allowed_ranks = list(/datum/mil_rank/civ/classc)
 	hud_icon = "hudengineer"

--- a/maps/site53/job/jobs/engineering.dm
+++ b/maps/site53/job/jobs/engineering.dm
@@ -53,6 +53,7 @@
 
 	access = list(
 		access_eng_comms,
+		access_securitylvl1,
 		access_engineeringlvl1,
 		access_engineeringlvl2,
 		access_engineeringlvl3,
@@ -102,6 +103,7 @@
 		access_engineeringlvl2,
 		access_engineeringlvl3,
 		access_engineeringlvl4,
+		access_atmospherics,
 		access_engine_equip
 	)
 	minimal_access = list()
@@ -151,6 +153,7 @@
 		access_engineeringlvl2,
 		access_engineeringlvl3,
 		access_engineeringlvl4,
+		access_atmospherics,
 		access_engine_equip
 	)
 	minimal_access = list()
@@ -197,6 +200,8 @@
 		access_engineeringlvl3,
 		access_engineeringlvl4,
 		access_engineeringlvl5,
+		access_atmospherics,
+		access_engine_equip,
 		access_keyauth
 	)
 	minimal_access = list()


### PR DESCRIPTION
- adds Atmospherics access to Senior Engineer, Containment Engineer, and Chief Engineer

- adds Engine Equip access to Chief Engineer

- adds Security Level 1 to regular Engineers, to allow access to Air Alarms.

- add securitylvl1 to Air Alarms, as a failsafe for possible mapper fails. Also can be used to cut down on extra variants of Air Alarms.

- c4c41c9 fixes Engineer outfit pulling junior engineer data instead of engineer.

## About the Pull Request

Adjusts engineering access levels. Adjusts alarm.dm air alarm preset access to help with placing new Air Alarms, if the mapper fails to manually adjust Air Alarm access.

## Why It's Good For The Game

Quality of Life for engineering, since some things may still require atmospherics access, and engineers being unable to access air alarms is annoying. Until Atmospherics is potentially removed, engineering requires access to them.

## Changelog

:cl:
code: c4c41c9 changes Engineer outfit type from juneng to eng, giving Engineers the proper ID card.
code: code/game/machinery/alarm.dm - added securitylvl1 to req_access
code: maps/site53/job/jobs/engineering.dm - added atmospherics access to CE, Containment Engineer, and Senior Engineer. Added Engine Equip access to Chief Engineer. Added Security Level 1 to Engineers.
/:cl: