### PR TITLE
chat darkmode admin pm color change

### DIFF
--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -919,7 +919,7 @@ em {
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
 .pm  .in				{color: #ff0000;}
 .pm  .out				{color: #ff0000;}
-.pm  .other				{color: ##5353ff;}
+.pm  .other				{color: #5353ff;}
 
 /* Admin: Channels */
 .mentor_channel			{color: #735638;	font-weight: bold;}

--- a/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/goon/chat-dark.scss
@@ -919,7 +919,7 @@ em {
 .pm  .howto				{color: #ff0000;	font-weight: bold;		font-size: 200%;}
 .pm  .in				{color: #ff0000;}
 .pm  .out				{color: #ff0000;}
-.pm  .other				{color: #0000ff;}
+.pm  .other				{color: ##5353ff;}
 
 /* Admin: Channels */
 .mentor_channel			{color: #735638;	font-weight: bold;}


### PR DESCRIPTION
Changed the `unreadable blue` color of admin PMs to `readable blue`.