### PR TITLE
Enables psi amp in uplink

### DIFF
--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -108,13 +108,11 @@
 	path = /obj/item/storage/secure/briefcase/heavysniper
 	antag_roles = list(MODE_MERCENARY)
 
-/*
 /datum/uplink_item/item/visible_weapons/psi_amp
 	name = "Cerebroenergetic Psionic Amplifier"
 	item_cost = 50
 	path = /obj/item/clothing/head/helmet/space/psi_amp/lesser
 	desc = "A powerful, illegal psi-amp. Boosts latent psi-faculties to extremely high levels."
-*/
 
 /datum/uplink_item/item/visible_weapons/machine_pistol
 	name = "Standard Machine Pistol"


### PR DESCRIPTION
## About the Pull Request

Re-enables the psi amp in traitor uplink items

## Why It's Good For The Game

why was it disabled

## Changelog

:cl:
add: Psionic amp added to traitor uplink.
/:cl:
