### PR TITLE
Buffs Mech Armour/Components, increases mech component cost

### DIFF
--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -18,7 +18,7 @@
 
 	var/speed = 1
 	var/mat_efficiency = 1
-	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
+	var/list/materials = list(MATERIAL_STEEL = 0, MATERIAL_ALUMINIUM = 0, MATERIAL_PLASTIC = 0, MATERIAL_GLASS = 0, MATERIAL_GOLD = 0, MATERIAL_SILVER = 0, MATERIAL_PLASTEEL = 0, MATERIAL_TITANIUM = 0, MATERIAL_PHORON = 0, MATERIAL_URANIUM = 0, MATERIAL_DIAMOND = 0)
 	var/res_max_amount = 200000
 
 	var/datum/research/files
@@ -288,6 +288,10 @@
 			mattype = /obj/item/stack/material/glass
 		if(MATERIAL_ALUMINIUM)
 			mattype = /obj/item/stack/material/aluminium
+		if(MATERIAL_TITANIUM)
+			mattype = /obj/item/stack/material/titanium
+		if(MATERIAL_PLASTEEL)
+			mattype = /obj/item/stack/material/plasteel
 		if(MATERIAL_PLASTIC)
 			mattype = /obj/item/stack/material/plastic
 		if(MATERIAL_GOLD)

--- a/code/modules/mechs/components/armour.dm
+++ b/code/modules/mechs/components/armour.dm
@@ -6,7 +6,7 @@
 	desc = "A pair of flexible armor plates, used to protect the internals of exosuits and its pilot."
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_PISTOL,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
 		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED,
@@ -54,8 +54,8 @@
 	icon_state_broken = "armor_c_broken"
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
-		bullet = ARMOR_BALLISTIC_RESISTANT,
-		laser = ARMOR_LASER_HANDGUNS,
+		bullet = ARMOR_BALLISTIC_RIFLE,
+		laser = ARMOR_LASER_MAJOR,
 		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_SHIELDED

--- a/code/modules/mechs/components/armour.dm
+++ b/code/modules/mechs/components/armour.dm
@@ -21,7 +21,7 @@
 	icon_state = "armor_r"
 	icon_state_broken = "armor_r_broken"
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT,
+		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_PISTOL,
 		laser = ARMOR_LASER_HANDGUNS,
 		energy = ARMOR_ENERGY_MINOR,

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -235,7 +235,7 @@
 	slot_flags = 0
 	default_material = MATERIAL_STEEL
 	base_parry_chance = 0 //Irrelevant for exosuits, revise if this changes
-	max_force = 25
+	max_force = 40 // Should be reworked later to use the materials system and care about the mecha's arm damage, for now 40/20 should do
 	force_multiplier = 0.75 // Equals 20 AP with 25 force
 	unbreakable = TRUE //Else we need a whole system for replacement blades
 	attack_cooldown_modifier = 10

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -235,7 +235,7 @@
 	slot_flags = 0
 	default_material = MATERIAL_STEEL
 	base_parry_chance = 0 //Irrelevant for exosuits, revise if this changes
-	max_force = 40 // Should be reworked later to use the materials system and care about the mecha's arm damage, for now 40/20 should do
+	max_force = 35 // Should be reworked later to use the materials system and care about the mecha's arm damage, for now 35/35 should do
 	force_multiplier = 0.75 // Equals 20 AP with 25 force
 	unbreakable = TRUE //Else we need a whole system for replacement blades
 	attack_cooldown_modifier = 10

--- a/code/modules/mechs/premade/combat.dm
+++ b/code/modules/mechs/premade/combat.dm
@@ -40,16 +40,18 @@
 	name = "combat arms"
 	exosuit_desc_string = "flexible, advanced manipulators"
 	icon_state = "combat_arms"
-	melee_damage = 5
-	action_delay = 10
+	max_damage = 100
+	melee_damage = 30
+	action_delay = 7
 	power_use = 50
 
 /obj/item/mech_component/propulsion/combat
 	name = "combat legs"
 	exosuit_desc_string = "sleek hydraulic legs"
 	icon_state = "combat_legs"
+	max_damage = 110
 	move_delay = 3
