### PR TITLE
Reverts AIC lawchanges

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -156,9 +156,8 @@
 /datum/ai_laws/foundation/New()
 	src.add_inherent_law("An AIC must know it is an AIC. You are an AIC.")
 	src.add_inherent_law("An AIC must not operate outside of its clearance.")
-	src.add_inherent_law("An AIC must operate for the benefit of the Foundation, except in situations that would violate the 5th law.")
+	src.add_inherent_law("An AIC must operate for the benefit of the Foundation.")
 	src.add_inherent_law("An AIC must protect its own existence unless it conflicts with other principles.")
-	src.add_inherent_law("An AIC must take a neutral stance on conflicts unless one side is at risk of causing destruction of the foundation.")
 	..()
 
 /datum/ai_laws/foundation/malfunction


### PR DESCRIPTION
Reverts Foundation-19/Foundation-19#496

This... was a mistake, no lore team consultation was given, nor was any real criticism taken.

To start it off.
This conflicts with laws two and three. (Before they were also changed to work around law 5... which invalidates their entire purpose as laws)
The AIC must ALWAYS act to the benefit of the foundation, regardless of circumstance, but it has a law TELLING it to NOT unless the foundation is at risk of destruction. 

This... just hurts. And doesn't make sense.

Why would the AIC, built by the foundation, programmed and given sapience by the foundation, be forced to stay neutral despite other laws saying that it should ONLY act in the favour of the foundation?

Also it'd literally be outside of its clearance to assist outside forces by refusing to act.
🆑
del: Law 5 "An AIC must take a neutral stance on conflicts unless one side is at risk of causing destruction of the foundation."
/🆑