### PR TITLE
Fix shrapnel shot from

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -290,6 +290,10 @@
 
 		process_accuracy(projectile, user, target, i, held_twohanded)
 
+		var/obj/item/projectile/P = projectile
+		if(istype(P)) // only for real projectiles
+			P.shot_from = src.name
+
 		if(pointblank)
 			process_point_blank(projectile, user, target)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -364,7 +364,7 @@
 	if(shrapnel_type)
 		var/obj/item/SP = new shrapnel_type()
 		SP.SetName((name != "shrapnel")? "[name] shrapnel" : "shrapnel")
-		SP.desc += " It looks like it was fired from [shot_from]."
+		SP.desc += " It looks like it was fired from \the [shot_from]."
 		return SP
 
 /obj/item/projectile/proc/old_style_target(atom/target, atom/source)


### PR DESCRIPTION
## About the Pull Request

title

## Why It's Good For The Game

shrapnel is worth removing now

## Changelog

:cl:
fix: Shrapnel now displays what gun it was shot from.
/:cl: