### PR TITLE
Add Holopad on all maps

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -16979,9 +16979,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad{
-	pixel_y = -15
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip)
 "UT" = (

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -954,6 +954,7 @@
 	dir = 6
 	},
 /obj/effect/catwalk_plated/white,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "cQ" = (
@@ -2943,6 +2944,7 @@
 	dir = 6
 	},
 /obj/effect/catwalk_plated/white,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "hX" = (
@@ -3110,6 +3112,7 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated/white,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "io" = (
@@ -7265,6 +7268,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/recreationhallway)
+"ss" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/dclass/cellbubble)
 "st" = (
 /obj/effect/landmark{
 	name = "scp420j"
@@ -7355,6 +7362,10 @@
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/titanium,
 /area/site53/lhcz/scp895)
+"sG" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood/walnut,
+/area/site53/lowertram/archive)
 "sH" = (
 /obj/structure/closet/coffin/scp895,
 /obj/structure/table/steel_reinforced,
@@ -9615,6 +9626,10 @@
 	name = "vinyl wooden floor"
 	},
 /area/site53/llcz/dclass/luxuryhall)
+"yW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/entrance_checkpoint)
 "yX" = (
 /obj/structure/sign/scp/dclass{
 	pixel_x = 32
@@ -10928,6 +10943,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
+"CV" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/site53/lhcz/scp049containment)
 "CW" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11280,6 +11299,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/recreationhallway)
+"DP" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/scp8containment)
 "DR" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
@@ -11493,6 +11516,14 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkpointoverlook)
+"Ew" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/lightgrey/border,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/reeducation)
 "Ex" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12352,6 +12383,10 @@
 "Hf" = (
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/prep)
+"Hh" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/purple,
+/area/site53/lowertram/archive)
 "Hi" = (
 /obj/machinery/camera/network/lcz{
 	dir = 4
@@ -14783,6 +14818,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/llcz/dclass/medicalpost/surgery)
 "Oa" = (
@@ -14915,6 +14951,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
 "Oy" = (
@@ -15704,6 +15741,10 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/lhcz/scp049containment)
+"QS" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/dclass/assignmentbubble)
 "QT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16160,6 +16201,10 @@
 /obj/structure/bed/roller,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
+"Ss" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lhcz/scp1102room)
 "St" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16373,6 +16418,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentbubble)
+"SZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/checkpointoverlook)
 "Ta" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/steel/fifty,
@@ -16921,6 +16972,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/luxurysleep)
+"US" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad{
+	pixel_y = -15
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/checkequip)
 "UT" = (
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/titanium,
@@ -17693,6 +17756,11 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/assignmentbubble)
+"Xp" = (
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/site53/uhcz/scp8containment)
 "Xv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/bed/roller,
@@ -25832,7 +25900,7 @@ Iw
 Iv
 hT
 IH
-QZ
+yW
 IN
 YX
 hy
@@ -32280,7 +32348,7 @@ cY
 XE
 zX
 zX
-zX
+ss
 zX
 zX
 XE
@@ -32821,7 +32889,7 @@ HE
 Ia
 iQ
 SY
-lS
+QS
 aq
 gM
 gq
@@ -34061,7 +34129,7 @@ dt
 eA
 pQ
 tv
-pQ
+SZ
 uC
 pQ
 pQ
@@ -34309,7 +34377,7 @@ JO
 dk
 GV
 kY
-kY
+US
 WF
 kY
 CX
@@ -36871,7 +36939,7 @@ Im
 ja
 lV
 JO
-Jx
+Ew
 JO
 JF
 lG
@@ -47135,7 +47203,7 @@ aj
 ah
 fK
 aJ
-ah
+sG
 ah
 cm
 ah
@@ -47145,7 +47213,7 @@ al
 gO
 Bw
 ta
-uk
+Hh
 gJ
 ah
 Cy
@@ -66381,7 +66449,7 @@ gq
 gq
 sJ
 Xf
-zo
+Ss
 Af
 Av
 AK
@@ -71248,7 +71316,7 @@ gq
 gq
 SV
 MB
-on
+CV
 oO
 SV
 SV
@@ -73590,7 +73658,7 @@ NN
 oZ
 pe
 MW
-MW
+Xp
 MW
 pe
 TY
@@ -75641,7 +75709,7 @@ xe
 ux
 zQ
 zl
-zl
+DP
 Rb
 Vi
 qX

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -4662,6 +4662,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "alD" = (
@@ -10589,6 +10590,7 @@
 /area/site53/lowertrams/orangeline)
 "ayB" = (
 /obj/effect/floor_decal/industrial/warning/corner,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lowertrams/orangeline)
 "ayC" = (
@@ -13267,6 +13269,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "aEP" = (
@@ -15690,6 +15693,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/effect/catwalk_plated/white,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aLf" = (
@@ -15763,6 +15767,7 @@
 "aLp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/catwalk_plated/dark,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/plating,
 /area/site53/upper_surface/serverfarmcontrol)
 "aLq" = (
@@ -18457,6 +18462,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
+"aTk" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/scp012)
 "aTm" = (
 /obj/machinery/door/airlock/glass/civilian{
 	name = "Kitchen"
@@ -23376,6 +23385,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated/white,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "bhI" = (
@@ -24707,6 +24717,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"bBW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "bCi" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -24781,6 +24795,10 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"bRG" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/generalpurpose2)
 "bRL" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/fifty,
@@ -25050,6 +25068,10 @@
 /obj/structure/closet/secure_closet/mtf/riotshotguns,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/armory)
+"cnW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/engineering/controlroom)
 "cof" = (
 /obj/machinery/recharge_station,
 /obj/machinery/camera/network/hcz{
@@ -25694,6 +25716,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
 "dKX" = (
@@ -25814,6 +25837,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"edv" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/site53/lowertrams/escape)
 "eel" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25859,6 +25886,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"eiU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/engineering/storage)
 "emM" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -26169,6 +26203,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/south)
+"fdN" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/scp106observ)
 "fdX" = (
 /obj/machinery/light/spot,
 /obj/structure/railing/mapped{
@@ -26359,6 +26397,10 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"fuX" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/medicalpost)
 "fva" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27090,6 +27132,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"gWo" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/vacant/prototype/control)
 "gWI" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -27144,6 +27190,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
+"hdJ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "heG" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/xenobiology)
@@ -27468,6 +27518,13 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
+"hOJ" = (
+/obj/machinery/camera/autoname{
+	network = list("Light Containment Zone Network");
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/scp263research)
 "hOP" = (
 /obj/machinery/camera/network/lcz,
 /obj/structure/closet/hydrant{
@@ -27827,6 +27884,11 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"iJL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/site53/lowertrams/brownline)
 "iKH" = (
 /obj/machinery/camera/autoname{
 	name = "SCP-247 Containment"
@@ -27857,6 +27919,15 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertrams/orangeline)
+"iOX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/reswing/robotics)
 "iRn" = (
 /obj/machinery/computer/upload/robot{
 	dir = 4
@@ -27877,6 +27948,7 @@
 /area/site53/lhcz/hczguardgear)
 "iTk" = (
 /obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/hczguardgear)
 "iUm" = (
@@ -28069,6 +28141,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
+"jmQ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp999)
 "jmX" = (
 /obj/machinery/door/airlock/glass/science{
 	name = "SCP-066 Containment Chamber";
@@ -28283,6 +28359,16 @@
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
 /area/site53/ulcz/generalpurpose)
+"jNG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/engineering/primaryhallway)
 "jOV" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -28613,6 +28699,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
+"kDD" = (
+/obj/machinery/hologram/holopad/longrange{
+	name = "AIC holopad"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/science/aicobservation)
 "kEw" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/techmaint,
@@ -29360,6 +29452,15 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"lWU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/site53/lowertrams/redline)
 "lXl" = (
 /obj/structure/hygiene/drain,
 /obj/machinery/light{
@@ -29661,6 +29762,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/surface/explorers/surrounding)
+"msC" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "mtc" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
@@ -29752,6 +29857,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
+"mBw" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "mDz" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-078";
@@ -30015,6 +30124,12 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/scp096)
+"neg" = (
+/obj/machinery/hologram/holopad{
+	pixel_x = 16
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "ngk" = (
 /obj/effect/floor_decal/corner/orange/mono,
 /obj/machinery/computer/guestpass{
@@ -30054,6 +30169,13 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"njj" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/engineering/atmos)
 "nks" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/combat,
@@ -30386,6 +30508,16 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"oei" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "oeP" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -30423,6 +30555,10 @@
 /obj/item/device/radio/phone,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
+"oky" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/engineering/primaryhallway)
 "ome" = (
 /obj/structure/sign/warning/secure_area{
 	pixel_y = 32
@@ -31217,6 +31353,13 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"qbX" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/upper_surface/serverfarmcontrol)
 "qfC" = (
 /obj/structure/window/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -31311,6 +31454,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
+"qnO" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "qoe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31865,6 +32012,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "rEG" = (
@@ -31973,6 +32121,10 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"rSP" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/surface/bunker)
 "rWa" = (
 /obj/structure/table/standard,
 /obj/machinery/camera/network/hcz{
@@ -31983,6 +32135,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
+"rWA" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/scp513)
 "rXl" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -32080,6 +32236,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
+"sec" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/lhcz/scp343entrance)
 "sek" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Checkpoint holding cell";
@@ -32166,6 +32330,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
+"slp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/engineering/engine_smes)
 "sme" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -32396,6 +32569,10 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
+"sVz" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lhcz/scp035room)
 "sWz" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -32418,6 +32595,13 @@
 /obj/item/storage/slide_projector,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"taz" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/reswing/robotics)
 "taB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -32496,6 +32680,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/engine_smes)
+"tjW" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/lino,
+/area/site53/lowertrams/restaurantkitchenarea)
+"tkI" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/engineering/containment_engineer)
 "tmK" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32625,6 +32822,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertrams/orangeline)
+"twW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/ulcz/generalpurpose)
 "tyU" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -32816,6 +33017,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"uaR" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/site53/reswing/xenobiology)
 "ubf" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32879,6 +33084,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"udQ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/hallways)
 "ugg" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Red Line";
@@ -33318,6 +33527,10 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"vhE" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/scp263research)
 "viG" = (
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor{
@@ -33578,6 +33791,10 @@
 /obj/machinery/reagent_temperature,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"vGz" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/scp096)
 "vGY" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -33790,6 +34007,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"vWZ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
 "vXh" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -33833,6 +34054,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uhcz/medicalpost)
+"vYz" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/lowertrams/restaurantkitchenarea)
 "vZy" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -34327,6 +34552,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "wVL" = (
@@ -35013,6 +35239,7 @@
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "ykA" = (
@@ -36960,7 +37187,7 @@ aGM
 aGM
 aGM
 aGM
-aGM
+vWZ
 aGM
 aGM
 aGM
@@ -39072,7 +39299,7 @@ hBR
 hBR
 hBR
 pTk
-aNo
+hdJ
 aNo
 agU
 azA
@@ -39313,7 +39540,7 @@ aDO
 asA
 pXS
 aDO
-aDO
+mBw
 bgF
 bgK
 bgS
@@ -40643,7 +40870,7 @@ aVH
 aES
 pjO
 wzX
-hRZ
+twW
 vtX
 jNc
 azA
@@ -40845,7 +41072,7 @@ aTM
 aMS
 aMS
 aMS
-aMS
+neg
 aMS
 aMS
 aMS
@@ -42965,7 +43192,7 @@ aNf
 aNf
 aNf
 aUZ
-aNf
+jmQ
 aNf
 aNE
 bdf
@@ -45069,7 +45296,7 @@ bpN
 swJ
 bpN
 bpN
-bpN
+vhE
 nzv
 mtc
 aXA
@@ -45330,7 +45557,7 @@ aXA
 xjx
 nzv
 aim
-aXo
+hOJ
 bdb
 aXA
 azA
@@ -45878,7 +46105,7 @@ akx
 apy
 aqB
 aqB
-aqB
+gWo
 aqB
 atw
 awX
@@ -46390,7 +46617,7 @@ azA
 aaD
 ajg
 akZ
-akZ
+tkI
 akI
 alz
 alB
@@ -47666,7 +47893,7 @@ aPp
 aWK
 afp
 afp
-afp
+oei
 aXg
 aXn
 aXn
@@ -47677,7 +47904,7 @@ bda
 aXw
 bix
 bix
-bix
+bRG
 bix
 xaC
 aXp
@@ -49699,7 +49926,7 @@ aWn
 jIl
 cNi
 mpT
-ags
+aTk
 fhv
 aVS
 aGM
@@ -49793,7 +50020,7 @@ aBe
 aqj
 ajI
 ayl
-aLF
+slp
 aPc
 aAb
 aoi
@@ -51338,7 +51565,7 @@ anr
 amu
 anr
 apk
-apk
+cnW
 anr
 apk
 apk
@@ -51810,7 +52037,7 @@ azA
 aMd
 aTW
 aJM
-aJM
+msC
 aKC
 aMy
 aJM
@@ -54374,7 +54601,7 @@ azA
 aFN
 dwQ
 jpc
-jpc
+rWA
 jpc
 jpc
 dwJ
@@ -57585,7 +57812,7 @@ asM
 aui
 auL
 auR
-avA
+eiU
 awN
 auL
 auL
@@ -59574,7 +59801,7 @@ aey
 aey
 aey
 aey
-aey
+iJL
 ayO
 aey
 aey
@@ -63299,7 +63526,7 @@ azA
 azA
 aax
 amW
-asj
+jNG
 auA
 arz
 asH
@@ -63567,7 +63794,7 @@ atD
 atD
 avg
 avg
-aww
+njj
 axq
 axt
 azk
@@ -66026,7 +66253,7 @@ aOW
 aOW
 tnJ
 aOW
-aOW
+kDD
 aOW
 aSH
 aTg
@@ -66661,7 +66888,7 @@ abU
 aCT
 aqS
 xoe
-xoe
+qbX
 xoe
 aSg
 aCT
@@ -66704,7 +66931,7 @@ aFy
 apV
 aGn
 aoh
-aoh
+oky
 aFl
 aIZ
 agH
@@ -67885,7 +68112,7 @@ iaF
 fKV
 abv
 acZ
-adt
+tjW
 ahR
 aav
 aSz
@@ -69470,7 +69697,7 @@ afO
 afO
 afO
 afO
-afO
+edv
 afO
 afO
 afO
@@ -69925,7 +70152,7 @@ aJd
 aIi
 afg
 aeQ
-abC
+taz
 abC
 abC
 obm
@@ -70195,7 +70422,7 @@ ahc
 aJA
 ebG
 aJn
-aKd
+iOX
 aJn
 aBn
 aBn
@@ -70476,7 +70703,7 @@ qgn
 abf
 abf
 abf
-abf
+vYz
 abf
 abf
 aLR
@@ -72575,7 +72802,7 @@ aFq
 aFq
 aFq
 aFr
-aFq
+lWU
 aFq
 aGd
 aFq
@@ -74720,7 +74947,7 @@ lDl
 aSO
 dyu
 nAG
-nWT
+rSP
 nWT
 oCa
 rCd
@@ -75650,7 +75877,7 @@ afX
 aMn
 aMn
 aMn
-aMn
+uaR
 aMn
 aMn
 bTl
@@ -79584,7 +79811,7 @@ aBC
 aBC
 aBC
 lAo
-nNb
+vGz
 nNb
 paF
 bdi
@@ -86896,7 +87123,7 @@ azA
 aZF
 aZK
 aZT
-aZT
+sVz
 bad
 bai
 baq
@@ -87118,7 +87345,7 @@ azA
 azA
 aBs
 xti
-ahS
+fdN
 aBd
 aBc
 ceF
@@ -91046,7 +91273,7 @@ aip
 aip
 aBU
 aBU
-aBU
+udQ
 aBU
 rHu
 aDA
@@ -92585,7 +92812,7 @@ azA
 aki
 akr
 baH
-baH
+sec
 baH
 bbh
 bbn
@@ -93930,7 +94157,7 @@ bjL
 biT
 biT
 biT
-biT
+fuX
 biT
 aGC
 atV
@@ -97029,7 +97256,7 @@ gID
 gID
 gID
 bhS
-rrU
+qnO
 bjw
 gID
 mBg
@@ -98087,7 +98314,7 @@ rrA
 quy
 taB
 xoD
-fUI
+bBW
 yew
 rrA
 azA

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -9987,10 +9987,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/atmos)
-"axr" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/engineering/atmos)
 "axs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
@@ -30125,9 +30121,7 @@
 /turf/simulated/floor,
 /area/site53/uhcz/scp096)
 "neg" = (
-/obj/machinery/hologram/holopad{
-	pixel_x = 16
-	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "ngk" = (
@@ -63275,7 +63269,7 @@ aua
 ave
 awf
 aww
-axr
+atr
 ays
 azi
 aDj

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -3862,6 +3862,7 @@
 /obj/machinery/camera/network/medbay{
 	c_tag = "Psychiatrist's Office"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "kT" = (
@@ -3999,6 +4000,7 @@
 /obj/effect/floor_decal/corner/orange/bordercorner{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "ll" = (
@@ -5166,6 +5168,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
 "oS" = (
@@ -5410,6 +5413,10 @@
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
+"pX" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "qa" = (
 /obj/structure/bed/chair,
 /obj/structure/cable{
@@ -5715,6 +5722,7 @@
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
 "rx" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
 "ry" = (
@@ -6979,6 +6987,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
+"we" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "wj" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -7365,6 +7377,10 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"zV" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/surgery/op2)
 "Ac" = (
 /obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/clothing/suit/bio_suit/security,
@@ -7430,6 +7446,10 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
+"Ba" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/surgery/op1)
 "Bc" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
@@ -7481,6 +7501,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"BM" = (
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 8
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/uez/goirepoffice)
 "BO" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -7591,6 +7618,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
 "Cq" = (
@@ -7757,6 +7785,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"EJ" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/equipmentroom)
 "ET" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -7796,6 +7828,11 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/maintenance/surfaceeast)
+"Fm" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/site53/surface/cryogenicsprimary)
 "Fs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -7856,6 +7893,10 @@
 "Go" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
+"Gt" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmreception)
 "Gv" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -7956,6 +7997,10 @@
 /obj/structure/iv_drip,
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
+"Hx" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/sleeper)
 "HG" = (
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/half{
@@ -8064,6 +8109,10 @@
 /obj/item/stool,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"IW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/exam_room)
 "Jc" = (
 /obj/item/clothing/suit/storage/toggle/fr_jacket,
 /obj/item/clothing/suit/storage/toggle/fr_jacket/ems,
@@ -8276,6 +8325,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
+"Ml" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/senioragentoffice)
 "Mq" = (
 /obj/effect/paint_stripe/red,
 /obj/effect/paint_stripe/red,
@@ -8501,6 +8554,10 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/tramhubhallwayentry)
+"Qh" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/logistics/logistics)
 "Qi" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/pine,
@@ -9220,6 +9277,11 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
+"Yz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/dark,
+/area/site53/medical/morgue)
 "YH" = (
 /obj/structure/morgue,
 /obj/machinery/light{
@@ -9271,6 +9333,10 @@
 /obj/machinery/camera/network/entrance,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
+"Zy" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/site53/logistics/logistics)
 "ZG" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -12746,7 +12812,7 @@ dA
 ty
 XM
 tB
-tB
+we
 tB
 Ky
 Ac
@@ -14810,7 +14876,7 @@ aQ
 oZ
 tf
 tk
-tB
+we
 ts
 ty
 dA
@@ -33123,7 +33189,7 @@ oV
 uQ
 uQ
 vr
-uQ
+Qh
 uQ
 uQ
 Vi
@@ -33365,7 +33431,7 @@ zO
 qF
 nk
 nk
-nk
+Zy
 nk
 qS
 nk
@@ -35587,7 +35653,7 @@ gX
 eH
 ky
 ky
-ky
+Yz
 ky
 ky
 ky
@@ -37374,7 +37440,7 @@ fH
 iw
 Sd
 iw
-iw
+IW
 iw
 iw
 ir
@@ -38669,7 +38735,7 @@ iX
 Qm
 cm
 ka
-ks
+Gt
 ks
 kr
 li
@@ -39431,7 +39497,7 @@ gT
 cS
 dd
 cZ
-cZ
+Hx
 cZ
 cZ
 iA
@@ -39753,7 +39819,7 @@ Ff
 bs
 vx
 vx
-vx
+Fm
 vx
 vx
 qW
@@ -39970,7 +40036,7 @@ cq
 Ce
 mk
 Mx
-UI
+BM
 UI
 qA
 mk
@@ -40464,7 +40530,7 @@ im
 im
 im
 dI
-iX
+pX
 gU
 fD
 dA
@@ -40751,7 +40817,7 @@ px
 px
 MX
 RJ
-Zn
+EJ
 Xq
 hp
 dE
@@ -41229,7 +41295,7 @@ dA
 dA
 Vm
 hk
-hy
+Ba
 hN
 hy
 io
@@ -42550,7 +42616,7 @@ mu
 Jt
 tL
 Zn
-Zn
+EJ
 SL
 UE
 MX
@@ -43542,7 +43608,7 @@ dA
 dA
 gO
 gJ
-ew
+zV
 me
 ew
 jZ
@@ -43584,7 +43650,7 @@ tX
 tQ
 nn
 Xu
-Xu
+Ml
 nL
 lC
 fx

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -1806,6 +1806,7 @@
 	dir = 1;
 	network = list("Entrance Zone Network")
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/red,
 /area/site53/uez/hallway)
 "fp" = (
@@ -2307,6 +2308,7 @@
 /turf/simulated/floor/carpet/orange,
 /area/site53/uez/hallway)
 "gz" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/orange,
 /area/site53/uez/hallway)
 "gA" = (
@@ -3576,6 +3578,14 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"ml" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
+/area/site53/uez/conference)
+"mn" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/upper_surface/commstower)
 "ms" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 1
@@ -3718,6 +3728,7 @@
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
 "rG" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
 "rI" = (
@@ -3882,6 +3893,10 @@
 /obj/item/clothing/gloves/forensic,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
+"wX" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood/mahogany,
+/area/site53/uez/hallway)
 "xa" = (
 /obj/effect/floor_decal/corner/red/bordercee{
 	dir = 8
@@ -3942,6 +3957,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroom)
+"zB" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/hallway)
 "zE" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -4076,6 +4095,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
+"DD" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/hallway)
 "DH" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
@@ -4254,6 +4277,10 @@
 /obj/item/stamp/approved,
 /obj/item/stamp/denied,
 /obj/item/stamp/cargo,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/logistics/logisticsofficer)
+"Ka" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
 "KA" = (
@@ -4490,6 +4517,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"RW" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/wood,
+/area/site53/uez/canteen)
 "Sh" = (
 /obj/machinery/light{
 	dir = 4;
@@ -4513,6 +4544,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroom)
+"Ta" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/green,
+/area/site53/uez/hallway)
 "Tg" = (
 /obj/effect/floor_decal/corner/orange/border,
 /obj/structure/closet/crate/bin{
@@ -4578,6 +4613,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"Vq" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/logistics/logisticsbreak)
 "Vt" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/tiled/monotile,
@@ -4587,6 +4626,15 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
+/area/site53/upper_surface/maincontrolroom)
+"We" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroom)
 "Wk" = (
 /obj/effect/landmark/start{
@@ -26947,7 +26995,7 @@ hk
 ia
 iq
 iy
-iy
+Vq
 iy
 iy
 RK
@@ -30025,7 +30073,7 @@ hZ
 iz
 it
 ii
-Zm
+Ka
 Zm
 Zm
 iz
@@ -32492,7 +32540,7 @@ hk
 hk
 hk
 cF
-cd
+zB
 dm
 dD
 dh
@@ -33095,7 +33143,7 @@ aY
 aY
 jH
 jp
-ki
+mn
 kK
 jH
 fC
@@ -34044,7 +34092,7 @@ dh
 dh
 dh
 gh
-gq
+Ta
 gA
 dY
 hk
@@ -35113,7 +35161,7 @@ ar
 bw
 aQ
 Iz
-gc
+We
 bo
 fF
 ar
@@ -35318,7 +35366,7 @@ cd
 co
 Rd
 ci
-ci
+wX
 ci
 dt
 ac
@@ -36859,7 +36907,7 @@ bX
 ci
 ci
 ci
-ci
+wX
 ci
 ci
 dt
@@ -37624,7 +37672,7 @@ hk
 ae
 bn
 bH
-bn
+DD
 bX
 bK
 bK
@@ -39687,7 +39735,7 @@ eP
 eN
 eN
 eR
-ex
+RW
 eN
 eN
 eu
@@ -39957,7 +40005,7 @@ Nv
 hp
 fh
 tc
-gT
+ml
 YJ
 hg
 hk


### PR DESCRIPTION
## About the Pull Request

added Holopads on all Site53 maps
Except CDZ.

Fix one camera in "General Purpose Testing Chamber"

## Why It's Good For The Game

AI now can use holopads and other personnel now can too.

## Changelog

:cl:
add: add Holopads
fix: Rotate camera
/:cl:
