### PR TITLE
Fix SCP-049 skills

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -38,7 +38,6 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	return
 /mob/living/carbon/human/scp049/New(new_loc, new_species)
 	new_species = "SCP-049"
-
 	return ..()
 
 /mob/living/carbon/human/scp049/Initialize()
@@ -70,7 +69,6 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	return ..()
 
 /mob/living/carbon/human/scp049/proc/init_049_skills()
-
 	skillset.skill_list = list()
 	for(var/decl/hierarchy/skill/S in GLOB.skills)
 		skillset.skill_list[S.type] = SKILL_TRAINED

--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -38,7 +38,8 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	return
 /mob/living/carbon/human/scp049/New(new_loc, new_species)
 	new_species = "SCP-049"
-	return  ..()
+
+	return ..()
 
 /mob/living/carbon/human/scp049/Initialize()
 	// fix names
@@ -56,7 +57,10 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 		/mob/living/carbon/human/scp049/proc/Im_here_to_cure_you,
 		/mob/living/carbon/human/scp049/proc/cure_action,
 	))
-	return ..()
+
+	. = ..()
+
+	init_049_skills()
 
 /mob/living/carbon/human/scp049/Destroy()
 	pestilence_images = null
@@ -64,6 +68,21 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 	target = null
 	GLOB.scp049s -= src
 	return ..()
+
+/mob/living/carbon/human/scp049/proc/init_049_skills()
+
+	skillset.skill_list = list()
+	for(var/decl/hierarchy/skill/S in GLOB.skills)
+		skillset.skill_list[S.type] = SKILL_TRAINED
+	skillset.skill_list[SKILL_HAULING] = SKILL_MASTER
+	skillset.skill_list[SKILL_COMBAT] = SKILL_EXPERIENCED // Let him fight back a tiny bit, yeah?
+	skillset.skill_list[SKILL_WEAPONS] = SKILL_BASIC // I surmise he isn't good with guns, though
+	// He's been doing this for a while, he should know his stuff
+	skillset.skill_list[SKILL_ANATOMY] = SKILL_MASTER
+	skillset.skill_list[SKILL_CHEMISTRY] = SKILL_MASTER
+	skillset.skill_list[SKILL_MEDICAL] = SKILL_MASTER
+	skillset.skill_list[SKILL_SCIENCE] = SKILL_EXPERIENCED
+	skillset.on_levels_change()
 
 /mob/living/carbon/human/scp049/Life()
 	. = ..()

--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -71,14 +71,14 @@ GLOBAL_LIST_EMPTY(scp049_1s)
 /mob/living/carbon/human/scp049/proc/init_049_skills()
 	skillset.skill_list = list()
 	for(var/decl/hierarchy/skill/S in GLOB.skills)
-		skillset.skill_list[S.type] = SKILL_TRAINED
+		skillset.skill_list[S.type] = SKILL_UNTRAINED
+	skillset.skill_list[SKILL_COOKING] = SKILL_TRAINED
+	skillset.skill_list[SKILL_BOTANY] = SKILL_TRAINED
 	skillset.skill_list[SKILL_HAULING] = SKILL_MASTER
-	skillset.skill_list[SKILL_COMBAT] = SKILL_EXPERIENCED // Let him fight back a tiny bit, yeah?
-	skillset.skill_list[SKILL_WEAPONS] = SKILL_BASIC // I surmise he isn't good with guns, though
-	// He's been doing this for a while, he should know his stuff
-	skillset.skill_list[SKILL_ANATOMY] = SKILL_MASTER
-	skillset.skill_list[SKILL_CHEMISTRY] = SKILL_MASTER
-	skillset.skill_list[SKILL_MEDICAL] = SKILL_MASTER
+	skillset.skill_list[SKILL_COMBAT] = SKILL_EXPERIENCED
+	skillset.skill_list[SKILL_ANATOMY] = SKILL_EXPERIENCED
+	skillset.skill_list[SKILL_CHEMISTRY] = SKILL_BASIC
+	skillset.skill_list[SKILL_MEDICAL] = SKILL_EXPERIENCED
 	skillset.skill_list[SKILL_SCIENCE] = SKILL_EXPERIENCED
 	skillset.on_levels_change()
 


### PR DESCRIPTION
## About the Pull Request

Fixes SCP-049 being unskilled, giving him unrivalled skill in the medical arts, as well as decent skills in science and melee combat

## Why It's Good For The Game

Fixes #725

## Changelog

:cl:
fix: SCP-049 has skills now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Skills:
Master: Athletics
Experienced: Combat, Medicine, Anatomy, Science
Trained: Cooking, Botany
Basic: Chemistry