### PR TITLE
makes binary key uplink only

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -870,20 +870,6 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/weldingtool/experimental
 	sort_string = "VAGAG"
 
-
-/datum/design/item/encryptionkey/AssembleDesignName()
-	..()
-	name = "Encryption key design ([item_name])"
-
-/datum/design/item/encryptionkey/binary
-	name = "binary"
-	desc = "Allows for deciphering the binary channel on-the-fly."
-	id = "binaryencrypt"
-	req_tech = list(TECH_ESOTERIC = 2)
-	materials = list(DEFAULT_WALL_MATERIAL = 300, "glass" = 300)
-	build_path = /obj/item/device/encryptionkey/binary
-	sort_string = "VASAA"
-
 /datum/design/item/camouflage/AssembleDesignName()
 	..()
 	name = "Camouflage design ([item_name])"

--- a/code/modules/research/designs/designs_singletons.dm
+++ b/code/modules/research/designs/designs_singletons.dm
@@ -2,15 +2,6 @@
 	..()
 	name = "Encryption key design ([item_name])"
 
-/datum/design/item/encryptionkey/binary
-	name = "binary"
-	desc = "Allows for deciphering the binary channel on-the-fly."
-	id = "binaryencrypt"
-	req_tech = list(TECH_ESOTERIC = 2)
-	materials = list(MATERIAL_STEEL = 300, MATERIAL_GLASS = 300)
-	build_path = /obj/item/device/encryptionkey/binary
-	sort_string = "VASAA"
-
 /datum/design/item/camouflage/AssembleDesignName()
 	..()
 	name = "Camouflage design ([item_name])"


### PR DESCRIPTION
## About the Pull Request

No longer researchable

## Why It's Good For The Game

Its really easy to get illegal tech 2, and this is just really cheap and makes rogue ai impossible, it should stay a traitor only item

## Changelog

:cl:
del: Binary key from research designs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
