### PR TITLE
Chaos Base armory rework

### DIFF
--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -2359,17 +2359,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "ld" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
 /area/centcom/chaos)
 "le" = (
 /obj/structure/closet{
@@ -2378,10 +2374,6 @@
 	},
 /obj/item/clothing/glasses/night,
 /turf/simulated/floor/tiled/techfloor,
-/area/centcom/chaos)
-"lj" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/exoplanet/snow,
 /area/centcom/chaos)
 "ll" = (
 /obj/effect/landmark{
@@ -2399,14 +2391,11 @@
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
-"lu" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/lino,
-/area/centcom/chaos)
 "lv" = (
 /obj/machinery/light,
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
 /turf/simulated/floor/lino,
 /area/centcom/chaos)
 "lw" = (
@@ -2525,6 +2514,9 @@
 /area/beach)
 "mi" = (
 /obj/structure/table/reinforced,
+/obj/random/smokes,
+/obj/random/smokes,
+/obj/random/smokes,
 /turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "mj" = (
@@ -2653,17 +2645,7 @@
 /area/centcom/chaos)
 "mJ" = (
 /obj/machinery/door/airlock/highsecurity,
-/obj/machinery/door/blast/shutters{
-	explosion_resistance = 100
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
-"mK" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "mL" = (
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -2719,10 +2701,22 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/centcom/chaos)
 "nc" = (
-/obj/structure/table/reinforced,
-/obj/random/smokes,
-/obj/random/smokes,
-/obj/random/smokes,
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 4
+	},
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "nd" = (
@@ -2772,10 +2766,6 @@
 /obj/structure/scp173_cage,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
-"np" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
 "nq" = (
 /turf/unsimulated/wall{
 	desc = "A secure airlock. Doesn't look like you can get through easily.";
@@ -2786,9 +2776,10 @@
 	},
 /area/centcom)
 "nr" = (
-/obj/structure/table/reinforced,
-/obj/item/ammo_casing/rocket,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/simulated/floor/lino,
 /area/centcom/chaos)
 "ns" = (
 /obj/structure/sign/warning/secure_area/armory{
@@ -2830,12 +2821,6 @@
 /area/centcom/chaos)
 "nx" = (
 /turf/simulated/floor/tiled/old_tile,
-/area/centcom/chaos)
-"ny" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "nz" = (
 /obj/structure/table/rack,
@@ -2892,49 +2877,6 @@
 /obj/item/bodybag,
 /turf/simulated/floor/tiled/old_tile,
 /area/centcom/chaos)
-"nJ" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southleft,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
-"nK" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southright,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
-"nL" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southleft,
-/obj/item/device/chameleon,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
 "nN" = (
 /obj/effect/landmark{
 	name = "endgame_exit"
@@ -2942,14 +2884,21 @@
 /turf/unsimulated/beach/sand,
 /area/beach)
 "nO" = (
-/obj/machinery/door/airlock/highsecurity,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	explosion_resistance = 100;
-	id_tag = "alpha1";
-	name = "Alpha-1"
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/suit/storage/vest/tactical,
+/obj/item/gun/projectile/automatic/scp/ak74,
+/obj/item/clothing/head/helmet/nt{
+	name = "temp chaos helm"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/clothing/mask/balaclava/tactical,
+/obj/item/storage/backpack/rucksack/tan,
+/obj/structure/closet,
+/obj/item/gun/projectile/pistol,
+/turf/simulated/floor/tiled/dark,
 /area/centcom/chaos)
 "nQ" = (
 /obj/structure/table/rack,
@@ -2984,20 +2933,6 @@
 	icon_state = "dark"
 	},
 /area/centcom)
-"nW" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/turf/simulated/floor/tiled/techfloor,
-/area/centcom/chaos)
 "nX" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 4
@@ -3107,34 +3042,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/tram/car1)
-"om" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/northleft,
-/obj/item/clothing/mask/chameleon/voice{
-	desc = "A face-covering mask that can be connected to an air supply. It seems to house some odd electronics. Literally a voice changer";
-	name = "SCP-1996-RU"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
-"on" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/northright,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
 "oo" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
@@ -3175,10 +3082,7 @@
 /turf/unsimulated/floor/plating,
 /area/centcom)
 "ou" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/field_generator,
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "ow" = (
@@ -3186,9 +3090,22 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "ox" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 4
+	},
+/obj/item/clothing/mask/chameleon/voice{
+	desc = "A face-covering mask that can be connected to an air supply. It seems to house some odd electronics. Literally a voice changer";
+	name = "SCP-1996-RU"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "oy" = (
 /obj/machinery/button/blast_door{
@@ -23882,26 +23799,26 @@ uU
 jU
 cw
 cw
+cw
 uU
+ek
+cw
 uU
-ek
-ek
-uU
-lj
+cw
 ek
 ek
 ek
 ek
-ek
-uU
+cw
+cw
 uU
 ac
-uU
-uU
+cw
+cw
 ek
-ek
-ek
-ek
+cw
+cw
+cw
 uU
 uU
 cw
@@ -24086,22 +24003,22 @@ cw
 cw
 uU
 uU
-uU
+cw
 ek
 uU
-uU
+cw
+ek
+cw
 ek
 ek
-ek
-ek
+uU
+cw
 uU
 uU
+cw
 uU
 uU
-uU
-uU
-uU
-ek
+cw
 uU
 Te
 uU
@@ -24286,24 +24203,24 @@ cw
 cw
 cw
 cw
-uU
 cw
-ac
-ek
-uU
-ek
-ek
+cw
+cw
+cw
+cw
+cw
+cw
 di
 eU
 eU
 di
-uU
-uU
-uU
-uU
-uU
-uU
-uU
+cw
+cw
+cw
+cw
+cw
+cw
+cw
 uU
 uU
 uU
@@ -24488,11 +24405,11 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-ek
-ek
+di
+di
+di
+di
+di
 di
 di
 di
@@ -24690,13 +24607,13 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
-cw
 di
-cw
+kx
+kM
+kM
+nr
+kM
+kM
 di
 eU
 eU
@@ -24893,12 +24810,12 @@ cw
 cw
 cw
 di
-di
-di
-di
-di
-di
-di
+kx
+kM
+nr
+kY
+nr
+nr
 di
 eU
 eU
@@ -25097,10 +25014,10 @@ cw
 di
 kp
 kM
-kP
 kX
 kX
-lu
+kX
+kX
 di
 eU
 eU
@@ -25298,11 +25215,11 @@ di
 di
 di
 kx
-kM
-kM
+kP
+kX
 kY
 kX
-lu
+kX
 di
 lM
 eU
@@ -25501,9 +25418,9 @@ jS
 di
 ky
 kM
-kM
 kZ
-kM
+kZ
+ld
 lv
 di
 eU
@@ -26116,7 +26033,7 @@ eU
 kE
 di
 nc
-nd
+ox
 nd
 nd
 di
@@ -26316,10 +26233,10 @@ eU
 lE
 eU
 eU
-mJ
+di
 nd
 nd
-nJ
+nd
 oe
 di
 cw
@@ -26519,9 +26436,9 @@ lE
 eU
 eU
 di
+oI
 nd
 nd
-nK
 nd
 di
 cw
@@ -26711,7 +26628,7 @@ jS
 jT
 jS
 di
-eU
+ow
 eU
 eU
 eU
@@ -26923,13 +26840,13 @@ lE
 eU
 eU
 di
-no
+oI
 nd
 nd
 nd
+nO
 nd
-nd
-nd
+nO
 di
 cw
 cw
@@ -27125,13 +27042,13 @@ lF
 eU
 eU
 di
-np
-nd
-nL
-nd
 oI
-om
 nd
+nd
+nd
+nO
+nd
+nO
 di
 cw
 cw
@@ -27327,13 +27244,13 @@ di
 eU
 lX
 di
-np
-nd
-nK
 nd
 nd
-on
-oe
+nd
+nd
+nO
+nd
+nO
 di
 cw
 cw
@@ -27529,13 +27446,13 @@ di
 eU
 eU
 di
-nr
-ny
-ou
-oI
 nd
 nd
 nd
+nd
+nO
+nd
+nO
 di
 cw
 cw
@@ -27731,13 +27648,13 @@ di
 lO
 eU
 di
-di
-di
-di
-di
-di
+nd
+nd
+nd
+nd
+nd
+nd
 nO
-di
 di
 cw
 cw
@@ -27932,14 +27849,14 @@ TQ
 di
 eU
 eU
-mK
-eU
-eU
-eU
-eU
-eU
-eU
-ow
+mJ
+nd
+nd
+nd
+nd
+nd
+nd
+nd
 di
 cw
 cw
@@ -28134,14 +28051,14 @@ TQ
 lG
 eU
 eU
-eU
-eU
-eU
-eU
-eU
-eU
-eU
-ox
+mJ
+nd
+nd
+nd
+nd
+nd
+nd
+no
 di
 cw
 cw
@@ -28337,10 +28254,10 @@ di
 lQ
 eU
 di
-lG
-di
-di
-di
+nd
+nd
+nd
+nd
 di
 di
 di
@@ -28539,9 +28456,9 @@ di
 eU
 eU
 di
-TQ
+nd
 nz
-Fo
+nz
 nA
 di
 cw
@@ -28741,10 +28658,10 @@ di
 eU
 lX
 di
-kS
-TQ
-TQ
-lz
+nd
+nd
+nd
+nd
 di
 cw
 cw
@@ -28943,10 +28860,10 @@ di
 mw
 mi
 di
-TQ
-ld
-nW
-nA
+nd
+Fo
+Fo
+ou
 di
 cw
 cw

--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -2889,7 +2889,8 @@
 /obj/item/clothing/suit/storage/vest/tactical,
 /obj/item/gun/projectile/automatic/scp/ak74,
 /obj/item/clothing/head/helmet/nt{
-	name = "temp chaos helm"
+	name = "security helm"
+	desc = "A helmet with 'SECURITY' printed on the back in red lettering."
 	},
 /obj/item/ammo_magazine/scp/ak,
 /obj/item/ammo_magazine/scp/ak,

--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -2889,7 +2889,7 @@
 /obj/item/clothing/suit/storage/vest/tactical,
 /obj/item/gun/projectile/automatic/scp/ak74,
 /obj/item/clothing/head/helmet/nt{
-	name = "security helm"
+	name = "security helm";
 	desc = "A helmet with 'SECURITY' printed on the back in red lettering."
 	},
 /obj/item/ammo_magazine/scp/ak,


### PR DESCRIPTION
## About the Pull Request

Changed the Chaos base a little bit, mostly the armory.
added 5 chameleon projectors for stealth chaos
What was added to the closet can be seen in the screenshot
Also enlarged the table so everyone could sit down and discuss offensive tactics.

## Why It's Good For The Game

Chaos base now has full chaos fighter kits.

## Changelog

:cl:
add: Added several tables,added 1 random snack.
add: Added several chairs.
add: added 5 chameleon projectors.
add: Added 9 weapon closet,Added more of the right ammo.
add: expanded the base of chaos a little near the tables, added some rock.
del: Removed table and chair in the armory, Removed rocket shell in the armory.
del: Removed unneeded ammo.
/:cl:
![1a](https://user-images.githubusercontent.com/80586098/188504473-ba5e3af8-eb65-46c2-aab6-d85e3949fe54.png)
![2a](https://user-images.githubusercontent.com/80586098/188504474-b68818f5-fcde-442f-86f9-3d3ce9e8502d.png)
![3a](https://user-images.githubusercontent.com/80586098/188504476-4d27606f-ac2e-45da-98b6-1300c1edc346.png)
![2ф](https://user-images.githubusercontent.com/80586098/188509822-80038e99-f7f5-47ac-b25a-73c83c7cc3a5.png)
