### PR TITLE
Makes Crisis robot actually worth using.

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -113,8 +113,8 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/taperoll/medical,
 		/obj/item/inflatable_dispenser/robot,
-		/obj/item/stack/medical/ointment,
-		/obj/item/stack/medical/bruise_pack,
+		/obj/item/stack/medical/advanced/ointment,
+		/obj/item/stack/medical/advanced/bruise_pack,
 		/obj/item/stack/medical/splint
 	)
 	synths = list(
@@ -132,8 +132,8 @@
 /obj/item/robot_module/medical/crisis/finalize_equipment()
 	. = ..()
 	for(var/thing in list(
-		 /obj/item/stack/medical/ointment,
-		 /obj/item/stack/medical/bruise_pack,
+		 /obj/item/stack/medical/advanced/ointment,
+		 /obj/item/stack/medical/advanced/bruise_pack,
 		 /obj/item/stack/medical/splint
 		))
 		var/obj/item/stack/medical/stack = locate(thing) in equipment

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -22,7 +22,7 @@
 	reagent_ids = list(/datum/reagent/medicine/bicaridine, /datum/reagent/medicine/dexalin, /datum/reagent/medicine/painkiller/tramadol)
 
 /obj/item/reagent_containers/borghypo/crisis
-	reagent_ids = list(/datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/inaprovaline, /datum/reagent/medicine/painkiller/tramadol)
+	reagent_ids = list(/datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/inaprovaline, /datum/reagent/medicine/painkiller/tramadol, /datum/reagent/medicine/adrenaline)
 
 /obj/item/reagent_containers/borghypo/Initialize()
 	. = ..()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -22,7 +22,7 @@
 	reagent_ids = list(/datum/reagent/medicine/bicaridine, /datum/reagent/medicine/dexalin, /datum/reagent/medicine/painkiller/tramadol)
 
 /obj/item/reagent_containers/borghypo/crisis
-	reagent_ids = list(/datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/inaprovaline, /datum/reagent/medicine/painkiller/tramadol, /datum/reagent/medicine/adrenaline)
+	reagent_ids = list(/datum/reagent/medicine/tricordrazine, /datum/reagent/medicine/inaprovaline, /datum/reagent/medicine/painkiller/tramadol, /datum/reagent/medicine/adrenaline, /datum/reagent/medicine/dexalin, /datum/reagent/paracetamol)
 
 /obj/item/reagent_containers/borghypo/Initialize()
 	. = ..()


### PR DESCRIPTION
## About the Pull Request
Gives adrenaline, dex, and tylenol, as well as ATK and ABK to the Crisis Cyborg.
<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The surgical cyborg was better at applying medical chemicals than the crisis robot.. It's a surgery robot. It's fine with what it has now, but the crisis cyborg should probably have better equipment. 
The emergency response flying robot was also better - more mobility, but no chem tools - than doctoring than the crisis robot.
This PR makes it so that the crisis cyborg is best at what it does, but can't do much more.
Flying vs Regular: 
Flying - more mobility (standard for flying), less gear and less health (standard for flying)
Regular - more health (standard for regular), more gear, less mobility.
I don't want the Surgical or Response robot to be weak, though, so I didn't change it too much.
Surgical is still good at surgery, and Response is still highly mobile. 
All this does is upgrade Crisis borg to not have nearly the same level of gear as the Response robot.


## Changelog

:cl:
add: Added dexalin to crisis cyborg hypospray
add: Added tylenol to crisis cyborg hypospray
add: Added adrenaline to crisis cyborg hypospray
add: Added advanced kits to crisis cyborg
/:cl:
