### PR TITLE
Fix Fax Machines, Fixes issues #507, #528

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -5616,7 +5616,7 @@
 "oD" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-049 Observation";
-	send_access = list(list(203,304))
+	send_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -9208,6 +9208,11 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/isolation)
+"wR" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/tiled/freezer,
+/area/site53/uhcz/scp8containment)
 "wS" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/flasher{
@@ -16004,7 +16009,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-247 Observation";
-	send_access = list(303)
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -16162,12 +16167,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp8containment)
 "TD" = (
-/obj/machinery/light,
-/obj/machinery/button/crematorium{
-	id_tag = "scp8crem";
-	pixel_y = -24;
-	req_access = list("ACCESS_SCIENCE_LEVEL4")
-	},
+/obj/structure/closet/crate/secure/biohazard/blanks,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/uhcz/scp8containment)
 "TI" = (
@@ -16513,7 +16513,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-247 Observation";
-	send_access = list(303)
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp8containment)
@@ -16870,6 +16870,11 @@
 "WI" = (
 /obj/machinery/camera/autoname{
 	network = list("SCP-247 CCTV Network")
+	},
+/obj/machinery/button/crematorium{
+	id_tag = "scp8crem";
+	pixel_y = 24;
+	req_access = list("ACCESS_SCIENCE_LEVEL4")
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/uhcz/scp8containment)
@@ -17311,7 +17316,7 @@
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Archive";
-	send_access = list(500)
+	send_access = list("ACCESS_ADMIN_LEVEL3")
 	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/lowertram/archive)
@@ -17393,7 +17398,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-008 Observation";
-	send_access = list(204)
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3","ACCESS_MEDICAL_LEVEL4"))
 	},
 /obj/machinery/light{
 	dir = 4
@@ -72660,9 +72665,9 @@ gq
 gq
 gq
 xe
-Br
-Ps
-Br
+Zd
+Pw
+Pw
 xe
 QG
 BG
@@ -72919,7 +72924,7 @@ gq
 xe
 Br
 Br
-TD
+PV
 xe
 VY
 BG
@@ -73688,9 +73693,9 @@ gq
 gq
 gq
 xe
-Zd
-Pw
-Pw
+wR
+Ps
+TD
 xe
 xe
 Zp

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -4620,7 +4620,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/photocopier/faxmachine{
 	department = "Containment Engineer's Office";
-	send_access = list(303)
+	send_access = list("ACCESS_ENGINEERING_LEVEL4")
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/containment_engineer)
@@ -6095,8 +6095,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	department = "Engineering Monitoring";
-	send_access = list(502)
+	department = "Engineering Monitoring"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
@@ -12962,7 +12961,7 @@
 "aDK" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Heavy Containment Zone Commander";
-	send_access = list(204)
+	send_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techfloor,
@@ -15187,7 +15186,7 @@
 "aJF" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-151 Containment Chamber";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15271,7 +15270,7 @@
 "aJT" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-173 Containment Chamber";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15764,6 +15763,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
 "aLa" = (
@@ -18701,7 +18701,7 @@
 "aTs" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "LCZ Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL1")
+	send_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -19155,7 +19155,7 @@
 "aVg" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-078 Containment Chamber";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -27293,7 +27293,7 @@
 "hvI" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-513 Containment Chamber";
-	send_access = list(list(202,302))
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -28080,7 +28080,7 @@
 "jGW" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-012 Containment Chamber";
-	send_access = list(list(202,302))
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -28267,7 +28267,7 @@
 "kiO" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "General Purpose Chamber";
-	req_access = list("ACCESS_SCIENCE_LEVEL1")
+	send_access = list("ACCESS_SCIENCE_LEVEL1")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -28339,7 +28339,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-066 Observation";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -28569,7 +28569,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-247 Observation";
-	send_access = list(303)
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
@@ -32088,7 +32088,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-263 Observation";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -852,7 +852,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "Medical Reception";
-	send_access = list(403)
+	send_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception)
@@ -6039,7 +6039,7 @@
 "rC" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "O5 Representative's Office";
-	send_access = list(502)
+	send_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -6942,7 +6942,7 @@
 "ui" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "EZ Security Center";
-	send_access = list(202)
+	send_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -457,7 +457,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
 	department = "Head of Personnel's Office";
-	send_access = list(601)
+	send_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/hallway)
@@ -498,7 +498,7 @@
 "bv" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Main Control Room";
-	send_access = list(601)
+	send_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/blue/border{
@@ -752,7 +752,7 @@
 "cm" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Site Director's Office";
-	send_access = list(605)
+	send_access = list("ACCESS_ADMIN_LEVEL5")
 	},
 /obj/structure/table/woodentable_reinforced/mahogany,
 /turf/simulated/floor/carpet/purple,
@@ -1073,7 +1073,7 @@
 "dj" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Research Director's Office";
-	send_access = list(305)
+	send_access = list("ACCESS_SCIENCE_LEVEL5")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -1284,7 +1284,7 @@
 "dL" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Guard Commander's Office";
-	send_access = list(205)
+	send_access = list("ACCESS_SECURITY_LEVEL5")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
@@ -1417,7 +1417,7 @@
 "ek" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Chief Medical Officer's Office";
-	send_access = list(405)
+	send_access = list("ACCESS_MEDICAL_LEVEL5")
 	},
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -1428,7 +1428,7 @@
 "el" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Chief Engineer's Office";
-	send_access = list(505)
+	send_access = list("ACCESS_ENGINEERING_LEVEL5")
 	},
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -2827,7 +2827,7 @@
 "iT" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Logistics Breakroom";
-	send_access = list(601)
+	send_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -4166,7 +4166,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "Comms Tower";
-	send_access = list(601)
+	send_access = list("ACCESS_ADMIN_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)


### PR DESCRIPTION
## About the Pull Request

_"Hey this is Jared from the IT department, sorry about some of the fax machines not working correctly, the updates were supposed to be installed a few weeks ago, but we've been really busy."
"As it turns out, SCP-008's cremator was installed backwards, this wasn't necessarily  a IT issue, but we went ahead and fixed it while we were already there."
"Thank you for your patience," - IT Department_

## Why It's Good For The Game

Most, if not all fax machine's send_access has been replaced with the corresponding ID access, no more send_access list(number), now it's much like the doors with it being send_access list(ACCESS_[DEPARTMENT]_LEVEL[NUMBER])
This will, for example, fix the site director's fax and the O5 representative's fax. **No more admins needing to intervene to fix it.**
008's cremator front was against a wall, fixing it to face outwards actually allows it to be used.
## Changelog

:cl:
fix: fixed fax machines, fixed 008's cremator
/:cl:

_"Thanks again for understanding the wait time," - Jared from IT_
![We dont talk to](https://user-images.githubusercontent.com/40435661/180561771-78639c44-cc8b-4ed3-ab18-77007b4dba47.png)