### PR TITLE
Fixes Airlock Electronics

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -17,10 +17,11 @@
 	var/autoset = TRUE // Whether the door should inherit access from surrounding areas
 
 /obj/item/airlock_electronics/attack_self(mob/user)
-	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
-		return ..(user)
+	if (ishuman(user) || issilicon(user))
+		ui_interact(user)
+		return
 
-	ui_interact(user)
+	return ..(user)
 
 
 /obj/item/airlock_electronics/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.hands_state)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -17,7 +17,7 @@
 	var/autoset = TRUE // Whether the door should inherit access from surrounding areas
 
 /obj/item/airlock_electronics/attack_self(mob/user)
-	if(!ishuman(user) || !issilicon(user))
+	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
 		return ..(user)
 
 	ui_interact(user)


### PR DESCRIPTION
Pulled from Baystation 12 Github. Allows humans to interact with Airlock Electronics again.

## About the Pull Request

Fixes interaction with Airlock Electronics.

## Why It's Good For The Game

Allows engineers to properly repair airlocks.

## Changelog

:cl:
fix: fixes airlock_electronics not opening it's UI when used in hand.
/:cl:
