### PR TITLE
Fix mob life bug

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -8,12 +8,13 @@
 	if(germ_level < GERM_LEVEL_AMBIENT && prob(30))	//if you're just standing there, you shouldn't get more germs beyond an ambient level
 		germ_level++
 
+	if(!InStasis())
+		//Chemicals in the body
+		handle_chemicals_in_body()
+
 	if(stat != DEAD && !InStasis())
 		//Breathing, if applicable
 		handle_breathing()
-
-		//Chemicals in the body
-		handle_chemicals_in_body()
 
 		//Random events (vomiting etc)
 		handle_random_events()


### PR DESCRIPTION
## About the Pull Request

https://github.com/Foundation-19/Foundation-19/blob/dev/code/modules/reagents/Chemistry-Reagents.dm#L94
reagent on_mob_life already checks if you're dead, but also checks if it's a chemical that affects you while dead
previously, reagent on_mob_life wouldn't get called at all because of this check in mob life which I assume was an oversight
this makes any chemical with the AFFECTS_DEAD flag actually work
SCP-500 can now actually revive the braindead instead of just sitting in the bloodstream doing jack shit

## Why It's Good For The Game

baycoders LOSING

## Changelog

:cl:
fix: All chemicals that affect the dead work now, such as SCP-500
/:cl:


