### PR TITLE
Fixes Response Team comms

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -264,7 +264,7 @@
 
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
-	freq_listening = list(SEC_FREQ, GOC_FREQ)
+	freq_listening = list(SEC_FREQ, GOC_FREQ, ERT_FREQ)
 	channel_tags = list(list(SEC_FREQ, "Security", COMMS_COLOR_SECURITY), list(GOC_FREQ, "GOC", COMMS_COLOR_COMMAND), list(ERT_FREQ, "Response Team", COMMS_COLOR_CENTCOMM))
 	autolinkers = list("security")
 

--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -55,7 +55,7 @@
 	id = "Receiver A"
 	network = "tcommsat"
 	autolinkers = list("receiverA") // link to relay
-	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, SEC_HCZ_FREQ, SEC_LCZ_FREQ, SEC_ECZ_FREQ, GOC_FREQ)
+	freq_listening = list(AI_FREQ, SCI_FREQ, MED_FREQ, SUP_FREQ, SRV_FREQ, COMM_FREQ, ENG_FREQ, SEC_FREQ, ENT_FREQ, SEC_HCZ_FREQ, SEC_LCZ_FREQ, SEC_ECZ_FREQ, GOC_FREQ, ERT_FREQ)
 
 	//Common and other radio frequencies for people to freely use
 /obj/machinery/telecomms/receiver/preset_right/New()
@@ -106,8 +106,8 @@
 /obj/machinery/telecomms/bus/preset_three
 	id = "Bus 3"
 	network = "tcommsat"
-	freq_listening = list(SEC_FREQ, COMM_FREQ, SEC_HCZ_FREQ, SEC_LCZ_FREQ, SEC_ECZ_FREQ, GOC_FREQ)
-	autolinkers = list("processor3", "security", "command", "hcz-security", "lcz-security", "ecz-security", "GOC")
+	freq_listening = list(SEC_FREQ, COMM_FREQ, SEC_HCZ_FREQ, SEC_LCZ_FREQ, SEC_ECZ_FREQ, GOC_FREQ, ERT_FREQ)
+	autolinkers = list("processor3", "security", "command", "hcz-security", "lcz-security", "ecz-security", "GOC", "centcomm")
 
 /obj/machinery/telecomms/bus/preset_four
 	id = "Bus 4"
@@ -265,7 +265,7 @@
 /obj/machinery/telecomms/server/presets/security
 	id = "Security Server"
 	freq_listening = list(SEC_FREQ, GOC_FREQ)
-	channel_tags = list(list(SEC_FREQ, "Security", COMMS_COLOR_SECURITY), list(GOC_FREQ, "GOC", COMMS_COLOR_COMMAND))
+	channel_tags = list(list(SEC_FREQ, "Security", COMMS_COLOR_SECURITY), list(GOC_FREQ, "GOC", COMMS_COLOR_COMMAND), list(ERT_FREQ, "Response Team", COMMS_COLOR_CENTCOMM))
 	autolinkers = list("security")
 
 /obj/machinery/telecomms/server/presets/centcomm


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

adds ERT to the Comms equipment, like the GOC frequency. somehow extending the ERT zlevel comm equipment's broadcast range to encompass Site 53 is an alternative and neater way of doing it, but. if this is a dumb way of fixing it let me know

also this is using CRLF instead of LF, so i'll fix it once the change to CRLF is merged

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Closes #299

## Changelog

:cl:
fix: Fixes MTF comms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
