### PR TITLE
Buffed Guard Skills

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -49,7 +49,7 @@
 	//duties = "<big><b>As the Entrance Zone Senior Agent, you and your team work independently from the guard commander and regular security structure. In this zone, you are tasked with the protection of administrative personnel, together with the agents stationed here. You should not leave your zone under usual SoP, or allow administration to go without protection detail into the facility.</b></big>"
 	economic_power = 4
 	minimal_player_age = 10
-	ideal_character_age = 45
+	ideal_character_age = 27
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ltofficerez
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -91,7 +91,7 @@
 	supervisors = "the Guard/Senior Agent"
 	economic_power = 4
 	minimal_player_age = 5
-	ideal_character_age = 30
+	ideal_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ncoofficerez
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -129,7 +129,7 @@
 	supervisors = "the Guard/Zone Commander"
 	economic_power = 4
 	minimal_player_age = 0
-	ideal_character_age = 27
+	ideal_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/enlistedofficerez
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -165,7 +165,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You should not leave your zone under usual SoP</b></big>"
 	economic_power = 4
 	minimal_player_age = 10
-	ideal_character_age = 45
+	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ltofficerhcz
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -267,7 +267,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You also carry the responsibility of guarding the D-Cells. You should not leave your zone under usual SoP</b></big>"
 	economic_power = 4
 	minimal_player_age = 10
-	ideal_character_age = 45
+	ideal_character_age = 30
 //	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ltofficer
 	allowed_branches = list(
 		/datum/mil_branch/security

--- a/maps/site53/job/jobs/security.dm
+++ b/maps/site53/job/jobs/security.dm
@@ -7,7 +7,7 @@
 	economic_power = 8
 	alt_titles = list("Security Chief", "Head of Security")
 	minimal_player_age = 15
-	ideal_character_age = 55
+	ideal_character_age = 35
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/command/cos
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -44,7 +44,8 @@
 	                    SKILL_EVA         = SKILL_BASIC,
 	                    SKILL_COMBAT      = SKILL_BASIC,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
-	                    SKILL_FORENSICS   = SKILL_BASIC)
+	                    SKILL_HAULING     = SKILL_TRAINED,
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
@@ -67,7 +68,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You also carry the responsibility of guarding the D-Cells. You should not leave your zone under usual SoP</b></big>"
 	economic_power = 4
 	minimal_player_age = 10
-	ideal_character_age = 45
+	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ltofficerlcz
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -93,14 +94,15 @@
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
-	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
+	                    SKILL_COMBAT      = SKILL_TRAINED,
+	                    SKILL_WEAPONS     = SKILL_TRAINED,
+	                    SKILL_HAULING     = SKILL_TRAINED,
+	                    SKILL_FORENSICS   = SKILL_MASTER)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 20
+	skill_points = 28
 
 /datum/job/ltofficerhcz
 	title = "HCZ Zone Commander"
@@ -111,7 +113,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You should not leave your zone under usual SoP</b></big>"
 	economic_power = 4
 	minimal_player_age = 10
-	ideal_character_age = 45
+	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ltofficerhcz
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -138,14 +140,15 @@
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
-	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
+	                    SKILL_COMBAT      = SKILL_EXPERIENCED,
+	                    SKILL_WEAPONS     = SKILL_TRAINED,
+	                    SKILL_HAULING     = SKILL_TRAINED,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 20
+	skill_points = 28
 
 /datum/job/ltofficerez
 	title = "EZ Supervisor"
@@ -156,7 +159,7 @@
 	//duties = "<big><b>As the Entrance Zone Senior Agent, you and your team work independently from the guard commander and regular security structure. In this zone, you are tasked with the protection of administrative personnel, together with the agents stationed here. You should not leave your zone under usual SoP, or allow administration to go without protection detail into the facility.</b></big>"
 	economic_power = 4
 	minimal_player_age = 10
-	ideal_character_age = 45
+	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ltofficerez
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -188,10 +191,11 @@
 	minimal_access = list()
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_TRAINED,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_TRAINED,
+	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
@@ -242,10 +246,11 @@
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_TRAINED,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
-	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
+	                    SKILL_COMBAT      = SKILL_TRAINED,
+	                    SKILL_WEAPONS     = SKILL_TRAINED,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
@@ -286,16 +291,17 @@
 	minimal_access = list()
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_TRAINED,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
-	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
+	                    SKILL_COMBAT      = SKILL_TRAINED,
+	                    SKILL_WEAPONS     = SKILL_TRAINED,
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 
-	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
-	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
+	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
+	                    SKILL_WEAPONS     = SKILL_MASTER,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 20
+	skill_points = 25
 
 /datum/job/ncoofficerez
 	title = "EZ Senior Agent"
@@ -307,7 +313,7 @@
 	economic_power = 4
 	alt_titles = list("EZ Senior Forensics Agent", "EZ Senior Investigations Agent", "EZ Senior Combat Medic")
 	minimal_player_age = 5
-	ideal_character_age = 30
+	ideal_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/ncoofficerez
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -344,7 +350,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 20
+	skill_points = 25
 //##
 //JUNIOR OFFICER
 //##
@@ -387,15 +393,16 @@
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_TRAINED,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_TRAINED,
 	                    SKILL_WEAPONS     = SKILL_BASIC,
-	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 15
+	skill_points = 20
 
 /datum/job/enlistedofficerhcz
 
@@ -433,15 +440,16 @@
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_TRAINED,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_TRAINED,
 	                    SKILL_WEAPONS     = SKILL_BASIC,
-	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
+	                    SKILL_FORENSICS   = SKILL_BASIC)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 15
+	skill_points = 20
 
 /datum/job/enlistedofficerez
 
@@ -454,7 +462,7 @@
 	economic_power = 4
 	alt_titles = list("EZ Forensics Agent", "EZ Investigations Agent", "EZ Combat Medic")
 	minimal_player_age = 0
-	ideal_character_age = 27
+	ideal_character_age = 25
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/security/enlistedofficerez
 	allowed_branches = list(
 		/datum/mil_branch/security
@@ -481,9 +489,10 @@
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_HAULING     = SKILL_TRAINED,
 	                    SKILL_EVA         = SKILL_BASIC,
 	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_WEAPONS     = SKILL_TRAINED,
 	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,

--- a/maps/site53/job/jobs/security.dm
+++ b/maps/site53/job/jobs/security.dm
@@ -94,14 +94,14 @@
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_COMPUTER    = SKILL_BASIC,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_TRAINED,
+	                    SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_TRAINED,
 	                    SKILL_HAULING     = SKILL_TRAINED,
-	                    SKILL_FORENSICS   = SKILL_MASTER)
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
-	                    SKILL_FORENSICS   = SKILL_MASTER)
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 	skill_points = 28
 
 /datum/job/ltofficerhcz
@@ -147,7 +147,7 @@
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
-	                    SKILL_FORENSICS   = SKILL_MASTER)
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 	skill_points = 28
 
 /datum/job/ltofficerez
@@ -192,11 +192,11 @@
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
 	                    SKILL_HAULING     = SKILL_TRAINED,
-	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_TRAINED,
 	                    SKILL_EVA         = SKILL_BASIC,
 	                    SKILL_COMBAT      = SKILL_TRAINED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
-	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
+	                    SKILL_FORENSICS   = SKILL_MASTER)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
@@ -254,7 +254,7 @@
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
-	                    SKILL_FORENSICS   = SKILL_MASTER)
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 	skill_points = 20
 
 /datum/job/ncoofficerhcz
@@ -300,7 +300,7 @@
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
-	                    SKILL_FORENSICS   = SKILL_MASTER)
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 	skill_points = 25
 
 /datum/job/ncoofficerez
@@ -341,10 +341,10 @@
 	minimal_access = list()
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
-	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_COMPUTER    = SKILL_TRAINED,
 	                    SKILL_EVA         = SKILL_BASIC,
-	                    SKILL_COMBAT      = SKILL_BASIC,
-	                    SKILL_WEAPONS     = SKILL_BASIC,
+	                    SKILL_COMBAT      = SKILL_TRAINED,
+	                    SKILL_WEAPONS     = SKILL_TRAINED,
 	                    SKILL_FORENSICS   = SKILL_EXPERIENCED)
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
@@ -401,7 +401,7 @@
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
-	                    SKILL_FORENSICS   = SKILL_MASTER)
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 	skill_points = 20
 
 /datum/job/enlistedofficerhcz
@@ -448,7 +448,7 @@
 
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
-	                    SKILL_FORENSICS   = SKILL_MASTER)
+	                    SKILL_FORENSICS   = SKILL_TRAINED)
 	skill_points = 20
 
 /datum/job/enlistedofficerez

--- a/maps/site53/job/jobs/security.dm
+++ b/maps/site53/job/jobs/security.dm
@@ -102,7 +102,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
 	                    SKILL_FORENSICS   = SKILL_TRAINED)
-	skill_points = 28
+	skill_points = 25
 
 /datum/job/ltofficerhcz
 	title = "HCZ Zone Commander"
@@ -148,7 +148,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
 	                    SKILL_FORENSICS   = SKILL_TRAINED)
-	skill_points = 28
+	skill_points = 25
 
 /datum/job/ltofficerez
 	title = "EZ Supervisor"
@@ -201,7 +201,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 28
+	skill_points = 25
 
 //##
 // OFFICERS
@@ -255,7 +255,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_TRAINED)
-	skill_points = 20
+	skill_points = 21
 
 /datum/job/ncoofficerhcz
 	title = "HCZ Sergeant"
@@ -301,7 +301,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_MASTER,
 	                    SKILL_WEAPONS     = SKILL_MASTER,
 	                    SKILL_FORENSICS   = SKILL_TRAINED)
-	skill_points = 25
+	skill_points = 21
 
 /datum/job/ncoofficerez
 	title = "EZ Senior Agent"
@@ -350,7 +350,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 25
+	skill_points = 21
 //##
 //JUNIOR OFFICER
 //##
@@ -402,7 +402,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_TRAINED)
-	skill_points = 20
+	skill_points = 17
 
 /datum/job/enlistedofficerhcz
 
@@ -449,7 +449,7 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_TRAINED)
-	skill_points = 20
+	skill_points = 17
 
 /datum/job/enlistedofficerez
 
@@ -498,5 +498,5 @@
 	max_skill = list(   SKILL_COMBAT      = SKILL_EXPERIENCED,
 	                    SKILL_WEAPONS     = SKILL_EXPERIENCED,
 	                    SKILL_FORENSICS   = SKILL_MASTER)
-	skill_points = 20
+	skill_points = 17
 


### PR DESCRIPTION
## About the Pull Request
Buffed guard skills and lowered minimum age for guards to 20/27/30/35  for Private>Sergeant>Zone Commander>Security Chief Respectively, This also removes forensic skills from LCZ and HCZ as they do not need it. this give LCZ and HCZ minimum CQC to trained
<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because it doesn't make a lot of sense none of the guards are even athletically trained, this also removed foreinsic skills from LCZ and HCZ setting it to basic since they don't need it. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: rebalanced guard skills
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