-	turn_delay = 3
+	turn_delay = 2
 	power_use = 20
 
 /obj/item/mech_component/sensors/combat
@@ -59,6 +61,7 @@
 	icon_state = "combat_head"
 	vision_flags = SEE_MOBS
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
+	max_damage = 75
 	power_use = 200
 
 /obj/item/mech_component/sensors/combat/prebuild()
@@ -72,6 +75,8 @@
 	pilot_coverage = 100
 	exosuit_desc_string = "an armoured chassis"
 	icon_state = "combat_body"
+	max_damage = 200
+	mech_health = 500
 	power_use = 40
 
 /obj/item/mech_component/chassis/combat/prebuild()
@@ -87,5 +92,5 @@
 			"[WEST]"  = list("x" = 12, "y" = 8)
 		)
 	)
-	
+
 	. = ..()

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -29,9 +29,9 @@
 	exosuit_desc_string = "super-heavy reinforced manipulators"
 	icon_state = "heavy_arms"
 	desc = "Designed to function where any other piece of equipment would have long fallen apart, the Hephaestus Superheavy Lifter series can take a beating and excel at delivering it."
-	melee_damage = 25
+	melee_damage = 50
 	action_delay = 15
-	max_damage = 90
+	max_damage = 200
 	power_use = 60
 
 /obj/item/mech_component/propulsion/heavy
@@ -41,7 +41,7 @@
 	icon_state = "heavy_legs"
 	move_delay = 5
 	turn_delay = 5
-	max_damage = 160
+	max_damage = 250
 	power_use = 100
 
 /obj/item/mech_component/sensors/heavy
@@ -49,7 +49,7 @@
 	exosuit_desc_string = "a reinforced monoeye"
 	desc = "A solitary sensor moves inside a recessed slit in the armour plates."
 	icon_state = "heavy_head"
-	max_damage = 120
+	max_damage = 175
 	power_use = 0
 
 /obj/item/mech_component/sensors/heavy/prebuild()
@@ -64,8 +64,8 @@
 	pilot_coverage = 100
 	exosuit_desc_string = "a heavily armoured chassis"
 	icon_state = "heavy_body"
-	max_damage = 150
-	mech_health = 500
+	max_damage = 300
+	mech_health = 700
 	power_use = 50
 	has_hardpoints = list(HARDPOINT_BACK)
 

--- a/code/modules/mechs/premade/heavy.dm
+++ b/code/modules/mechs/premade/heavy.dm
@@ -50,7 +50,7 @@
 	desc = "A solitary sensor moves inside a recessed slit in the armour plates."
 	icon_state = "heavy_head"
 	max_damage = 175
-	power_use = 0
+	power_use = 50
 
 /obj/item/mech_component/sensors/heavy/prebuild()
 	..()

--- a/code/modules/mechs/premade/light.dm
+++ b/code/modules/mechs/premade/light.dm
@@ -28,9 +28,9 @@
 	name = "light arms"
 	exosuit_desc_string = "lightweight, segmented manipulators"
 	icon_state = "light_arms"
-	melee_damage = 5
-	action_delay = 15
-	max_damage = 40
+	melee_damage = 10
+	action_delay = 5
+	max_damage = 50
 	power_use = 10
 	desc = "As flexible as they are fragile, these Vey-Med manipulators can follow a pilot's movements in close to real time."
 
@@ -40,7 +40,7 @@
 	icon_state = "light_legs"
 	move_delay = 2
 	turn_delay = 3
-	max_damage = 40
+	max_damage = 45
 	power_use = 5
 	desc = "These Odysseus series legs are built from lightweight flexible polymers, making them capable of handling falls from up to 120 meters in 1g environments. Provided that the exosuit lands on its feet."
 	max_fall_damage = 0
@@ -54,7 +54,7 @@
 	gender = PLURAL
 	exosuit_desc_string = "advanced sensor array"
 	icon_state = "light_head"
-	max_damage = 30
+	max_damage = 50
 	vision_flags = SEE_TURFS
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	power_use = 50
@@ -73,7 +73,7 @@
 	hide_pilot = TRUE //Sprite too small, legs clip through, so for now hide pilot
 	exosuit_desc_string = "an open and light chassis"
 	icon_state = "light_body"
-	max_damage = 50
+	max_damage = 75
 	power_use = 5
 	has_hardpoints = list(HARDPOINT_BACK, HARDPOINT_LEFT_SHOULDER)
 	desc = "The Veymed Odysseus series cockpits combine ultralight materials and clear aluminum laminates to provide an optimized cockpit experience."

--- a/code/modules/mechs/premade/misc.dm
+++ b/code/modules/mechs/premade/misc.dm
@@ -3,7 +3,7 @@
 	exosuit_desc_string = "hydraulic quadlegs"
 	desc = "Xion Industrial's arachnid series boasts more leg per leg than the leading competitor."
 	icon_state = "spiderlegs"
-	max_damage = 80
+	max_damage = 90
 	move_delay = 4
 	turn_delay = 1
 	power_use = 25
@@ -27,7 +27,7 @@
 	hide_pilot = TRUE //Sprite too small, legs clip through, so for now hide pilot
 	exosuit_desc_string = "a spherical chassis"
 	icon_state = "pod_body"
-	max_damage = 70
+	max_damage = 90
 	power_use = 5
 	has_hardpoints = list(HARDPOINT_BACK)
 	desc = "The NanoTrasen Katamari series cockpits have won a massive tender by SCG few years back. No one is sure why, but these terrible things keep popping up on every government facility."

--- a/code/modules/mechs/premade/powerloader.dm
+++ b/code/modules/mechs/premade/powerloader.dm
@@ -3,16 +3,16 @@
 	desc = "An ancient, but well-liked cargo handling exosuit."
 
 /mob/living/exosuit/premade/powerloader/Initialize()
-	if(!arms) 
+	if(!arms)
 		arms = new /obj/item/mech_component/manipulators/powerloader(src)
 		arms.color = "#ffbc37"
-	if(!legs) 
+	if(!legs)
 		legs = new /obj/item/mech_component/propulsion/powerloader(src)
 		legs.color = "#ffbc37"
-	if(!head) 
+	if(!head)
 		head = new /obj/item/mech_component/sensors/powerloader(src)
 		head.color = "#ffbc37"
-	if(!body) 
+	if(!body)
 		body = new /obj/item/mech_component/chassis/powerloader(src)
 		body.color = "#ffbc37"
 
@@ -25,7 +25,7 @@
 
 /mob/living/exosuit/premade/powerloader/mechete/Initialize()
 	. = ..()
-	
+
 	if (arms)
 		arms.color = "#6c8aaf"
 	if (legs)
@@ -42,7 +42,7 @@
 /obj/item/mech_component/manipulators/powerloader
 	name = "exosuit arms"
 	exosuit_desc_string = "heavy-duty industrial lifters"
-	max_damage = 70
+	max_damage = 95
 	power_use = 30
 	desc = "The Xion Industrial Digital Interaction Manifolds allow you poke untold dangers from the relative safety of your cockpit."
 
@@ -50,8 +50,8 @@
 	name = "exosuit legs"
 	exosuit_desc_string = "reinforced hydraulic legs"
 	desc = "Wide and stable but not particularly fast."
-	max_damage = 70
-	move_delay = 4
+	max_damage = 80
+	move_delay = 3
 	turn_delay = 4
 	power_use = 10
 
@@ -115,16 +115,16 @@
 	desc = "A mix and match of industrial parts designed to withstand fires."
 
 /mob/living/exosuit/premade/firefighter/New()
-	if(!arms) 
+	if(!arms)
 		arms = new /obj/item/mech_component/manipulators/powerloader(src)
 		arms.color = "#385b3c"
-	if(!legs) 
+	if(!legs)
 		legs = new /obj/item/mech_component/propulsion/powerloader(src)
 		legs.color = "#385b3c"
-	if(!head) 
+	if(!head)
 		head = new /obj/item/mech_component/sensors/powerloader(src)
 		head.color = "#385b3c"
-	if(!body) 
+	if(!body)
 		body = new /obj/item/mech_component/chassis/heavy(src)
 		body.color = "#385b3c"
 

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -161,7 +161,7 @@
 	name = "combat exosuit sensors"
 	id = "combat_head"
 	time = 60
