### PR TITLE
008 Buffs but it works this time

### DIFF
--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 
 	H.move_intent.move_delay = 6
 	H.stat = CONSCIOUS
-
+	..()
 
 /datum/species/zombie/handle_environment_special(mob/living/carbon/human/H)
 	if (H.stat == CONSCIOUS)

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -341,7 +341,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 		if (prob(3))
 			H.zombify()
 
-	M.reagents.add_reagent(/datum/reagent/zombie, RAND_F(0.5, 1.5))
+	M.reagents.add_reagent(/datum/reagent/zombie, RAND_F(1.5, 3.5))
 
 /datum/reagent/zombie/affect_touch(mob/living/carbon/M, alien, removed)
 	affect_blood(M, alien, removed * 0.5)

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -49,13 +49,13 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 /datum/species/zombie
 	name = "Zombie"
 	name_plural = "Zombies"
-	slowdown = 15
+	slowdown = 10
 	blood_color = "#700f0f"
 	death_message = "writhes and twitches before falling motionless."
 	species_flags = SPECIES_FLAG_NO_PAIN | SPECIES_FLAG_NO_SCAN
 	spawn_flags = SPECIES_IS_RESTRICTED
-	brute_mod = 1
-	burn_mod = 2.5 //Vulnerable to fire
+	brute_mod = 0.8
+	burn_mod = 2 //Vulnerable to fire
 	oxy_mod = 0
 	stun_mod = 0.05
 	weaken_mod = 0.05
@@ -84,6 +84,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 		/obj/structure/wall_frame,
 		/obj/structure/railing,
 		/obj/structure/girder,
+		/obj/structure/window/reinforced
 		/turf/simulated/wall,
 		/obj/machinery/door/blast/shutters,
 		/obj/machinery/door
@@ -115,17 +116,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	H.move_intent.move_delay = 6
 	H.stat = CONSCIOUS
 
-	if (H.wear_id)
-		qdel(H.wear_id)
-	if (H.gloves)
-		qdel(H.gloves)
-	if (H.head)
-		qdel(H.head) //Remove helmet so headshots aren't impossible
-	if (H.glasses)
-		qdel(H.glasses)
-	if (H.wear_mask)
-		qdel(H.wear_mask)
-	..()
+
 
 /datum/species/zombie/handle_environment_special(mob/living/carbon/human/H)
 	if (H.stat == CONSCIOUS)
@@ -269,7 +260,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 
 /datum/unarmed_attack/bite/sharp/zombie
 	attack_verb = list("slashed", "sunk their teeth into", "bit", "mauled")
-	damage = 3
+	damage = 5
 
 /datum/unarmed_attack/bite/sharp/zombie/is_usable(mob/living/carbon/human/user, mob/living/carbon/human/target, zone)
 	. = ..()
@@ -289,13 +280,13 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	var/vuln = 1 - target.get_blocked_ratio(zone, TOX, damage_flags = DAM_BIO) //Are they protected from bites?
 	if (vuln > 0.05)
 		if (prob(vuln * 100)) //Protective infection chance
-			if (prob(min(100 - target.get_blocked_ratio(zone, BRUTE) * 100, 70))) //General infection chance
-				target.reagents.add_reagent(/datum/reagent/zombie, 1) //Infect 'em
+			if (prob(min(100 - target.get_blocked_ratio(zone, BRUTE) * 100, 100))) //General infection chance
+				target.reagents.add_reagent(/datum/reagent/zombie, 5) //Infect 'em
 
 
 /datum/reagent/zombie
-	name = "Liquid Corruption"
-	description = "A filthy, oily substance which slowly churns of its own accord."
+	name = "008 Prions"
+	description = "A oily substance which slowly churns of its own accord."
 	taste_description = "decaying blood"
 	color = "#540000"
 	taste_mult = 5

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 		/obj/structure/wall_frame,
 		/obj/structure/railing,
 		/obj/structure/girder,
-		/obj/structure/window/reinforced
+		/obj/structure/window/reinforced,
 		/turf/simulated/wall,
 		/obj/machinery/door/blast/shutters,
 		/obj/machinery/door
@@ -115,7 +115,6 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 
 	H.move_intent.move_delay = 6
 	H.stat = CONSCIOUS
-
 
 
 /datum/species/zombie/handle_environment_special(mob/living/carbon/human/H)

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -285,7 +285,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 
 /datum/reagent/zombie
 	name = "008 Prions"
-	description = "A oily substance which slowly churns of its own accord."
+	description = "An oily substance which slowly churns of its own accord."
 	taste_description = "decaying blood"
 	color = "#540000"
 	taste_mult = 5


### PR DESCRIPTION
## About the Pull Request

This PR aims to make zombies a little bit stronger by increasing their speed toughness and infection chance by small increments. Also alters liquid corruption so it is named 008 prions.
## Why It's Good For The Game

Zombies were severely underpowered without the ability to break through the windows, also they were too slow to catch anyone and really weren't worth the effort to go past all of the security measures in their containment. Now they will be an actual threat to the facility if they get out of control.
## Changelog

:cl:
add: Zombies are now slightly stronger, faster and tougher
add: Zombie infection chance set to 100%
add: Infection now progresses more rapidly
fix: Zombies no longer lose some clothes upon reanimation
spellcheck: Liquid Corruption renamed 008 prions and description altered slightly
/:cl:


