### PR TITLE
Adds inflatable popping to 173

### DIFF
--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -112,6 +112,9 @@ GLOBAL_LIST_EMPTY(scp173s)
 		playsound(get_turf(A), 'sound/effects/grillehit.ogg', 50, 1)
 		qdel(A)
 		return
+	if(istype(A, /obj/structure/inflatable))
+		var/obj/structure/inflatable/W = A
+		W.deflate(violent=1)
 	return
 
 /mob/living/scp_173/Life()


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

closes #567

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

it pops instantly (like windows, grills), no attack animation, but at least it makes a nice popping noise. 173 needs a general attack refactor probably, but. fixes the issue for now

## Changelog

:cl:
fix: SCP-173 is no longer limited by flimsy plastic doors and walls
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