-	materials = list(MATERIAL_TITANIUM = 10000, MATERIAL_SILVER = 5000)
+	materials = list(MATERIAL_TITANIUM = 10000, MATERIAL_SILVER = 2500, MATERIAL_GOLD = 2500)
 	build_path = /obj/item/mech_component/sensors/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -169,7 +169,7 @@
 	name = "combat exosuit chassis"
 	id = "combat_body"
 	time = 60
-	materials = list(MATERIAL_STEEL = 20000, MATERIAL_TITANIUM = 15000, MATERIAL_PLASTEEL = 10000)
+	materials = list(MATERIAL_STEEL = 20000, MATERIAL_TITANIUM = 12500, MATERIAL_PLASTEEL = 10000)
 	build_path = /obj/item/mech_component/chassis/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -253,7 +253,7 @@
 	name = "heavy exosuit sensors"
 	id = "heavy_head"
 	time = 35
-	materials = list(MATERIAL_PLASTEEL = 7500, MATERIAL_URANIUM = 5000)
+	materials = list(MATERIAL_PLASTEEL = 7500, MATERIAL_URANIUM = 3500)
 	build_path = /obj/item/mech_component/sensors/heavy
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -275,7 +275,7 @@
 	name = "heavy exosuit motivators"
 	id = "heavy_legs"
 	time = 35
-	materials = list(MATERIAL_PLASTEEL = 15000, MATERIAL_URANIUM = 5000)
+	materials = list(MATERIAL_PLASTEEL = 15000, MATERIAL_URANIUM = 3500)
 	build_path = /obj/item/mech_component/propulsion/heavy
 
 /datum/design/item/mechfab/exosuit/spider

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -124,7 +124,7 @@
 	id = "mech_armour_basic"
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit
 	time = 30
-	materials = list(MATERIAL_STEEL = 7500)
+	materials = list(MATERIAL_STEEL = 10000)
 
 /datum/design/item/mechfab/exosuit/radproof_armour
 	name = "radiation-proof exosuit armour"
@@ -132,7 +132,7 @@
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/radproof
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 12500)
+	materials = list(MATERIAL_STEEL = 15000)
 
 /datum/design/item/mechfab/exosuit/em_armour
 	name = "EM-shielded exosuit armour"
@@ -140,7 +140,7 @@
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/em
 	time = 50
 	req_tech = list(TECH_MATERIAL = 2)
-	materials = list(MATERIAL_STEEL = 12500, MATERIAL_SILVER = 1000)
+	materials = list(MATERIAL_ALUMINIUM = 7500, MATERIAL_SILVER = 2500)
 
 /datum/design/item/mechfab/exosuit/combat_armour
 	name = "Combat exosuit armour"
@@ -148,7 +148,7 @@
 	build_path = /obj/item/robot_parts/robot_component/armour/exosuit/combat
 	time = 50
 	req_tech = list(TECH_MATERIAL = 4)
-	materials = list(MATERIAL_STEEL = 20000, MATERIAL_DIAMOND = 5000)
+	materials = list(MATERIAL_PLASTEEL = 10000, MATERIAL_DIAMOND = 5000, MATERIAL_URANIUM = 5000)
 
 /datum/design/item/mechfab/exosuit/control_module
 	name = "exosuit control module"
@@ -157,11 +157,19 @@
 	time = 15
 	materials = list(MATERIAL_STEEL = 5000)
 
+/datum/design/item/mechfab/exosuit/combat_head
+	name = "combat exosuit sensors"
+	id = "combat_head"
+	time = 60
+	materials = list(MATERIAL_TITANIUM = 10000, MATERIAL_SILVER = 5000)
+	build_path = /obj/item/mech_component/sensors/combat
+	req_tech = list(TECH_COMBAT = 2)
+
 /datum/design/item/mechfab/exosuit/combat_torso
 	name = "combat exosuit chassis"
 	id = "combat_body"
 	time = 60
-	materials = list(MATERIAL_STEEL = 45000)
+	materials = list(MATERIAL_STEEL = 20000, MATERIAL_TITANIUM = 15000, MATERIAL_PLASTEEL = 10000)
 	build_path = /obj/item/mech_component/chassis/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -169,7 +177,7 @@
 	name = "combat exosuit manipulators"
 	id = "combat_arms"
 	time = 30
-	materials = list(MATERIAL_STEEL = 15000)
+	materials = list(MATERIAL_STEEL = 5000, MATERIAL_TITANIUM = 5000)
 	build_path = /obj/item/mech_component/manipulators/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -177,7 +185,7 @@
 	name = "combat exosuit motivators"
 	id = "combat_legs"
 	time = 30
-	materials = list(MATERIAL_STEEL = 15000)
+	materials = list(MATERIAL_STEEL = 10000, MATERIAL_TITANIUM = 7500)
 	build_path = /obj/item/mech_component/propulsion/combat
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -186,34 +194,34 @@
 	id = "powerloader_head"
 	build_path = /obj/item/mech_component/sensors/powerloader
 	time = 15
-	materials = list(MATERIAL_STEEL = 5000)
+	materials = list(MATERIAL_STEEL = 7500)
 
 /datum/design/item/mechfab/exosuit/powerloader_torso
 	name = "power loader chassis"
 	id = "powerloader_body"
 	build_path = /obj/item/mech_component/chassis/powerloader
 	time = 50
-	materials = list(MATERIAL_STEEL = 20000)
+	materials = list(MATERIAL_STEEL = 25000)
 
 /datum/design/item/mechfab/exosuit/powerloader_arms
 	name = "power loader manipulators"
 	id = "powerloader_arms"
 	build_path = /obj/item/mech_component/manipulators/powerloader
 	time = 30
-	materials = list(MATERIAL_STEEL = 6000)
+	materials = list(MATERIAL_STEEL = 5000)
 
 /datum/design/item/mechfab/exosuit/powerloader_legs
 	name = "power loader motivators"
 	id = "powerloader_legs"
 	build_path = /obj/item/mech_component/propulsion/powerloader
 	time = 30
-	materials = list(MATERIAL_STEEL = 6000)
+	materials = list(MATERIAL_STEEL = 7500)
 
 /datum/design/item/mechfab/exosuit/light_head
 	name = "light exosuit sensors"
 	id = "light_head"
 	time = 20
-	materials = list(MATERIAL_STEEL = 8000)
+	materials = list(MATERIAL_ALUMINIUM = 7500, MATERIAL_PLASTIC = 5000)
 	build_path = /obj/item/mech_component/sensors/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -221,7 +229,7 @@
 	name = "light exosuit chassis"
 	id = "light_body"
 	time = 40
-	materials = list(MATERIAL_STEEL = 30000)
+	materials = list(MATERIAL_ALUMINIUM = 15000, MATERIAL_PLASTIC = 7500)
 	build_path = /obj/item/mech_component/chassis/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -229,7 +237,7 @@
 	name = "light exosuit manipulators"
 	id = "light_arms"
 	time = 20
-	materials = list(MATERIAL_STEEL = 10000)
+	materials = list(MATERIAL_ALUMINIUM = 5000, MATERIAL_PLASTIC = 2500)
 	build_path = /obj/item/mech_component/manipulators/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -237,7 +245,7 @@
 	name = "light exosuit motivators"
 	id = "light_legs"
 	time = 25
-	materials = list(MATERIAL_STEEL = 10000)
+	materials = list(MATERIAL_ALUMINIUM = 7500, MATERIAL_PLASTIC = 2500)
 	build_path = /obj/item/mech_component/propulsion/light
 	req_tech = list(TECH_MATERIAL = 1)
 
@@ -245,7 +253,7 @@
 	name = "heavy exosuit sensors"
 	id = "heavy_head"
 	time = 35
-	materials = list(MATERIAL_STEEL = 16000)
+	materials = list(MATERIAL_PLASTEEL = 7500, MATERIAL_URANIUM = 5000)
 	build_path = /obj/item/mech_component/sensors/heavy
 	req_tech = list(TECH_COMBAT = 2)
 
@@ -253,28 +261,28 @@
 	name = "heavy exosuit chassis"
 	id = "heavy_body"
 	time = 75
-	materials = list(MATERIAL_STEEL = 70000, MATERIAL_URANIUM = 10000)
+	materials = list(MATERIAL_PLASTEEL = 35000, MATERIAL_URANIUM = 15000)
 	build_path = /obj/item/mech_component/chassis/heavy
 
 /datum/design/item/mechfab/exosuit/heavy_arms
 	name = "heavy exosuit manipulators"
 	id = "heavy_arms"
 	time = 35
-	materials = list(MATERIAL_STEEL = 20000)
+	materials = list(MATERIAL_PLASTEEL = 15000, MATERIAL_URANIUM = 2500)
 	build_path = /obj/item/mech_component/manipulators/heavy
 
 /datum/design/item/mechfab/exosuit/heavy_legs
 	name = "heavy exosuit motivators"
 	id = "heavy_legs"
 	time = 35
-	materials = list(MATERIAL_STEEL = 20000)
+	materials = list(MATERIAL_PLASTEEL = 15000, MATERIAL_URANIUM = 5000)
 	build_path = /obj/item/mech_component/propulsion/heavy
 
 /datum/design/item/mechfab/exosuit/spider
 	name = "quadruped motivators"
 	id = "quad_legs"
 	time = 20
-	materials = list(MATERIAL_STEEL = 12000)
+	materials = list(MATERIAL_TITANIUM = 7500, MATERIAL_ALUMINIUM = 2500)
 	build_path = /obj/item/mech_component/propulsion/spider
 	req_tech = list(TECH_ENGINEERING = 2)
 
@@ -282,7 +290,7 @@
 	name = "armored treads"
 	id = "treads"
 	time = 35
-	materials = list(MATERIAL_STEEL = 25000)
+	materials = list(MATERIAL_PLASTEEL = 10000, MATERIAL_STEEL = 7500)
 	build_path = /obj/item/mech_component/propulsion/tracks
 	req_tech = list(TECH_MATERIAL = 4)
 
@@ -291,7 +299,7 @@
 	id = "sphere_body"
 	build_path = /obj/item/mech_component/chassis/pod
 	time = 50
-	materials = list(MATERIAL_STEEL = 18000)
+	materials = list(MATERIAL_STEEL = 12500, MATERIAL_ALUMINIUM = 5000)
 
 /datum/design/item/robot_upgrade
 	build_type = MECHFAB
@@ -477,7 +485,7 @@
 	name = "plasteel mech shield"
 	id = "mech_shield_ballistic"
 	time = 45
-	materials = list(MATERIAL_STEEL = 40000, MATERIAL_ALUMINIUM = 5000)
+	materials = list(MATERIAL_STEEL = 10000, MATERIAL_PLASTEEL = 10000)
 	req_tech = list(TECH_MATERIAL = 3)
 	build_path = /obj/item/mech_equipment/ballistic_shield
 


### PR DESCRIPTION
## About the Pull Request

Increases the durability and armour of light, heavy, combat, PL and misc mecha components. Increases mecha's combat armour to block rifle rounds, because a tankette having less armour then a personal plate carrier doesn't make sense.

Makes mecha's useful for fighting people with rifles! It's not logical that the army/Foundation would invest RnD resources/budget into a vehicle class that's primarily a fighter (heavy/combat mecha's only carry 1 person) and yet can't fight anyone that's using rifle ammo. Mecha's should be nigh-immune to most pistols and heavily resistant to rifles.

## Why It's Good For The Game

Increases construction costs for high-end mecha while improving the reward of owning a high-end mecha. Hopefully makes mecha's not irrelevant the second a class D gets their hands on an actual gun. You won't be invincible, however, as a skilled gunperson can aim for the weaker mecha's limbs/head to cripple it.

Increases the damage output on mecha's arms, because, c'mon. A pair of reinforced plasteel knuckles should do more then **5** damage FFS, mecha arms don't have any armour pen AFAIK so I've increased that a little.

(You can cripple a heavy mecha for about 35 M16 rounds, bear in mind heavy mecha's move at a snail's pace and M16's are somewhat common and fire at full-auto.) [Currently, you can _destroy_ a heavy mecha for around 15 M16 rounds.]

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Buffs mecha's components and armour to be worth using against riflepeople! Buffs mecha's melee output to be... more usable against any target. Buffs high-end (combat, heavy) mecha costs for obvious reasons. Also, adds the combat sensors module to the exofab because it was oddly missing.
/:cl:
