### PR TITLE
Medbay Rework

### DIFF
--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -258,6 +258,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/cryogenicsprimary)
+"aM" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/defibrillator/loaded,
+/obj/item/auto_cpr,
+/obj/item/defibrillator/compact/loaded,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "aN" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/prepainted,
@@ -381,6 +391,9 @@
 /obj/item/storage/firstaid/adv,
 /obj/item/crowbar/prybar,
 /obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "bb" = (
@@ -751,7 +764,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception)
 "cp" = (
 /obj/structure/cable{
@@ -886,6 +899,8 @@
 	dir = 8
 	},
 /obj/structure/table/standard,
+/obj/item/pen,
+/obj/item/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "cU" = (
@@ -1062,6 +1077,7 @@
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 9
 	},
+/obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "dw" = (
@@ -1141,7 +1157,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception/waiting)
 "dH" = (
 /obj/effect/floor_decal/corner/green/border{
@@ -1179,6 +1195,8 @@
 /obj/structure/noticeboard{
 	pixel_y = 28
 	},
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "dM" = (
@@ -1186,6 +1204,7 @@
 /area/site53/medical/equipstorage)
 "dN" = (
 /obj/structure/coatrack,
+/obj/item/clothing/suit/storage/toggle/labcoat,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "dO" = (
@@ -1200,10 +1219,13 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "dR" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
 /obj/structure/table/standard,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/glass/fifty,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "dS" = (
@@ -1277,7 +1299,11 @@
 /turf/simulated/wall/prepainted,
 /area/site53/entrancezone/hallway)
 "ee" = (
-/obj/machinery/fabricator,
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "ef" = (
@@ -1302,14 +1328,16 @@
 "eh" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/mono,
-/obj/item/storage/pill_bottle/amnesticsb,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/auto_cpr,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "ei" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2{
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op1)
 "el" = (
@@ -1362,6 +1390,7 @@
 /area/site53/medical/mentalhealth/isolation)
 "er" = (
 /obj/structure/table/standard,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "es" = (
@@ -1385,14 +1414,27 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
 "eu" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2{
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
+"ev" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/masks,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "ew" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op2)
 "ex" = (
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/hall)
 "ey" = (
 /obj/structure/bed,
@@ -1419,6 +1461,7 @@
 	},
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "eA" = (
@@ -1483,13 +1526,21 @@
 	id_tag = "therapy";
 	pixel_y = -24
 	},
-/obj/item/storage/med_pouch/oxyloss,
-/obj/item/storage/med_pouch/oxyloss,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "eM" = (
 /obj/structure/bed/chair/office/comfy/black{
 	dir = 4
+	},
+/obj/effect/floor_decal/carpet/orange,
+/obj/effect/floor_decal/carpet/orange{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/orange{
+	dir = 6
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
@@ -1520,19 +1571,23 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
 "eS" = (
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "eT" = (
 /turf/simulated/floor/plating,
 /area/site53/uez/janitor)
 "eU" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/regular,
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/item/storage/firstaid/regular,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/infirmary)
+/area/site53/medical/equipstorage)
 "eV" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -1558,6 +1613,16 @@
 /area/site53/medical/equipstorage)
 "eY" = (
 /obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/orange{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/orange{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/orange{
+	dir = 9
+	},
+/obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
 "eZ" = (
@@ -1752,6 +1817,9 @@
 /obj/structure/bookcase/manuals/medical{
 	pixel_y = 32
 	},
+/obj/item/device/taperecorder,
+/obj/item/device/tape,
+/obj/item/device/tape,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "fv" = (
@@ -1784,6 +1852,9 @@
 /obj/structure/bookcase{
 	pixel_y = 32
 	},
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/device/camera_film,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "fB" = (
@@ -1853,10 +1924,10 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
 "fN" = (
-/obj/structure/flora/pottedplant/minitree,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "fO" = (
@@ -1953,17 +2024,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception/waiting)
 "gb" = (
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "gc" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/storage/medical_lolli_jar{
+	pixel_y = 10
 	},
-/turf/simulated/floor/carpet/orange,
-/area/site53/medical/mentalhealth/office)
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "gd" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/half{
@@ -1982,7 +2054,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/hall)
 "gf" = (
 /obj/machinery/door/airlock/maintenance{
@@ -1997,24 +2069,17 @@
 /area/site53/maintenance/surfacewest)
 "gg" = (
 /obj/structure/table/woodentable/walnut,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/item/boombox,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "gh" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "gi" = (
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 32;
-	pixel_z = -9
-	},
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
+/obj/structure/table/standard,
+/obj/item/storage/box/cups,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "gj" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -2156,8 +2221,7 @@
 "gC" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/mono,
-/obj/machinery/cell_charger,
-/obj/item/screwdriver,
+/obj/item/storage/firstaid/combat,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "gD" = (
@@ -2213,6 +2277,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "gM" = (
@@ -2254,9 +2319,7 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception)
 "gQ" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
+/obj/structure/bed/chair,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -2305,7 +2368,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
 "gY" = (
 /obj/machinery/vending/wallmed1{
@@ -2316,6 +2379,7 @@
 /area/site53/medical/infirmary)
 "gZ" = (
 /obj/structure/table/standard,
+/obj/item/storage/firstaid/regular,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
 "ha" = (
@@ -2332,7 +2396,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op2)
 "hb" = (
 /obj/structure/table/standard,
@@ -2377,6 +2441,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "hi" = (
@@ -2483,6 +2548,7 @@
 "hz" = (
 /obj/structure/table/standard,
 /obj/item/device/radio/phone/medbay,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception)
 "hA" = (
@@ -2502,6 +2568,9 @@
 /area/site53/medical/surgery/hall)
 "hC" = (
 /obj/structure/bed/psych,
+/obj/effect/floor_decal/carpet/orange{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
 "hD" = (
@@ -2510,6 +2579,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/book/manual/scp/medsop,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "hE" = (
@@ -2555,6 +2625,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/storage/box/donkpockets,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "hL" = (
@@ -2562,7 +2633,7 @@
 	name = "Psychiatric Isolation";
 	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
 "hM" = (
 /obj/structure/hygiene/sink{
@@ -2649,7 +2720,7 @@
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
 "hW" = (
-/obj/structure/table/standard,
+/obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "hX" = (
@@ -2750,6 +2821,9 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/clothing/gloves/latex/nitrile,
 /obj/item/storage/firstaid/adv,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "ik" = (
@@ -2803,11 +2877,10 @@
 /turf/simulated/wall/prepainted,
 /area/site53/medical/infirmary)
 "iu" = (
-/obj/machinery/smartfridge/chemistry{
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
+/obj/machinery/sleeper{
+	dir = 4
 	},
-/obj/effect/paint_stripe/paleblue,
-/turf/simulated/wall/prepainted,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
 "iv" = (
 /obj/effect/floor_decal/corner/red/half{
@@ -2863,6 +2936,9 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "iD" = (
@@ -2889,12 +2965,17 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
 "iF" = (
-/obj/structure/table/standard,
-/obj/item/storage/fancy/cigarettes/killthroat,
-/obj/item/flame/lighter/zippo,
-/obj/item/storage/firstaid/surgery,
+/obj/structure/closet{
+	name = "Coroner"
+	},
+/obj/item/clothing/under/rank/medical/scrubs/black,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/latex/nitrile,
 /obj/item/autopsy_scanner,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
 "iG" = (
 /obj/effect/floor_decal/corner/green{
@@ -2917,9 +2998,7 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/hall)
 "iH" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "iI" = (
@@ -2938,12 +3017,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
 "iK" = (
-/obj/machinery/vending/medical{
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
 	},
+/obj/structure/bed/chair,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "iL" = (
@@ -2951,7 +3028,7 @@
 	name = "Mental Isolation";
 	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "iM" = (
 /obj/effect/floor_decal/corner/orange/border{
@@ -2975,11 +3052,9 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "iQ" = (
-/obj/effect/floor_decal/corner/paleblue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
+/obj/effect/floor_decal/carpet/orange,
+/turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
 "iR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3017,6 +3092,7 @@
 	dir = 1
 	},
 /obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "iV" = (
@@ -3048,6 +3124,8 @@
 	c_tag = "Psychiatry";
 	dir = 8
 	},
+/obj/item/pen,
+/obj/item/paper_bin,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "iZ" = (
@@ -3118,6 +3196,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
@@ -3236,16 +3320,18 @@
 /turf/simulated/wall/prepainted,
 /area/site53/medical/chemistry)
 "jo" = (
-/obj/machinery/door/airlock/multi_tile/glass/medical{
-	name = "Chemistry Laboratory";
-	req_access = list("ACCESS_MEDICAL_LEVEL2")
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/medical{
+	name = "Chemistry";
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
+	},
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
 "jp" = (
 /obj/structure/railing/mapped,
@@ -3253,7 +3339,6 @@
 /area/quartermaster/hangar)
 "jq" = (
 /obj/machinery/optable,
-/obj/item/clothing/mask/surgical,
 /obj/item/clothing/suit/surgicalapron,
 /turf/simulated/floor/plating,
 /area/site53/medical/morgue)
@@ -3462,6 +3547,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
 "jV" = (
@@ -3605,9 +3693,16 @@
 /turf/simulated/floor/snow,
 /area/site53/medical/mentalhealth/isolation)
 "kl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/smartfridge/chemistry{
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/obj/effect/paint_stripe/mauve,
+/obj/machinery/door/window{
+	dir = 1;
+	name = "shower cabin";
+	req_access = list("ACCESS_MEDICAL_LEVEL2")
+	},
+/turf/simulated/wall/prepainted,
 /area/site53/medical/chemistry)
 "km" = (
 /obj/machinery/light{
@@ -3681,6 +3776,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "ky" = (
@@ -3701,6 +3797,7 @@
 	},
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "kA" = (
@@ -3860,6 +3957,9 @@
 "kW" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/effect/floor_decal/carpet/orange{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
 "kX" = (
@@ -3880,7 +3980,8 @@
 "kZ" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/mono,
-/obj/item/defibrillator/loaded,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "la" = (
@@ -3897,8 +3998,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
 "lc" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/trauma,
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/infirmreception/waiting)
+/area/site53/medical/equipstorage)
 "ld" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -4041,7 +4149,9 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception/waiting)
 "lq" = (
-/obj/structure/table/standard,
+/obj/structure/reagent_dispensers/water_cooler{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception/waiting)
 "lr" = (
@@ -4197,6 +4307,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"lT" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/exam_room)
 "lW" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
@@ -4944,6 +5059,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
 "om" = (
@@ -5185,6 +5304,9 @@
 /obj/item/stamp/approved,
 /obj/item/stamp/denied,
 /obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
 "pd" = (
@@ -5228,7 +5350,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op1)
 "pj" = (
 /obj/effect/floor_decal/corner/green/bordercorner{
@@ -5360,7 +5482,7 @@
 	id_tag = "medicallockdown";
 	name = "Medical Lockdown shutter"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception/waiting)
 "pN" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -5381,6 +5503,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/senioragentoffice)
+"pP" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmary)
 "pW" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/maple,
@@ -5409,6 +5536,10 @@
 "qm" = (
 /obj/machinery/light,
 /turf/simulated/open,
+/area/site53/zonecommanderoffice)
+"qo" = (
+/obj/effect/floor_decal/carpet/blue2,
+/turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "qx" = (
 /obj/structure/closet/cabinet,
@@ -5616,6 +5747,9 @@
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
 	},
+/obj/effect/floor_decal/carpet/blue{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/o5repoffice)
 "rm" = (
@@ -5655,6 +5789,7 @@
 /obj/structure/bed/chair/comfy/red{
 	dir = 4
 	},
+/obj/effect/floor_decal/carpet/blue,
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/o5repoffice)
 "rs" = (
@@ -5665,6 +5800,15 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 9
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
 "rt" = (
@@ -5683,6 +5827,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
 "rw" = (
@@ -5704,6 +5851,13 @@
 	icon_state = "1-4"
 	},
 /obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
 "rz" = (
@@ -5712,6 +5866,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/carpet/blue2,
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
 "rA" = (
@@ -5722,6 +5877,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/floor_decal/carpet/blue2,
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
 "rB" = (
@@ -6115,9 +6271,24 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"sO" = (
+/obj/effect/floor_decal/carpet/orange{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/orange{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/orange{
+	dir = 5
+	},
+/turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
 "sQ" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "sR" = (
@@ -6137,6 +6308,9 @@
 "sT" = (
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "sU" = (
@@ -6164,6 +6338,7 @@
 "sZ" = (
 /obj/structure/table/reinforced,
 /obj/random/clipboard,
+/obj/effect/floor_decal/carpet/blue2,
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "tb" = (
@@ -6570,6 +6745,12 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/logistics/logistics)
+"uw" = (
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/screwdriver,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/exam_room)
 "uz" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -6859,6 +7040,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/commstower)
+"vu" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "vv" = (
 /obj/machinery/light{
 	dir = 4;
@@ -7087,6 +7278,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/surface/surface)
+"xf" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/surgery,
+/obj/item/storage/box/freezer,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/medical/morgue)
 "xg" = (
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
@@ -7112,6 +7309,26 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
+"xx" = (
+/obj/structure/bed/chair/comfy/red{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue,
+/obj/effect/floor_decal/carpet/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/blue{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/o5repoffice)
+"xE" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "xF" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/r_wall/prepainted,
@@ -7129,6 +7346,11 @@
 /obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
+"yj" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "yk" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -7186,10 +7408,21 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"yY" = (
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 32;
+	pixel_z = -9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/entrancezone/hallway)
 "za" = (
 /obj/structure/table/standard,
-/obj/item/defibrillator/loaded,
-/obj/item/roller,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception)
 "zb" = (
@@ -7222,9 +7455,6 @@
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/item/reagent_containers/dropper/industrial,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
@@ -7263,6 +7493,9 @@
 /obj/item/reagent_containers/syringe/amnesticsc,
 /obj/item/reagent_containers/syringe/amnesticsc,
 /obj/item/reagent_containers/syringe/amnesticsc,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
 "zp" = (
@@ -7378,6 +7611,19 @@
 "Ao" = (
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
+"Ar" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/structure/closet,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Az" = (
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile/white,
@@ -7435,6 +7681,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"Bm" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Bq" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
@@ -7446,8 +7701,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
 "Bt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/purple/half{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
 "Bv" = (
@@ -7574,10 +7833,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
 "Cp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
@@ -7612,6 +7867,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"CP" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/fabricator,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "CU" = (
 /obj/structure/iv_drip,
 /obj/structure/cable/green{
@@ -7639,12 +7901,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "Dh" = (
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 4
 	},
+/obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "Dz" = (
@@ -7655,6 +7918,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"DJ" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/obj/item/pen,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "DO" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -7690,6 +7959,26 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"DZ" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/combat,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/storage/firstaid/combat,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"Eb" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/random/firstaid,
+/obj/item/storage/firstaid/stab,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ec" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -7723,6 +8012,14 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
+"Ej" = (
+/obj/structure/table/woodentable/walnut,
+/obj/item/toy/desk/fan,
+/obj/effect/floor_decal/carpet/orange{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
 "Em" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -7761,9 +8058,8 @@
 "Fe" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/mono,
-/obj/item/auto_cpr,
-/obj/item/auto_cpr,
-/obj/item/auto_cpr,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsb,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "Ff" = (
@@ -7826,8 +8122,20 @@
 /obj/structure/table/standard,
 /obj/item/pen,
 /obj/item/paper_bin,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
+"FX" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception/waiting)
 "Gb" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -7898,8 +8206,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
 "GZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
@@ -7909,6 +8217,10 @@
 	},
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
+"Hd" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "He" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -7931,7 +8243,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "Hl" = (
-/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "Ho" = (
@@ -8025,6 +8337,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
+"Iy" = (
+/obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/blue,
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/o5repoffice)
 "Iz" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -8088,8 +8405,17 @@
 /obj/item/storage/firstaid/adv,
 /obj/item/crowbar/prybar,
 /obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
+"Jn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/office)
 "Jr" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile/white,
@@ -8160,6 +8486,13 @@
 /obj/structure/bed/chair/wheelchair,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/mentalhealth/isolation)
+"Kw" = (
+/obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/orange{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
 "Ky" = (
 /obj/effect/landmark/start{
 	name = "LCZ Guard"
@@ -8167,12 +8500,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
 "KB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/chemistry)
+/obj/structure/table/woodentable/walnut,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
 "KR" = (
 /obj/structure/closet/secure_closet/mtf/breachautomatics,
 /obj/item/ammo_magazine/box/a556,
@@ -8332,6 +8664,35 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"MV" = (
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs,
+/obj/structure/closet/secure_closet/freezer{
+	icon = 'icons/obj/closets/fridge.dmi';
+	name = "Secure Freezer"
+	},
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/storage/box/freezer,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "MX" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
@@ -8363,6 +8724,13 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"Nr" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/vending/medical{
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ny" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a10mm,
@@ -8379,6 +8747,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
+"NA" = (
+/obj/effect/floor_decal/carpet/orange{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
 "NB" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -8386,6 +8760,10 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"NS" = (
+/obj/item/clothing/suit/hospital,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Oe" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Sergeant Equipment";
@@ -8415,6 +8793,9 @@
 /area/site53/maintenance/surfacewest)
 "Ok" = (
 /obj/structure/bed/chair/armchair/brown,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "Op" = (
@@ -8505,10 +8886,10 @@
 /turf/simulated/floor/tiled,
 /area/site53/uez/armory)
 "PX" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/defibrillator/compact/loaded,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/stoutbush,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "PZ" = (
@@ -8522,6 +8903,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
 /area/site53/surface/surface)
+"Qb" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/closet/secure_closet{
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
+	},
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/reagent_containers/syringe/amnesticsc,
+/obj/item/reagent_containers/ivbag/amnesticsd,
+/obj/item/reagent_containers/ivbag/amnesticsf,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Qe" = (
 /turf/simulated/wall/wood,
 /area/site53/surface/surface)
@@ -8572,6 +8967,15 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"Qs" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"QH" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/sleeper)
 "QJ" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -8584,6 +8988,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uez/armory)
+"QL" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2,
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "QP" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
@@ -8603,6 +9017,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
+"QS" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/medical/equipstorage)
 "QT" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
@@ -8638,6 +9056,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
+"Ri" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Rn" = (
 /obj/structure/lattice,
 /obj/structure/ladder,
@@ -8689,9 +9113,7 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
 "RS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
 "RW" = (
@@ -8703,7 +9125,7 @@
 /area/site53/surface/surface)
 "Sd" = (
 /obj/structure/table/standard,
-/obj/item/storage/firstaid/adv,
+/obj/item/defibrillator/loaded,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
 "Sf" = (
@@ -8726,7 +9148,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
 "Sk" = (
-/obj/machinery/sleeper,
+/obj/machinery/bodyscanner{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
 "Sm" = (
@@ -8746,6 +9170,15 @@
 /obj/item/stack/material/titanium/fifty,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"Sq" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/screwdriver,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Su" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -8794,8 +9227,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
 "SX" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
@@ -8899,6 +9332,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
+"Us" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/exam_room)
 "Uv" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -9036,7 +9475,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/equipstorage)
+"VP" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage Room";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/tiled/white,
 /area/site53/medical/equipstorage)
 "Wl" = (
 /obj/structure/disposalpipe/segment,
@@ -9065,6 +9511,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"Ww" = (
+/obj/machinery/chemical_dispenser/full,
+/obj/effect/floor_decal/corner/purple/mono,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/chemistry)
+"WA" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/plastic/fifty,
+/obj/item/stack/material/steel/fifty,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "WG" = (
 /obj/machinery/floodlight{
 	anchored = 1;
@@ -9099,6 +9561,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
+"WZ" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception)
 "Xd" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 9
@@ -9196,6 +9663,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfaceeast)
+"XQ" = (
+/obj/effect/floor_decal/carpet/orange{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
 "XW" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -9232,11 +9705,12 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
 	},
+/obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "Yo" = (
@@ -9302,6 +9776,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"YY" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/book/manual/scp/medsop,
+/obj/machinery/light,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Za" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/maple,
@@ -9310,8 +9797,16 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/structure/table/woodentable/walnut,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
+"Zk" = (
+/obj/effect/paint_stripe/green,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/surgery/hall)
 "Zn" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -16407,7 +16902,7 @@ aQ
 ty
 sS
 sV
-sR
+qo
 tx
 ty
 dA
@@ -30234,11 +30729,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+jP
+jP
+jP
+jP
 dA
 dA
 dA
@@ -30491,11 +30986,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+Qb
+vH
+Ar
+jP
 dA
 dA
 dA
@@ -30748,11 +31243,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+Eb
+vH
+ev
+jP
 dA
 dA
 dA
@@ -31005,11 +31500,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+DZ
+vH
+dR
+jP
 dA
 dA
 dA
@@ -31262,11 +31757,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+vu
+vH
+Bm
+jP
 dA
 dA
 dA
@@ -31519,11 +32014,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+Nr
+vH
+MV
+jP
 dA
 dA
 dA
@@ -31776,11 +32271,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+QL
+vH
+aM
+jP
 dA
 dA
 dA
@@ -32033,11 +32528,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+eU
+vH
+YY
+jP
 dA
 dA
 dA
@@ -32290,11 +32785,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+lc
+vH
+Sq
+jP
 dA
 dA
 dA
@@ -32547,11 +33042,11 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-dA
-dA
+jP
+WA
+vH
+CP
+jP
 dA
 dA
 dA
@@ -32806,7 +33301,7 @@ jP
 jP
 jP
 jP
-jP
+VP
 jP
 jP
 dA
@@ -33063,7 +33558,7 @@ jm
 WH
 jP
 ee
-dR
+vH
 PX
 jP
 dA
@@ -33311,7 +33806,7 @@ dA
 dA
 dA
 jP
-ik
+gi
 gb
 dM
 gb
@@ -33319,23 +33814,23 @@ dM
 gb
 dM
 fg
-vH
+Qs
 vH
 ba
 jP
 dA
 dA
 dm
-eA
-eA
-dm
-eA
+DJ
 eA
 dm
-eA
+DJ
 eA
 dm
+DJ
 eA
+dm
+yj
 eA
 dm
 dA
@@ -33568,7 +34063,7 @@ dA
 dA
 dA
 jP
-gb
+QS
 dM
 gb
 dM
@@ -34610,7 +35105,7 @@ QV
 Dg
 iR
 kj
-eU
+iR
 eZ
 ZS
 fC
@@ -34854,7 +35349,7 @@ dA
 Xy
 iX
 iX
-iX
+NS
 iX
 iX
 iX
@@ -34864,7 +35359,7 @@ iX
 iX
 iX
 iX
-eS
+iX
 iX
 ls
 mc
@@ -35121,7 +35616,7 @@ fl
 fl
 fl
 pE
-is
+pP
 iM
 fh
 mc
@@ -35134,7 +35629,7 @@ lz
 fe
 mc
 iF
-lb
+xf
 US
 mc
 dA
@@ -35370,7 +35865,7 @@ pE
 jd
 hC
 Hs
-dJ
+iQ
 dN
 pE
 dU
@@ -35625,15 +36120,15 @@ dA
 dA
 pE
 Ok
+NA
 dJ
-dJ
-dJ
+iQ
 pn
 eJ
 pn
 eY
 kW
-eY
+Kw
 pE
 gQ
 iX
@@ -35882,17 +36377,17 @@ dA
 dA
 pE
 fu
-dJ
-dJ
+sO
+XQ
 eM
 eL
 pE
 kS
-eY
+Ej
 hV
-eY
+KB
 pE
-hW
+Hd
 iX
 hE
 mc
@@ -36144,8 +36639,8 @@ eI
 iY
 gg
 pE
-pn
-gc
+Jn
+NA
 cW
 zk
 pE
@@ -36910,7 +37405,7 @@ dA
 dA
 dA
 dA
-fQ
+lT
 gd
 iw
 iw
@@ -36919,14 +37414,14 @@ iw
 iw
 iw
 ir
-iu
+fQ
 Dh
 iP
 je
 jo
 ol
-SX
-kJ
+RS
+RS
 SX
 Uk
 jn
@@ -37170,19 +37665,19 @@ dA
 fQ
 cU
 iw
-gZ
+uw
 iw
 ZU
 fM
-iw
+Us
 ir
 fQ
 fQ
-iQ
+iS
 Yj
 kl
 Bt
-KB
+kJ
 Cp
 GZ
 es
@@ -37440,7 +37935,7 @@ jh
 jr
 Yu
 kK
-RS
+kJ
 zf
 la
 jn
@@ -37687,8 +38182,8 @@ iw
 gZ
 iw
 Sk
-iw
-iw
+fM
+iu
 ir
 ia
 le
@@ -37952,7 +38447,7 @@ fQ
 iS
 wD
 jr
-pB
+Ww
 dY
 kJ
 dY
@@ -38210,7 +38705,7 @@ iT
 jk
 jN
 jN
-jN
+WZ
 kB
 jN
 jN
@@ -38462,7 +38957,7 @@ dQ
 hg
 iy
 fQ
-hW
+Ri
 iX
 Cq
 jN
@@ -38719,7 +39214,7 @@ gT
 gT
 gT
 gT
-hW
+Hl
 iX
 Qm
 cm
@@ -39225,7 +39720,7 @@ dA
 dA
 dA
 dA
-gT
+QH
 gk
 dc
 cZ
@@ -39756,7 +40251,7 @@ jS
 jS
 jS
 jS
-lc
+jS
 iI
 ln
 aY
@@ -40013,8 +40508,8 @@ ki
 RK
 ki
 lq
-pA
-gi
+FX
+lo
 tC
 aP
 bg
@@ -40528,7 +41023,7 @@ da
 da
 da
 da
-lo
+yY
 tD
 dt
 Ce
@@ -42595,7 +43090,7 @@ lo
 mB
 lF
 rk
-rk
+Iy
 rn
 rn
 rD
@@ -42831,7 +43326,7 @@ ha
 fE
 fE
 gO
-dl
+Zk
 hf
 iX
 fD
@@ -42852,7 +43347,7 @@ lo
 mB
 lF
 rl
-rl
+xx
 VA
 rn
 rE
@@ -43345,7 +43840,7 @@ fk
 ew
 bx
 gO
-hW
+eS
 iX
 iX
 fD
@@ -43859,7 +44354,7 @@ hH
 ew
 dx
 gO
-hW
+gc
 iX
 iX
 fD
@@ -44118,7 +44613,7 @@ pe
 gO
 Hl
 iX
-iX
+xE
 fD
 dA
 dA

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -810,6 +810,16 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/maintenance/surfaceeast)
+"cF" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/screwdriver,
+/obj/effect/floor_decal/corner/paleblue/half,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "cG" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -843,6 +853,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception)
+"cL" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "cM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -1090,11 +1107,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
-"dy" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception/waiting)
 "dA" = (
 /turf/unsimulated/mineral,
 /area/space)
@@ -1215,10 +1227,13 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "dR" = (
-/obj/effect/paint_stripe/white,
-/obj/effect/paint_stripe/white,
-/obj/effect/paint_stripe/white,
-/turf/simulated/wall/prepainted,
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/masks,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "dS" = (
 /obj/structure/bed/chair,
@@ -1563,16 +1578,12 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/janitor)
 "eU" = (
-/obj/effect/floor_decal/corner/orange/border{
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 32;
-	pixel_z = -9
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "eV" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -2015,16 +2026,8 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "gc" = (
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/structure/closet,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4
-	},
+/obj/structure/table/standard,
+/obj/item/storage/box/cups,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "gd" = (
@@ -2067,8 +2070,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "gi" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/cups,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/fabricator,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "gj" = (
@@ -2621,7 +2627,7 @@
 /area/site53/medical/equipstorage)
 "hL" = (
 /obj/machinery/door/airlock/medical{
-	name = "Psychiatric Isolation";
+	name = "Psychiatric Isolation 3";
 	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
 /turf/simulated/floor/wood/walnut,
@@ -2712,9 +2718,7 @@
 /area/site53/medical/mentalhealth/office)
 "hW" = (
 /obj/structure/table/standard,
-/obj/item/storage/medical_lolli_jar{
-	pixel_y = 10
-	},
+/obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "hX" = (
@@ -3544,6 +3548,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/clothing/glasses/science,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
 "jV" = (
@@ -3992,16 +3997,18 @@
 /area/site53/medical/chemistry)
 "lb" = (
 /obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
 "lc" = (
+/obj/structure/table/standard,
+/obj/item/defibrillator/loaded,
+/obj/item/auto_cpr,
+/obj/item/defibrillator/compact/loaded,
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 8
 	},
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/screwdriver,
-/obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "ld" = (
@@ -5168,6 +5175,10 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"oA" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "oB" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -5476,6 +5487,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception/waiting)
+"pM" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/obj/item/pen,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "pN" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -5495,6 +5512,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/senioragentoffice)
+"pS" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception)
+"pV" = (
+/obj/effect/paint_stripe/white,
+/obj/effect/paint_stripe/white,
+/obj/effect/paint_stripe/white,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/equipstorage)
 "pW" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/maple,
@@ -5520,11 +5548,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroomstairs)
-"qh" = (
-/obj/structure/table/standard,
-/obj/item/paper,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
 "qm" = (
 /obj/machinery/light,
 /turf/simulated/open,
@@ -6110,11 +6133,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/logistics/logistics)
-"sh" = (
-/obj/effect/paint_stripe/green,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/surgery/hall)
 "si" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -6748,13 +6766,6 @@
 /obj/item/screwdriver,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
-"uy" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "uz" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -6784,6 +6795,16 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"uF" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/plastic/fifty,
+/obj/item/stack/material/glass/fifty,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "uG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -7152,6 +7173,23 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/restaurant)
+"wp" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"wu" = (
+/obj/machinery/door/airlock/medical{
+	name = "Psychiatric Isolation 1";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "ww" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/mono,
@@ -7281,10 +7319,6 @@
 "xg" = (
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
-"xh" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "xn" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
@@ -7307,15 +7341,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"xw" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/masks,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "xx" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
@@ -7346,12 +7371,6 @@
 /obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
-"yf" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "yk" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -7371,11 +7390,19 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
-"yy" = (
-/obj/effect/floor_decal/corner/paleblue/half,
+"yv" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
 /obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/item/book/manual/scp/medsop,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "yz" = (
@@ -7388,6 +7415,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"yD" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/trauma,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "yG" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7402,6 +7438,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lowertrams/restaurant)
+"yJ" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "yV" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -7555,10 +7600,23 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
+"zH" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "zI" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"zJ" = (
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "zO" = (
 /turf/simulated/floor/tiled,
 /area/site53/surface/surface)
@@ -7578,16 +7636,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op2)
-"zY" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/bed/chair/wheelchair,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Ac" = (
 /obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/clothing/suit/bio_suit/security,
@@ -7618,6 +7666,12 @@
 "Ao" = (
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
+"Ax" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Az" = (
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile/white,
@@ -7638,6 +7692,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/maintenance/surfaceeast)
+"AP" = (
+/obj/machinery/door/airlock/medical{
+	name = "Psychiatric Isolation";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "AT" = (
 /turf/simulated/floor/reinforced,
 /area/site53/surface/surface)
@@ -7653,6 +7714,15 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
+"AW" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ba" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
@@ -7668,15 +7738,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"Be" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/o2,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Bf" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner/red/half{
@@ -7694,6 +7755,36 @@
 /obj/item/stool,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"Br" = (
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs,
+/obj/structure/closet/secure_closet/freezer{
+	icon = 'icons/obj/closets/fridge.dmi';
+	name = "Secure Freezer"
+	},
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/storage/box/freezer,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Bt" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -7851,6 +7942,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"CC" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmary)
 "CF" = (
 /obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/clothing/suit/bio_suit/security,
@@ -7861,15 +7957,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"CG" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "CU" = (
 /obj/structure/iv_drip,
 /obj/structure/cable/green{
@@ -7906,13 +7993,6 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Dp" = (
-/obj/structure/flora/pottedplant/fern,
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Dz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7921,10 +8001,18 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"DF" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 4
+"DG" = (
+/obj/structure/closet/secure_closet{
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
 	},
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/reagent_containers/syringe/amnesticsc,
+/obj/item/reagent_containers/ivbag/amnesticsd,
+/obj/item/reagent_containers/ivbag/amnesticsf,
+/obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "DO" = (
@@ -7946,13 +8034,6 @@
 "DV" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfaceeast)
-"DW" = (
-/obj/structure/table/rack,
-/obj/random/firstaid,
-/obj/item/storage/firstaid/stab,
-/obj/effect/floor_decal/corner/paleblue/three_quarters,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "DX" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -7969,6 +8050,11 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"Ea" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "Ec" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -8032,13 +8118,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"Ex" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "EJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -8052,6 +8131,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/medical/morgue)
+"Fb" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/medical/equipstorage)
 "Fe" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -8081,6 +8164,15 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/maintenance/surfaceeast)
+"Fn" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Fs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8149,34 +8241,11 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"Gs" = (
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/lungs,
-/obj/structure/closet/secure_closet/freezer{
-	icon = 'icons/obj/closets/fridge.dmi';
-	name = "Secure Freezer"
-	},
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/storage/box/freezer,
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/machinery/light,
+"Gp" = (
+/obj/structure/table/rack,
+/obj/random/firstaid,
+/obj/item/storage/firstaid/stab,
+/obj/effect/floor_decal/corner/paleblue/three_quarters,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "Gt" = (
@@ -8194,13 +8263,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"Gz" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 4
-	},
-/obj/structure/bed/chair/wheelchair,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "GH" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -8348,21 +8410,29 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/tramhubhallwayentry)
+"Ib" = (
+/obj/machinery/door/airlock/medical{
+	name = "Psychiatric Isolation 2";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "Ic" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/plastic/fifty,
 /obj/item/stack/material/aluminium/fifty,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
-"Il" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/trauma,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+"Ig" = (
+/obj/effect/paint_stripe/green,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/surgery/hall)
+"Ik" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception/waiting)
 "Im" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8483,12 +8553,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
-"JM" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/office)
 "JN" = (
 /obj/structure/table/woodentable{
 	dir = 5
@@ -8512,14 +8576,10 @@
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/prepainted,
 /area/site53/medical/infirmary)
-"Kk" = (
+"Kh" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
 	},
-/obj/structure/table/standard,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/glass/fifty,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "Kq" = (
@@ -8529,6 +8589,19 @@
 /obj/structure/bed/chair/wheelchair,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/mentalhealth/isolation)
+"Kv" = (
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Kw" = (
 /obj/structure/table/woodentable/walnut,
 /obj/effect/floor_decal/carpet/orange{
@@ -8547,6 +8620,10 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/carpet/orange,
+/area/site53/medical/mentalhealth/office)
+"KF" = (
+/obj/structure/flora/pottedplant/fern,
+/turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
 "KR" = (
 /obj/structure/closet/secure_closet/mtf/breachautomatics,
@@ -8567,21 +8644,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"Lc" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/fabricator,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
-"Le" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storage Room";
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/equipstorage)
 "Lf" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -8639,6 +8701,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
+"LC" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/sleeper)
 "LE" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "ezcell1";
@@ -8650,19 +8717,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"LN" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
+"LW" = (
+/obj/effect/floor_decal/corner/paleblue/half,
 /obj/structure/table/standard,
-/obj/item/book/manual/scp/medsop,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "Ma" = (
@@ -8737,6 +8796,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"MU" = (
+/obj/structure/flora/pottedplant/fern,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "MX" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
@@ -8748,35 +8814,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"MZ" = (
-/obj/structure/table/standard,
-/obj/item/defibrillator/loaded,
-/obj/item/auto_cpr,
-/obj/item/defibrillator/compact/loaded,
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
-"Nc" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmary)
-"Ng" = (
-/obj/structure/closet/secure_closet{
-	req_access = list("ACCESS_MEDICAL_LEVEL3")
-	},
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/reagent_containers/syringe/amnesticsc,
-/obj/item/reagent_containers/ivbag/amnesticsd,
-/obj/item/reagent_containers/ivbag/amnesticsf,
-/obj/effect/floor_decal/corner/paleblue,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Ni" = (
 /obj/effect/floor_decal/corner/red/bordercee{
 	dir = 1
@@ -8827,15 +8864,14 @@
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
 "NS" = (
-/obj/item/clothing/suit/hospital,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
-"NY" = (
-/obj/structure/table/standard,
-/obj/item/paper,
-/obj/item/pen,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Oe" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Sergeant Equipment";
@@ -8863,6 +8899,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
+"Oi" = (
+/obj/effect/floor_decal/corner/green/border{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Ok" = (
 /obj/structure/bed/chair/armchair/brown,
 /obj/machinery/light{
@@ -8903,20 +8948,6 @@
 /obj/machinery/light,
 /turf/simulated/open,
 /area/site53/zonecommanderoffice)
-"Pa" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception)
-"Pb" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Pr" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
@@ -9156,6 +9187,11 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception/waiting)
+"RN" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/exam_room)
 "RR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/mre/menu2,
@@ -9165,11 +9201,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
-"RV" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "RW" = (
 /obj/structure/sign/directions/evac{
 	dir = 4;
@@ -9177,11 +9208,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
-"RY" = (
-/obj/effect/paint_stripe/red,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/sleeper)
 "Sd" = (
 /obj/structure/table/standard,
 /obj/item/defibrillator/loaded,
@@ -9257,11 +9283,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"SR" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/exam_room)
 "SS" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -9305,6 +9326,17 @@
 /obj/structure/closet,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"Tq" = (
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 32;
+	pixel_z = -9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/entrancezone/hallway)
 "TG" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9366,16 +9398,6 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"TS" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/vending/medical{
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "TU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9384,6 +9406,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"TW" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/office)
 "Uc" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
@@ -9431,6 +9459,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/equipmentroom)
+"UC" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"UD" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "UE" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -9490,10 +9531,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"Vp" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/medical/equipstorage)
 "Vr" = (
 /obj/machinery/vending/engineering{
 	dir = 1;
@@ -9501,15 +9538,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"Vx" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
-	},
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Vy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -9567,6 +9595,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"Wo" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/vending/medical{
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Wr" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -9582,6 +9620,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"Wv" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage Room";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/equipstorage)
 "Ww" = (
 /obj/machinery/chemical_dispenser/full,
 /obj/effect/floor_decal/corner/purple/mono,
@@ -9613,6 +9658,13 @@
 /obj/item/gun/projectile/automatic/scp/p90,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
+"WL" = (
+/obj/structure/table/standard,
+/obj/item/storage/medical_lolli_jar{
+	pixel_y = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "WX" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -9771,15 +9823,6 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Yl" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Yo" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9819,10 +9862,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
-"YJ" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "YK" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/snow,
@@ -9906,13 +9945,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
-"ZZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 
 (1,1,1) = {"
 dA
@@ -31300,7 +31332,7 @@ dA
 dA
 dA
 dA
-dR
+pV
 jP
 jP
 eS
@@ -31558,12 +31590,12 @@ dA
 dA
 dA
 eS
-Ng
-DF
-zY
-Gz
-DF
-gc
+DG
+UC
+wp
+cL
+UC
+Kv
 eS
 dA
 dA
@@ -31815,12 +31847,12 @@ dA
 dA
 dA
 eS
-TS
+Wo
 vH
 vH
 vH
 vH
-Gs
+Br
 eS
 dA
 dA
@@ -32072,12 +32104,12 @@ dA
 dA
 dA
 eS
-xw
+dR
 vH
-Be
-DW
+Fn
+Gp
 vH
-yf
+Kh
 eS
 dA
 dA
@@ -32329,12 +32361,12 @@ dA
 dA
 dA
 eS
-Ex
+LW
 vH
-CG
-Yl
+NS
+AW
 vH
-yf
+Kh
 eS
 dA
 dA
@@ -32586,12 +32618,12 @@ dA
 dA
 dA
 eS
-yy
+UD
 vH
-Il
-Pb
+yD
+zH
 vH
-Kk
+uF
 eS
 dA
 dA
@@ -32843,12 +32875,12 @@ dA
 dA
 dA
 eS
-uy
+eU
 vH
 vH
 vH
 vH
-Lc
+gi
 jP
 dA
 dA
@@ -33100,12 +33132,12 @@ dA
 dA
 dA
 eS
-Vx
-MZ
-LN
+yJ
 lc
+yv
+cF
 vH
-Dp
+MU
 jP
 dA
 dA
@@ -33361,7 +33393,7 @@ eS
 eS
 eS
 eS
-Le
+Wv
 jP
 jP
 dA
@@ -33866,7 +33898,7 @@ dA
 dA
 dA
 jP
-gi
+gc
 gb
 dM
 gb
@@ -33881,16 +33913,16 @@ jP
 dA
 dA
 dm
-NY
+pM
 eA
 dm
-NY
+pM
 eA
 dm
-NY
+pM
 eA
 dm
-qh
+Ea
 eA
 dm
 dA
@@ -34123,7 +34155,7 @@ dA
 dA
 dA
 jP
-Vp
+Fb
 dM
 gb
 dM
@@ -34653,16 +34685,16 @@ du
 BO
 Kc
 dm
-hL
+wu
+dm
+dm
+Ib
 dm
 dm
 hL
 dm
 dm
-hL
-dm
-dm
-hL
+AP
 dm
 dm
 nU
@@ -35409,7 +35441,7 @@ dA
 Xy
 iX
 iX
-NS
+iX
 iX
 iX
 iX
@@ -35676,7 +35708,7 @@ fl
 fl
 fl
 pE
-Nc
+CC
 iM
 fh
 mc
@@ -35943,7 +35975,7 @@ jY
 jY
 jY
 jY
-lb
+jY
 mc
 wS
 oP
@@ -36447,7 +36479,7 @@ Ej
 hV
 KB
 pE
-YJ
+oA
 iX
 hE
 mc
@@ -36457,7 +36489,7 @@ jY
 jY
 jY
 jY
-lb
+jY
 mc
 gV
 kU
@@ -36694,12 +36726,12 @@ dA
 dA
 pE
 fz
-kw
+KF
 eI
 iY
 gg
 pE
-JM
+TW
 NA
 cW
 zk
@@ -36961,7 +36993,7 @@ pE
 pE
 pE
 pE
-xh
+zJ
 iX
 fT
 mc
@@ -37465,7 +37497,7 @@ dA
 dA
 dA
 dA
-SR
+RN
 gd
 iw
 iw
@@ -38765,7 +38797,7 @@ iT
 jk
 jN
 jN
-Pa
+pS
 kB
 jN
 jN
@@ -39780,7 +39812,7 @@ dA
 dA
 dA
 dA
-RY
+LC
 gk
 dc
 cZ
@@ -40568,7 +40600,7 @@ ki
 RK
 ki
 lq
-dy
+Ik
 lo
 tC
 aP
@@ -41083,7 +41115,7 @@ da
 da
 da
 da
-eU
+Tq
 tD
 dt
 Ce
@@ -42616,7 +42648,7 @@ ib
 ib
 Vm
 dl
-hf
+Oi
 eO
 fD
 dA
@@ -43386,7 +43418,7 @@ ha
 fE
 fE
 gO
-sh
+Ig
 hf
 iX
 fD
@@ -43900,7 +43932,7 @@ fk
 ew
 bx
 gO
-RV
+hW
 iX
 iX
 fD
@@ -44414,7 +44446,7 @@ hH
 ew
 dx
 gO
-hW
+WL
 iX
 iX
 fD
@@ -44673,7 +44705,7 @@ pe
 gO
 Hl
 iX
-ZZ
+Ax
 fD
 dA
 dA

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -258,13 +258,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/cryogenicsprimary)
-"aM" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "aN" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/prepainted,
@@ -806,13 +799,6 @@
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/prepainted,
 /area/site53/uez/janitor)
-"cw" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "cC" = (
 /obj/machinery/light/small,
 /obj/structure/closet/secure_closet/engineering_electrical{
@@ -1104,6 +1090,11 @@
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
+"dy" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception/waiting)
 "dA" = (
 /turf/unsimulated/mineral,
 /area/space)
@@ -1224,6 +1215,7 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "dR" = (
+/obj/effect/paint_stripe/white,
 /obj/effect/paint_stripe/white,
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/prepainted,
@@ -1563,23 +1555,24 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
 "eS" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_2,
+/obj/effect/paint_stripe/white,
+/obj/effect/paint_stripe/white,
 /turf/simulated/wall/prepainted,
-/area/site53/medical/infirmary)
+/area/site53/medical/equipstorage)
 "eT" = (
 /turf/simulated/floor/plating,
 /area/site53/uez/janitor)
 "eU" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/vending/medical{
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/orange/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 32;
+	pixel_z = -9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/entrancezone/hallway)
 "eV" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -2022,11 +2015,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "gc" = (
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/structure/closet,
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 8
-	},
-/obj/structure/bed/chair{
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
@@ -2070,16 +2067,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "gi" = (
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/structure/closet,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4
-	},
+/obj/structure/table/standard,
+/obj/item/storage/box/cups,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "gj" = (
@@ -2723,7 +2712,9 @@
 /area/site53/medical/mentalhealth/office)
 "hW" = (
 /obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
+/obj/item/storage/medical_lolli_jar{
+	pixel_y = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "hX" = (
@@ -3631,11 +3622,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception)
-"ke" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/exam_room)
 "kf" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -4009,11 +3995,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
 "lc" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
 /obj/structure/table/standard,
-/obj/item/paper,
-/obj/item/pen,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
+/obj/machinery/cell_charger,
+/obj/item/screwdriver,
+/obj/effect/floor_decal/corner/paleblue/half,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "ld" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -4731,11 +4721,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/senioragentoffice)
-"mX" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/cups,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "mY" = (
 /obj/effect/landmark/start{
 	name = "EZ Junior Agent"
@@ -5269,12 +5254,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
-"oQ" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "oS" = (
 /turf/unsimulated/mineral,
 /area/site53/surface/surface)
@@ -5441,15 +5420,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/site53/uez/bridge)
-"pv" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/trauma,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "pw" = (
 /obj/effect/paint_stripe/orange,
 /obj/machinery/status_display,
@@ -5550,6 +5520,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroomstairs)
+"qh" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "qm" = (
 /obj/machinery/light,
 /turf/simulated/open,
@@ -5697,14 +5672,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/site53/surface/cryogenicsprimary)
-"qY" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "qZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white/monotile,
@@ -6143,6 +6110,11 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/logistics/logistics)
+"sh" = (
+/obj/effect/paint_stripe/green,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/surgery/hall)
 "si" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -6776,6 +6748,13 @@
 /obj/item/screwdriver,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
+"uy" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "uz" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -7164,26 +7143,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"vZ" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception/waiting)
-"wc" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/item/book/manual/scp/medsop,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "we" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
@@ -7233,15 +7192,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"wI" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/masks,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "wJ" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
@@ -7331,6 +7281,10 @@
 "xg" = (
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
+"xh" = (
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "xn" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
@@ -7353,6 +7307,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
+"xw" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/masks,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "xx" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
@@ -7378,25 +7341,17 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"xP" = (
-/obj/structure/closet/secure_closet{
-	req_access = list("ACCESS_MEDICAL_LEVEL3")
-	},
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/reagent_containers/syringe/amnesticsc,
-/obj/item/reagent_containers/ivbag/amnesticsd,
-/obj/item/reagent_containers/ivbag/amnesticsf,
-/obj/effect/floor_decal/corner/paleblue,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "xW" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
+"yf" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "yk" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -7408,12 +7363,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"ym" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/office)
 "yt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7422,6 +7371,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
+"yy" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "yz" = (
 /turf/unsimulated/mineral,
 /area/site53/medical/surgery/hall)
@@ -7578,10 +7534,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
-"zD" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/medical/equipstorage)
 "zE" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 5
@@ -7626,6 +7578,16 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op2)
+"zY" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ac" = (
 /obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/clothing/suit/bio_suit/security,
@@ -7706,6 +7668,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"Be" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Bf" = (
 /obj/structure/closet,
 /obj/effect/floor_decal/corner/red/half{
@@ -7848,11 +7819,6 @@
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/prepainted,
 /area/site53/maintenance/surfaceeast)
-"Ch" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception)
 "Ck" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/half{
@@ -7895,12 +7861,12 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"CP" = (
+"CG" = (
 /obj/structure/table/rack,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
@@ -7940,17 +7906,13 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Di" = (
-/obj/effect/floor_decal/corner/orange/border{
+"Dp" = (
+/obj/structure/flora/pottedplant/fern,
+/obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
 	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 32;
-	pixel_z = -9
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Dz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7959,6 +7921,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"DF" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "DO" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -7978,6 +7946,13 @@
 "DV" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfaceeast)
+"DW" = (
+/obj/structure/table/rack,
+/obj/random/firstaid,
+/obj/item/storage/firstaid/stab,
+/obj/effect/floor_decal/corner/paleblue/three_quarters,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "DX" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -8042,15 +8017,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"En" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
-"Er" = (
-/obj/structure/table/standard,
-/obj/item/paper,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
 "Es" = (
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "ezcell3";
@@ -8066,19 +8032,17 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"Ex" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "EJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"ER" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "ET" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -8147,13 +8111,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"FD" = (
-/obj/structure/flora/pottedplant/fern,
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "FH" = (
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile,
@@ -8192,6 +8149,36 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
+"Gs" = (
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs,
+/obj/structure/closet/secure_closet/freezer{
+	icon = 'icons/obj/closets/fridge.dmi';
+	name = "Secure Freezer"
+	},
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/storage/box/freezer,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Gt" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
@@ -8201,24 +8188,15 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"Gw" = (
-/obj/effect/paint_stripe/white,
-/obj/effect/paint_stripe/white,
-/obj/effect/paint_stripe/white,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/equipstorage)
 "Gx" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"GC" = (
+"Gz" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/structure/bed/chair/wheelchair,
 /turf/simulated/floor/tiled/monotile/white,
@@ -8316,22 +8294,6 @@
 /obj/structure/iv_drip,
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
-"Ht" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
-"Hv" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "Hx" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
@@ -8372,16 +8334,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"HR" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/screwdriver,
-/obj/effect/floor_decal/corner/paleblue/half,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "HU" = (
 /obj/machinery/light{
 	dir = 1;
@@ -8402,6 +8354,15 @@
 /obj/item/stack/material/aluminium/fifty,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"Il" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/trauma,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Im" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8522,11 +8483,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
-"JG" = (
-/obj/effect/paint_stripe/green,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/surgery/hall)
+"JM" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/office)
 "JN" = (
 /obj/structure/table/woodentable{
 	dir = 5
@@ -8550,11 +8512,14 @@
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/prepainted,
 /area/site53/medical/infirmary)
-"Kd" = (
-/obj/structure/table/rack,
-/obj/random/firstaid,
-/obj/item/storage/firstaid/stab,
-/obj/effect/floor_decal/corner/paleblue/three_quarters,
+"Kk" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/plastic/fifty,
+/obj/item/stack/material/glass/fifty,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "Kq" = (
@@ -8602,6 +8567,21 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
+"Lc" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/fabricator,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"Le" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage Room";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/equipstorage)
 "Lf" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -8670,13 +8650,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"LP" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/o2,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
+"LN" = (
+/obj/effect/floor_decal/corner/paleblue/half{
 	dir = 8
 	},
+/obj/structure/table/standard,
+/obj/item/book/manual/scp/medsop,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "Ma" = (
@@ -8762,6 +8748,35 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
+"MZ" = (
+/obj/structure/table/standard,
+/obj/item/defibrillator/loaded,
+/obj/item/auto_cpr,
+/obj/item/defibrillator/compact/loaded,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"Nc" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmary)
+"Ng" = (
+/obj/structure/closet/secure_closet{
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
+	},
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/reagent_containers/syringe/amnesticsc,
+/obj/item/reagent_containers/ivbag/amnesticsd,
+/obj/item/reagent_containers/ivbag/amnesticsf,
+/obj/effect/floor_decal/corner/paleblue,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ni" = (
 /obj/effect/floor_decal/corner/red/bordercee{
 	dir = 1
@@ -8782,16 +8797,6 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"Np" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/stack/material/steel/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/glass/fifty,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Ny" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a10mm,
@@ -8825,6 +8830,12 @@
 /obj/item/clothing/suit/hospital,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"NY" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/obj/item/pen,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "Oe" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Sergeant Equipment";
@@ -8892,6 +8903,20 @@
 /obj/machinery/light,
 /turf/simulated/open,
 /area/site53/zonecommanderoffice)
+"Pa" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception)
+"Pb" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Pr" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
@@ -9045,13 +9070,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
-"QR" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 4
-	},
-/obj/structure/bed/chair/wheelchair,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "QT" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
@@ -9076,10 +9094,6 @@
 	dir = 8;
 	pixel_x = -23
 	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
-"QY" = (
-/obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "Ra" = (
@@ -9142,16 +9156,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception/waiting)
-"RQ" = (
-/obj/structure/table/standard,
-/obj/item/defibrillator/loaded,
-/obj/item/auto_cpr,
-/obj/item/defibrillator/compact/loaded,
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "RR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/mre/menu2,
@@ -9162,12 +9166,10 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
 "RV" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storage Room";
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white,
-/area/site53/medical/equipstorage)
+/area/site53/medical/infirmary)
 "RW" = (
 /obj/structure/sign/directions/evac{
 	dir = 4;
@@ -9175,6 +9177,11 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
+"RY" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/sleeper)
 "Sd" = (
 /obj/structure/table/standard,
 /obj/item/defibrillator/loaded,
@@ -9227,13 +9234,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
-"Sv" = (
-/obj/structure/table/standard,
-/obj/item/storage/medical_lolli_jar{
-	pixel_y = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "Sw" = (
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile/white,
@@ -9257,6 +9257,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"SR" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/exam_room)
 "SS" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -9282,36 +9287,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
-"SY" = (
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/lungs,
-/obj/structure/closet/secure_closet/freezer{
-	icon = 'icons/obj/closets/fridge.dmi';
-	name = "Secure Freezer"
-	},
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/storage/box/freezer,
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Td" = (
 /obj/structure/table/reinforced,
 /obj/item/material/ashtray/plastic,
@@ -9391,6 +9366,16 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"TS" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/vending/medical{
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "TU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9412,14 +9397,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
-"Uo" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/fabricator,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Us" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -9513,6 +9490,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
+"Vp" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/medical/equipstorage)
 "Vr" = (
 /obj/machinery/vending/engineering{
 	dir = 1;
@@ -9520,11 +9501,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"Vt" = (
-/obj/effect/paint_stripe/red,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/sleeper)
+"Vx" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Vy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -9786,6 +9771,15 @@
 /obj/effect/floor_decal/corner/purple/border,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"Yl" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Yo" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9825,6 +9819,10 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
+"YJ" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "YK" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/snow,
@@ -9838,12 +9836,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/equipmentroom)
-"YS" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "YT" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "ezcell2";
@@ -9914,6 +9906,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
+"ZZ" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 
 (1,1,1) = {"
 dA
@@ -31301,14 +31300,14 @@ dA
 dA
 dA
 dA
-Gw
+dR
 jP
 jP
-dR
-dR
-dR
-dR
-dR
+eS
+eS
+eS
+eS
+eS
 dA
 dA
 dA
@@ -31558,14 +31557,14 @@ dA
 dA
 dA
 dA
-dR
-xP
-YS
-GC
-QR
-YS
-gi
-dR
+eS
+Ng
+DF
+zY
+Gz
+DF
+gc
+eS
 dA
 dA
 dA
@@ -31815,14 +31814,14 @@ dA
 dA
 dA
 dA
-dR
-eU
+eS
+TS
 vH
 vH
 vH
 vH
-SY
-dR
+Gs
+eS
 dA
 dA
 dA
@@ -32072,14 +32071,14 @@ dA
 dA
 dA
 dA
-dR
-wI
+eS
+xw
 vH
-LP
-Kd
+Be
+DW
 vH
-oQ
-dR
+yf
+eS
 dA
 dA
 dA
@@ -32329,14 +32328,14 @@ dA
 dA
 dA
 dA
-dR
-qY
+eS
+Ex
 vH
-ER
-CP
+CG
+Yl
 vH
-oQ
-dR
+yf
+eS
 dA
 dA
 dA
@@ -32586,14 +32585,14 @@ dA
 dA
 dA
 dA
-dR
-aM
+eS
+yy
 vH
-pv
-Ht
+Il
+Pb
 vH
-Np
-dR
+Kk
+eS
 dA
 dA
 dA
@@ -32843,13 +32842,13 @@ dA
 dA
 dA
 dA
-dR
-cw
+eS
+uy
 vH
 vH
 vH
 vH
-Uo
+Lc
 jP
 dA
 dA
@@ -33100,13 +33099,13 @@ dA
 dA
 dA
 dA
-dR
-gc
-RQ
-wc
-HR
+eS
+Vx
+MZ
+LN
+lc
 vH
-FD
+Dp
 jP
 dA
 dA
@@ -33357,12 +33356,12 @@ jP
 jP
 jP
 jP
-dR
-dR
-dR
-dR
-dR
-RV
+eS
+eS
+eS
+eS
+eS
+Le
 jP
 jP
 dA
@@ -33867,7 +33866,7 @@ dA
 dA
 dA
 jP
-mX
+gi
 gb
 dM
 gb
@@ -33882,16 +33881,16 @@ jP
 dA
 dA
 dm
-lc
+NY
 eA
 dm
-lc
+NY
 eA
 dm
-lc
+NY
 eA
 dm
-Er
+qh
 eA
 dm
 dA
@@ -34124,7 +34123,7 @@ dA
 dA
 dA
 jP
-zD
+Vp
 dM
 gb
 dM
@@ -35677,7 +35676,7 @@ fl
 fl
 fl
 pE
-eS
+Nc
 iM
 fh
 mc
@@ -36448,7 +36447,7 @@ Ej
 hV
 KB
 pE
-En
+YJ
 iX
 hE
 mc
@@ -36700,7 +36699,7 @@ eI
 iY
 gg
 pE
-ym
+JM
 NA
 cW
 zk
@@ -36962,7 +36961,7 @@ pE
 pE
 pE
 pE
-QY
+xh
 iX
 fT
 mc
@@ -37466,7 +37465,7 @@ dA
 dA
 dA
 dA
-ke
+SR
 gd
 iw
 iw
@@ -38766,7 +38765,7 @@ iT
 jk
 jN
 jN
-Ch
+Pa
 kB
 jN
 jN
@@ -39781,7 +39780,7 @@ dA
 dA
 dA
 dA
-Vt
+RY
 gk
 dc
 cZ
@@ -40569,7 +40568,7 @@ ki
 RK
 ki
 lq
-vZ
+dy
 lo
 tC
 aP
@@ -41084,7 +41083,7 @@ da
 da
 da
 da
-Di
+eU
 tD
 dt
 Ce
@@ -43387,7 +43386,7 @@ ha
 fE
 fE
 gO
-JG
+sh
 hf
 iX
 fD
@@ -43901,7 +43900,7 @@ fk
 ew
 bx
 gO
-hW
+RV
 iX
 iX
 fD
@@ -44415,7 +44414,7 @@ hH
 ew
 dx
 gO
-Sv
+hW
 iX
 iX
 fD
@@ -44674,7 +44673,7 @@ pe
 gO
 Hl
 iX
-Hv
+ZZ
 fD
 dA
 dA

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -258,16 +258,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/cryogenicsprimary)
-"aM" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/defibrillator/loaded,
-/obj/item/auto_cpr,
-/obj/item/defibrillator/compact/loaded,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "aN" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/prepainted,
@@ -804,6 +794,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfaceeast)
+"cu" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/obj/item/pen,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "cv" = (
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/prepainted,
@@ -1219,14 +1215,8 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "dR" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "dS" = (
 /obj/structure/bed/chair,
@@ -1419,17 +1409,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
-"ev" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/masks,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "ew" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op2)
@@ -1476,6 +1455,14 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"eD" = (
+/obj/structure/flora/pottedplant/fern,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "eE" = (
@@ -1571,23 +1558,24 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
 "eS" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
 /obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
+/obj/machinery/cell_charger,
+/obj/item/screwdriver,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "eT" = (
 /turf/simulated/floor/plating,
 /area/site53/uez/janitor)
 "eU" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/regular,
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/item/storage/firstaid/regular,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/standard,
+/obj/item/storage/medical_lolli_jar{
+	pixel_y = 10
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "eV" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -2030,12 +2018,10 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "gc" = (
-/obj/structure/table/standard,
-/obj/item/storage/medical_lolli_jar{
-	pixel_y = 10
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/exam_room)
 "gd" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/half{
@@ -2076,8 +2062,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "gi" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/cups,
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "gj" = (
@@ -2720,7 +2709,7 @@
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
 "hW" = (
-/obj/machinery/vending/cola,
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "hX" = (
@@ -3998,12 +3987,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
 "lc" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/trauma,
 /obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
@@ -4307,11 +4293,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"lT" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/exam_room)
 "lW" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
@@ -5503,11 +5484,32 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/senioragentoffice)
-"pP" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmary)
+"pS" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/book/manual/scp/medsop,
+/obj/machinery/light,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"pT" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/trauma,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"pV" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "pW" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/maple,
@@ -6534,6 +6536,13 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"tG" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/vending/medical{
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "tH" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/half{
@@ -7040,16 +7049,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/commstower)
-"vu" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "vv" = (
 /obj/machinery/light{
 	dir = 4;
@@ -7131,6 +7130,11 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"vM" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmary)
 "vO" = (
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -7254,6 +7258,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
+"wW" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "xa" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 9
@@ -7287,6 +7295,11 @@
 "xg" = (
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
+"xl" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "xn" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
@@ -7322,13 +7335,6 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/o5repoffice)
-"xE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "xF" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/r_wall/prepainted,
@@ -7341,16 +7347,54 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"xV" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/structure/closet,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "xW" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
-"yj" = (
-/obj/structure/table/standard,
-/obj/item/paper,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
+"xY" = (
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs,
+/obj/structure/closet/secure_closet/freezer{
+	icon = 'icons/obj/closets/fridge.dmi';
+	name = "Secure Freezer"
+	},
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/storage/box/freezer,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "yk" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -7362,6 +7406,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"yl" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "yt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7408,17 +7461,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"yY" = (
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
+"yZ" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage Room";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 32;
-	pixel_z = -9
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/equipstorage)
 "za" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -7611,19 +7660,6 @@
 "Ao" = (
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
-"Ar" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/structure/closet,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Az" = (
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile/white,
@@ -7681,15 +7717,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"Bm" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Bq" = (
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 4
@@ -7857,6 +7884,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"Cx" = (
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 32;
+	pixel_z = -9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/entrancezone/hallway)
 "CF" = (
 /obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/clothing/suit/bio_suit/security,
@@ -7867,13 +7905,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"CP" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/machinery/fabricator,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "CU" = (
 /obj/structure/iv_drip,
 /obj/structure/cable/green{
@@ -7910,6 +7941,12 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"Dm" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Dz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7918,12 +7955,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"DJ" = (
-/obj/structure/table/standard,
-/obj/item/paper,
-/obj/item/pen,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
 "DO" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -7959,26 +7990,6 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"DZ" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/combat,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/storage/firstaid/combat,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
-"Eb" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/random/firstaid,
-/obj/item/storage/firstaid/stab,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Ec" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -8042,6 +8053,12 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"EF" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "EJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -8131,11 +8148,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
-"FX" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception/waiting)
 "Gb" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -8217,10 +8229,6 @@
 	},
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
-"Hd" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "He" = (
 /obj/machinery/atmospherics/unary/tank/air{
 	dir = 4
@@ -8243,9 +8251,10 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "Hl" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception/waiting)
 "Ho" = (
 /obj/structure/closet/secure_closet/mtf/nco/ez,
 /obj/item/crowbar/red,
@@ -8273,6 +8282,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/sleeper)
+"Hz" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "HG" = (
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/half{
@@ -8309,6 +8324,20 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"HR" = (
+/obj/structure/closet/secure_closet{
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
+	},
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/reagent_containers/syringe/amnesticsc,
+/obj/item/reagent_containers/ivbag/amnesticsd,
+/obj/item/reagent_containers/ivbag/amnesticsf,
+/obj/effect/floor_decal/corner/paleblue,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "HU" = (
 /obj/machinery/light{
 	dir = 1;
@@ -8329,6 +8358,15 @@
 /obj/item/stack/material/aluminium/fifty,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
+"Id" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Im" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8410,12 +8448,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
-"Jn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/office)
 "Jr" = (
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/monotile/white,
@@ -8511,6 +8543,13 @@
 /obj/item/ammo_magazine/box/a556,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
+"KX" = (
+/obj/machinery/fabricator,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Lb" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Helipad";
@@ -8581,6 +8620,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
+"LC" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "LE" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "ezcell1";
@@ -8592,6 +8638,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"LM" = (
+/obj/structure/table/standard,
+/obj/item/defibrillator/loaded,
+/obj/item/auto_cpr,
+/obj/item/defibrillator/compact/loaded,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ma" = (
 /obj/machinery/door/airlock/glass/civilian{
 	name = "Hub"
@@ -8644,6 +8700,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
+"My" = (
+/obj/structure/table/rack,
+/obj/random/firstaid,
+/obj/item/storage/firstaid/stab,
+/obj/effect/floor_decal/corner/paleblue/three_quarters,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "MN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8664,35 +8727,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"MV" = (
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/lungs,
-/obj/structure/closet/secure_closet/freezer{
-	icon = 'icons/obj/closets/fridge.dmi';
-	name = "Secure Freezer"
-	},
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/storage/box/freezer,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "MX" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
@@ -8718,19 +8752,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensicsstairwell)
+"Nj" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/cups,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Nk" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"Nr" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/vending/medical{
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+"Nl" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/sleeper)
 "Ny" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a10mm,
@@ -8764,6 +8801,11 @@
 /obj/item/clothing/suit/hospital,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"NY" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception)
 "Oe" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Sergeant Equipment";
@@ -8831,6 +8873,15 @@
 /obj/machinery/light,
 /turf/simulated/open,
 /area/site53/zonecommanderoffice)
+"OJ" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/masks,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Pr" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
@@ -8903,20 +8954,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
 /area/site53/surface/surface)
-"Qb" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/closet/secure_closet{
-	req_access = list("ACCESS_MEDICAL_LEVEL3")
-	},
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/reagent_containers/syringe/amnesticsc,
-/obj/item/reagent_containers/ivbag/amnesticsd,
-/obj/item/reagent_containers/ivbag/amnesticsf,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Qe" = (
 /turf/simulated/wall/wood,
 /area/site53/surface/surface)
@@ -8967,15 +9004,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"Qs" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
-"QH" = (
-/obj/effect/paint_stripe/red,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/sleeper)
+"QD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/office)
 "QJ" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -8988,16 +9022,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uez/armory)
-"QL" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/o2,
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "QP" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
@@ -9017,10 +9041,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
-"QS" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/medical/equipstorage)
 "QT" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
@@ -9056,6 +9076,19 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
+"Rh" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/stack/material/glass/fifty,
+/obj/item/stack/material/plastic/fifty,
+/obj/item/stack/material/steel/fifty,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ri" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -9170,15 +9203,6 @@
 /obj/item/stack/material/titanium/fifty,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
-"Sq" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/screwdriver,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Su" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
@@ -9250,6 +9274,15 @@
 /obj/structure/closet,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"TF" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "TG" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9409,6 +9442,15 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/logistics/logistics)
+"Vj" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Vl" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/teargas,
@@ -9477,13 +9519,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/equipstorage)
-"VP" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storage Room";
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/equipstorage)
 "Wl" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
@@ -9519,14 +9554,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
-"WA" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/steel/fifty,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+"WF" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "WG" = (
 /obj/machinery/floodlight{
 	anchored = 1;
@@ -9561,11 +9595,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"WZ" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception)
 "Xd" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 9
@@ -9575,6 +9604,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/mentalhealth/isolation)
+"Xf" = (
+/obj/effect/paint_stripe/green,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/surgery/hall)
 "Xq" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/border,
@@ -9601,6 +9635,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /area/site53/medical/infirmary)
+"Xz" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "XD" = (
 /obj/effect/floor_decal/corner/orange/border,
 /obj/machinery/papershredder,
@@ -9752,10 +9791,22 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
+"YI" = (
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "YK" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"YQ" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "YR" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -9777,16 +9828,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
 "YY" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
 	},
-/obj/structure/table/standard,
-/obj/item/book/manual/scp/medsop,
-/obj/machinery/light,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "Za" = (
@@ -9802,11 +9849,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/uez/o5repoffice)
-"Zk" = (
-/obj/effect/paint_stripe/green,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/surgery/hall)
 "Zn" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
@@ -30729,11 +30771,11 @@ dA
 dA
 dA
 dA
-jP
-jP
-jP
-jP
-jP
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -30983,15 +31025,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-Qb
-vH
-Ar
 jP
-dA
+jP
+jP
+jP
+jP
+jP
+jP
+jP
 dA
 dA
 dA
@@ -31240,15 +31282,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-Eb
-vH
-ev
+HR
+EF
+EF
+Id
+EF
+EF
+xY
 jP
-dA
 dA
 dA
 dA
@@ -31497,15 +31539,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-DZ
+gi
 vH
-dR
+vH
+vH
+vH
+vH
+xV
 jP
-dA
 dA
 dA
 dA
@@ -31754,15 +31796,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-vu
+tG
 vH
-Bm
+vH
+TF
+My
+vH
+Hz
 jP
-dA
 dA
 dA
 dA
@@ -32011,15 +32053,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-Nr
+OJ
 vH
-MV
+vH
+yl
+YY
+vH
+Hz
 jP
-dA
 dA
 dA
 dA
@@ -32268,15 +32310,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-QL
+YQ
 vH
-aM
+vH
+pT
+Vj
+vH
+Hz
 jP
-dA
 dA
 dA
 dA
@@ -32525,15 +32567,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-eU
+LC
 vH
-YY
+vH
+vH
+vH
+vH
+Hz
 jP
-dA
 dA
 dA
 dA
@@ -32782,15 +32824,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
 lc
 vH
-Sq
+vH
+vH
+vH
+vH
+eD
 jP
-dA
 dA
 dA
 dA
@@ -33039,15 +33081,15 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
 jP
-WA
-vH
-CP
+LM
+pS
+eS
+Rh
+Dm
+Dm
+KX
 jP
-dA
 dA
 dA
 dA
@@ -33301,10 +33343,10 @@ jP
 jP
 jP
 jP
-VP
+yZ
 jP
 jP
-dA
+jP
 dA
 dA
 dA
@@ -33806,7 +33848,7 @@ dA
 dA
 dA
 jP
-gi
+Nj
 gb
 dM
 gb
@@ -33814,23 +33856,23 @@ dM
 gb
 dM
 fg
-Qs
+pV
 vH
 ba
 jP
 dA
 dA
 dm
-DJ
+cu
 eA
 dm
-DJ
+cu
 eA
 dm
-DJ
+cu
 eA
 dm
-yj
+Xz
 eA
 dm
 dA
@@ -34063,7 +34105,7 @@ dA
 dA
 dA
 jP
-QS
+dR
 dM
 gb
 dM
@@ -35616,7 +35658,7 @@ fl
 fl
 fl
 pE
-pP
+vM
 iM
 fh
 mc
@@ -36387,7 +36429,7 @@ Ej
 hV
 KB
 pE
-Hd
+wW
 iX
 hE
 mc
@@ -36639,7 +36681,7 @@ eI
 iY
 gg
 pE
-Jn
+QD
 NA
 cW
 zk
@@ -36901,7 +36943,7 @@ pE
 pE
 pE
 pE
-hW
+YI
 iX
 fT
 mc
@@ -37405,7 +37447,7 @@ dA
 dA
 dA
 dA
-lT
+gc
 gd
 iw
 iw
@@ -38705,7 +38747,7 @@ iT
 jk
 jN
 jN
-WZ
+NY
 kB
 jN
 jN
@@ -39214,7 +39256,7 @@ gT
 gT
 gT
 gT
-Hl
+hW
 iX
 Qm
 cm
@@ -39720,7 +39762,7 @@ dA
 dA
 dA
 dA
-QH
+Nl
 gk
 dc
 cZ
@@ -40508,7 +40550,7 @@ ki
 RK
 ki
 lq
-FX
+Hl
 lo
 tC
 aP
@@ -41023,7 +41065,7 @@ da
 da
 da
 da
-yY
+Cx
 tD
 dt
 Ce
@@ -43326,7 +43368,7 @@ ha
 fE
 fE
 gO
-Zk
+Xf
 hf
 iX
 fD
@@ -43840,7 +43882,7 @@ fk
 ew
 bx
 gO
-eS
+xl
 iX
 iX
 fD
@@ -44354,7 +44396,7 @@ hH
 ew
 dx
 gO
-gc
+eU
 iX
 iX
 fD
@@ -44611,9 +44653,9 @@ gD
 dZ
 pe
 gO
-Hl
+hW
 iX
-xE
+WF
 fD
 dA
 dA

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -258,6 +258,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/cryogenicsprimary)
+"aM" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "aN" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/prepainted,
@@ -384,6 +391,7 @@
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "bb" = (
@@ -794,16 +802,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfaceeast)
-"cu" = (
-/obj/structure/table/standard,
-/obj/item/paper,
-/obj/item/pen,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
 "cv" = (
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/prepainted,
 /area/site53/uez/janitor)
+"cw" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "cC" = (
 /obj/machinery/light/small,
 /obj/structure/closet/secure_closet/engineering_electrical{
@@ -1215,8 +1224,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "dR" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/dark/monotile,
+/obj/effect/paint_stripe/white,
+/obj/effect/paint_stripe/white,
+/turf/simulated/wall/prepainted,
 /area/site53/medical/equipstorage)
 "dS" = (
 /obj/structure/bed/chair,
@@ -1294,6 +1304,9 @@
 	pixel_y = 30
 	},
 /obj/structure/flora/pottedplant/stoutbush,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "ef" = (
@@ -1457,14 +1470,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
-"eD" = (
-/obj/structure/flora/pottedplant/fern,
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "eE" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -1558,24 +1563,23 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
 "eS" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/machinery/cell_charger,
-/obj/item/screwdriver,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmary)
 "eT" = (
 /turf/simulated/floor/plating,
 /area/site53/uez/janitor)
 "eU" = (
-/obj/structure/table/standard,
-/obj/item/storage/medical_lolli_jar{
-	pixel_y = 10
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/machinery/vending/medical{
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
 	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "eV" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -2018,10 +2022,14 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
 "gc" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/exam_room)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "gd" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/half{
@@ -2062,10 +2070,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "gi" = (
-/obj/structure/bed/chair,
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/light{
-	dir = 1
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/item/bodybag/cryobag,
+/obj/structure/closet,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
@@ -2709,7 +2722,8 @@
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
 "hW" = (
-/obj/machinery/papershredder,
+/obj/structure/table/standard,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "hX" = (
@@ -3617,6 +3631,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception)
+"ke" = (
+/obj/effect/paint_stripe/paleblue,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/exam_room)
 "kf" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -3787,6 +3806,9 @@
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/combat,
 /obj/effect/floor_decal/corner/paleblue/half,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "kA" = (
@@ -3987,12 +4009,11 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
 "lc" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+/obj/structure/table/standard,
+/obj/item/paper,
+/obj/item/pen,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "ld" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -4710,6 +4731,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/senioragentoffice)
+"mX" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/cups,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "mY" = (
 /obj/effect/landmark/start{
 	name = "EZ Junior Agent"
@@ -5243,6 +5269,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
+"oQ" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "oS" = (
 /turf/unsimulated/mineral,
 /area/site53/surface/surface)
@@ -5409,6 +5441,15 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/site53/uez/bridge)
+"pv" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/trauma,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "pw" = (
 /obj/effect/paint_stripe/orange,
 /obj/machinery/status_display,
@@ -5484,32 +5525,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/senioragentoffice)
-"pS" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/item/book/manual/scp/medsop,
-/obj/machinery/light,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
-"pT" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/trauma,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
-"pV" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "pW" = (
 /obj/machinery/door/unpowered/simple/wood,
 /turf/simulated/floor/wood/maple,
@@ -5682,6 +5697,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/site53/surface/cryogenicsprimary)
+"qY" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "qZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white/monotile,
@@ -6536,13 +6559,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"tG" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/machinery/vending/medical{
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "tH" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/half{
@@ -7130,11 +7146,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"vM" = (
-/obj/effect/paint_stripe/paleblue,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmary)
 "vO" = (
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -7153,6 +7164,26 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
+"vZ" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception/waiting)
+"wc" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/book/manual/scp/medsop,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/obj/item/clothing/glasses/hud/health,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "we" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
@@ -7202,6 +7233,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"wI" = (
+/obj/effect/floor_decal/corner/paleblue/half,
+/obj/structure/table/standard,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/gloves,
+/obj/item/storage/box/masks,
+/obj/item/storage/box/masks,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "wJ" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
@@ -7258,10 +7298,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
-"wW" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "xa" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 9
@@ -7295,11 +7331,6 @@
 "xg" = (
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
-"xl" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "xn" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
@@ -7347,18 +7378,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"xV" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
+"xP" = (
+/obj/structure/closet/secure_closet{
+	req_access = list("ACCESS_MEDICAL_LEVEL3")
 	},
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/roller,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/item/bodybag/cryobag,
-/obj/structure/closet,
-/obj/machinery/light,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/reagent_containers/syringe/amnesticsc,
+/obj/item/reagent_containers/ivbag/amnesticsd,
+/obj/item/reagent_containers/ivbag/amnesticsf,
+/obj/effect/floor_decal/corner/paleblue,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "xW" = (
@@ -7366,35 +7397,6 @@
 /obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
-"xY" = (
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/lungs,
-/obj/structure/closet/secure_closet/freezer{
-	icon = 'icons/obj/closets/fridge.dmi';
-	name = "Secure Freezer"
-	},
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/storage/box/freezer,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "yk" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -7406,15 +7408,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"yl" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/regular,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+"ym" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/office)
 "yt" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7461,13 +7460,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
-"yZ" = (
-/obj/machinery/door/airlock/medical{
-	name = "Medical Storage Room";
-	req_access = list("ACCESS_MEDICAL_LEVEL1")
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/equipstorage)
 "za" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -7586,6 +7578,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
+"zD" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/medical/equipstorage)
 "zE" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 5
@@ -7852,6 +7848,11 @@
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/prepainted,
 /area/site53/maintenance/surfaceeast)
+"Ch" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/infirmreception)
 "Ck" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/half{
@@ -7884,17 +7885,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Cx" = (
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/obj/structure/sign/directions/science{
-	dir = 4;
-	pixel_y = 32;
-	pixel_z = -9
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
 "CF" = (
 /obj/structure/closet/secure_closet/mtf/nco,
 /obj/item/clothing/suit/bio_suit/security,
@@ -7905,6 +7895,15 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"CP" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "CU" = (
 /obj/structure/iv_drip,
 /obj/structure/cable/green{
@@ -7941,12 +7940,17 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Dm" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
+"Di" = (
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
+/obj/structure/sign/directions/science{
+	dir = 4;
+	pixel_y = 32;
+	pixel_z = -9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/entrancezone/hallway)
 "Dz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8038,6 +8042,15 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
+"En" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
+"Er" = (
+/obj/structure/table/standard,
+/obj/item/paper,
+/turf/simulated/floor/wood/walnut,
+/area/site53/medical/mentalhealth/isolation)
 "Es" = (
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "ezcell3";
@@ -8053,16 +8066,19 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"EF" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "EJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
+"ER" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "ET" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -8131,6 +8147,13 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
+"FD" = (
+/obj/structure/flora/pottedplant/fern,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "FH" = (
 /obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile,
@@ -8178,12 +8201,28 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
+"Gw" = (
+/obj/effect/paint_stripe/white,
+/obj/effect/paint_stripe/white,
+/obj/effect/paint_stripe/white,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/equipstorage)
 "Gx" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
+"GC" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "GH" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -8251,10 +8290,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "Hl" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception/waiting)
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Ho" = (
 /obj/structure/closet/secure_closet/mtf/nco/ez,
 /obj/item/crowbar/red,
@@ -8278,16 +8316,26 @@
 /obj/structure/iv_drip,
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
+"Ht" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
+"Hv" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32;
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Hx" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/sleeper)
-"Hz" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "HG" = (
 /obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/corner/red/half{
@@ -8325,17 +8373,13 @@
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
 "HR" = (
-/obj/structure/closet/secure_closet{
-	req_access = list("ACCESS_MEDICAL_LEVEL3")
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
 	},
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsa,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/reagent_containers/syringe/amnesticsc,
-/obj/item/reagent_containers/ivbag/amnesticsd,
-/obj/item/reagent_containers/ivbag/amnesticsf,
-/obj/effect/floor_decal/corner/paleblue,
+/obj/structure/table/standard,
+/obj/machinery/cell_charger,
+/obj/item/screwdriver,
+/obj/effect/floor_decal/corner/paleblue/half,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "HU" = (
@@ -8358,15 +8402,6 @@
 /obj/item/stack/material/aluminium/fifty,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
-"Id" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Im" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -8439,7 +8474,6 @@
 /obj/structure/closet/secure_closet/paramedic{
 	req_access = list("ACCESS_MEDICAL_LEVEL2")
 	},
-/obj/machinery/light,
 /obj/item/storage/firstaid/adv,
 /obj/item/crowbar/prybar,
 /obj/item/storage/firstaid/combat,
@@ -8488,6 +8522,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
+"JG" = (
+/obj/effect/paint_stripe/green,
+/obj/structure/sign/warning/nosmoking_2,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/surgery/hall)
 "JN" = (
 /obj/structure/table/woodentable{
 	dir = 5
@@ -8511,6 +8550,13 @@
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/prepainted,
 /area/site53/medical/infirmary)
+"Kd" = (
+/obj/structure/table/rack,
+/obj/random/firstaid,
+/obj/item/storage/firstaid/stab,
+/obj/effect/floor_decal/corner/paleblue/three_quarters,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Kq" = (
 /obj/effect/floor_decal/corner/orange{
 	dir = 6
@@ -8543,13 +8589,6 @@
 /obj/item/ammo_magazine/box/a556,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
-"KX" = (
-/obj/machinery/fabricator,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Lb" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Helipad";
@@ -8620,13 +8659,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"LC" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "LE" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "ezcell1";
@@ -8638,12 +8670,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"LM" = (
-/obj/structure/table/standard,
-/obj/item/defibrillator/loaded,
-/obj/item/auto_cpr,
-/obj/item/defibrillator/compact/loaded,
-/obj/effect/floor_decal/corner/paleblue{
+"LP" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2,
+/obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -8700,13 +8731,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"My" = (
-/obj/structure/table/rack,
-/obj/random/firstaid,
-/obj/item/storage/firstaid/stab,
-/obj/effect/floor_decal/corner/paleblue/three_quarters,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "MN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8752,22 +8776,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensicsstairwell)
-"Nj" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/cups,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Nk" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"Nl" = (
-/obj/effect/paint_stripe/red,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/sleeper)
+"Np" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/structure/table/standard,
+/obj/item/stack/material/steel/fifty,
+/obj/item/stack/material/plastic/fifty,
+/obj/item/stack/material/glass/fifty,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Ny" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a10mm,
@@ -8801,11 +8825,6 @@
 /obj/item/clothing/suit/hospital,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"NY" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/warning/nosmoking_1,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/infirmreception)
 "Oe" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Sergeant Equipment";
@@ -8873,15 +8892,6 @@
 /obj/machinery/light,
 /turf/simulated/open,
 /area/site53/zonecommanderoffice)
-"OJ" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/masks,
-/obj/item/storage/box/masks,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Pr" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/snow,
@@ -9004,12 +9014,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"QD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/office)
 "QJ" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -9041,6 +9045,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
+"QR" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/obj/structure/bed/chair/wheelchair,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "QT" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 8
@@ -9067,6 +9078,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"QY" = (
+/obj/machinery/vending/cola,
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Ra" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -9076,19 +9091,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"Rh" = (
-/obj/effect/floor_decal/corner/paleblue/half{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/obj/item/stack/material/glass/fifty,
-/obj/item/stack/material/plastic/fifty,
-/obj/item/stack/material/steel/fifty,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Ri" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -9140,6 +9142,16 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception/waiting)
+"RQ" = (
+/obj/structure/table/standard,
+/obj/item/defibrillator/loaded,
+/obj/item/auto_cpr,
+/obj/item/defibrillator/compact/loaded,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "RR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/mre/menu2,
@@ -9149,6 +9161,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
+"RV" = (
+/obj/machinery/door/airlock/medical{
+	name = "Medical Storage Room";
+	req_access = list("ACCESS_MEDICAL_LEVEL1")
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/equipstorage)
 "RW" = (
 /obj/structure/sign/directions/evac{
 	dir = 4;
@@ -9208,6 +9227,13 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
+"Sv" = (
+/obj/structure/table/standard,
+/obj/item/storage/medical_lolli_jar{
+	pixel_y = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/medical/infirmary)
 "Sw" = (
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile/white,
@@ -9256,6 +9282,36 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
+"SY" = (
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs,
+/obj/structure/closet/secure_closet/freezer{
+	icon = 'icons/obj/closets/fridge.dmi';
+	name = "Secure Freezer"
+	},
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/storage/box/freezer,
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Td" = (
 /obj/structure/table/reinforced,
 /obj/item/material/ashtray/plastic,
@@ -9274,15 +9330,6 @@
 /obj/structure/closet,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"TF" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/toxin,
-/obj/item/storage/firstaid/o2,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "TG" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9365,6 +9412,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
+"Uo" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/machinery/fabricator,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "Us" = (
 /obj/machinery/sleeper{
 	dir = 8
@@ -9442,15 +9497,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/logistics/logistics)
-"Vj" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/effect/floor_decal/corner/paleblue/three_quarters{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Vl" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/teargas,
@@ -9474,6 +9520,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
+"Vt" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/sign/warning/nosmoking_1,
+/turf/simulated/wall/prepainted,
+/area/site53/medical/sleeper)
 "Vy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -9554,13 +9605,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
-"WF" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32;
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "WG" = (
 /obj/machinery/floodlight{
 	anchored = 1;
@@ -9604,11 +9648,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/mentalhealth/isolation)
-"Xf" = (
-/obj/effect/paint_stripe/green,
-/obj/structure/sign/warning/nosmoking_2,
-/turf/simulated/wall/prepainted,
-/area/site53/medical/surgery/hall)
 "Xq" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/border,
@@ -9635,11 +9674,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /area/site53/medical/infirmary)
-"Xz" = (
-/obj/structure/table/standard,
-/obj/item/paper,
-/turf/simulated/floor/wood/walnut,
-/area/site53/medical/mentalhealth/isolation)
 "XD" = (
 /obj/effect/floor_decal/corner/orange/border,
 /obj/machinery/papershredder,
@@ -9791,22 +9825,10 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
-"YI" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled/white,
-/area/site53/medical/infirmary)
 "YK" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"YQ" = (
-/obj/effect/floor_decal/corner/paleblue/half,
-/obj/structure/table/standard,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "YR" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -9816,6 +9838,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/equipmentroom)
+"YS" = (
+/obj/effect/floor_decal/corner/paleblue/half{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/medical/equipstorage)
 "YT" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "ezcell2";
@@ -9827,15 +9855,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
-"YY" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/medical/equipstorage)
 "Za" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/wood/maple,
@@ -31025,15 +31044,15 @@ dA
 dA
 dA
 dA
-jP
-jP
-jP
-jP
-jP
-jP
-jP
-jP
-jP
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -31282,15 +31301,15 @@ dA
 dA
 dA
 dA
+Gw
 jP
-HR
-EF
-EF
-Id
-EF
-EF
-xY
 jP
+dR
+dR
+dR
+dR
+dR
+dA
 dA
 dA
 dA
@@ -31539,15 +31558,15 @@ dA
 dA
 dA
 dA
-jP
+dR
+xP
+YS
+GC
+QR
+YS
 gi
-vH
-vH
-vH
-vH
-vH
-xV
-jP
+dR
+dA
 dA
 dA
 dA
@@ -31796,15 +31815,15 @@ dA
 dA
 dA
 dA
-jP
-tG
+dR
+eU
 vH
 vH
-TF
-My
 vH
-Hz
-jP
+vH
+SY
+dR
+dA
 dA
 dA
 dA
@@ -32053,15 +32072,15 @@ dA
 dA
 dA
 dA
-jP
-OJ
+dR
+wI
 vH
+LP
+Kd
 vH
-yl
-YY
-vH
-Hz
-jP
+oQ
+dR
+dA
 dA
 dA
 dA
@@ -32310,15 +32329,15 @@ dA
 dA
 dA
 dA
-jP
-YQ
+dR
+qY
 vH
+ER
+CP
 vH
-pT
-Vj
-vH
-Hz
-jP
+oQ
+dR
+dA
 dA
 dA
 dA
@@ -32567,15 +32586,15 @@ dA
 dA
 dA
 dA
-jP
-LC
+dR
+aM
 vH
+pv
+Ht
 vH
-vH
-vH
-vH
-Hz
-jP
+Np
+dR
+dA
 dA
 dA
 dA
@@ -32824,15 +32843,15 @@ dA
 dA
 dA
 dA
+dR
+cw
+vH
+vH
+vH
+vH
+Uo
 jP
-lc
-vH
-vH
-vH
-vH
-vH
-eD
-jP
+dA
 dA
 dA
 dA
@@ -33081,15 +33100,15 @@ dA
 dA
 dA
 dA
+dR
+gc
+RQ
+wc
+HR
+vH
+FD
 jP
-LM
-pS
-eS
-Rh
-Dm
-Dm
-KX
-jP
+dA
 dA
 dA
 dA
@@ -33338,15 +33357,15 @@ jP
 jP
 jP
 jP
+dR
+dR
+dR
+dR
+dR
+RV
 jP
 jP
-jP
-jP
-jP
-yZ
-jP
-jP
-jP
+dA
 dA
 dA
 dA
@@ -33848,7 +33867,7 @@ dA
 dA
 dA
 jP
-Nj
+mX
 gb
 dM
 gb
@@ -33856,23 +33875,23 @@ dM
 gb
 dM
 fg
-pV
+vH
 vH
 ba
 jP
 dA
 dA
 dm
-cu
+lc
 eA
 dm
-cu
+lc
 eA
 dm
-cu
+lc
 eA
 dm
-Xz
+Er
 eA
 dm
 dA
@@ -34105,7 +34124,7 @@ dA
 dA
 dA
 jP
-dR
+zD
 dM
 gb
 dM
@@ -35658,7 +35677,7 @@ fl
 fl
 fl
 pE
-vM
+eS
 iM
 fh
 mc
@@ -36429,7 +36448,7 @@ Ej
 hV
 KB
 pE
-wW
+En
 iX
 hE
 mc
@@ -36681,7 +36700,7 @@ eI
 iY
 gg
 pE
-QD
+ym
 NA
 cW
 zk
@@ -36943,7 +36962,7 @@ pE
 pE
 pE
 pE
-YI
+QY
 iX
 fT
 mc
@@ -37447,7 +37466,7 @@ dA
 dA
 dA
 dA
-gc
+ke
 gd
 iw
 iw
@@ -38747,7 +38766,7 @@ iT
 jk
 jN
 jN
-NY
+Ch
 kB
 jN
 jN
@@ -39256,7 +39275,7 @@ gT
 gT
 gT
 gT
-hW
+Hl
 iX
 Qm
 cm
@@ -39762,7 +39781,7 @@ dA
 dA
 dA
 dA
-Nl
+Vt
 gk
 dc
 cZ
@@ -40550,7 +40569,7 @@ ki
 RK
 ki
 lq
-Hl
+vZ
 lo
 tC
 aP
@@ -41065,7 +41084,7 @@ da
 da
 da
 da
-Cx
+Di
 tD
 dt
 Ce
@@ -43368,7 +43387,7 @@ ha
 fE
 fE
 gO
-Xf
+JG
 hf
 iX
 fD
@@ -43882,7 +43901,7 @@ fk
 ew
 bx
 gO
-xl
+hW
 iX
 iX
 fD
@@ -44396,7 +44415,7 @@ hH
 ew
 dx
 gO
-eU
+Sv
 iX
 iX
 fD
@@ -44653,9 +44672,9 @@ gD
 dZ
 pe
 gO
-hW
+Hl
 iX
-WF
+Hv
 fD
 dA
 dA


### PR DESCRIPTION
## About the Pull Request

A redesign of Medbay with bug fixes, new items, and space filler.

## Why It's Good For The Game

Now it's a little more comfortable to play ( I hope )

## Changelog

:cl:
add: Moved chem fridge from Recovery Ward to Chemistry and added windoor in front of it.
add: Added some extinguisher cabinets.
add: Added NO SMOKING signs.
add: Closet for coroner in morgue.
add: Added food vendors.
add: Added more items in Psychiatrist office, like boombox, camera, recorder, etc.
add: Medical Storage room.
add: Added one more sleeper and sanner in the Recovery Ward.
add: Added more lights around.
add: Added more stuff around, like papers, pens, cleaners, plants and others.
add: Added some carpets edges on this level.
fix: Replaced some floor tiles under the doors it must be.
fix: Access to anestethics closets in surgery ( now it can be opened ).
/:cl:

![image](https://user-images.githubusercontent.com/89781344/188659048-42d2adfa-4a88-4b29-953e-2d55e8638457.png)

![image](https://user-images.githubusercontent.com/89781344/188659088-a01cb337-8bb3-4b48-9df8-d7cc98d1d7c1.png)

![image](https://user-images.githubusercontent.com/89781344/188659126-6a660a84-cd2a-4b80-904a-021e30764162.png)

![image](https://user-images.githubusercontent.com/89781344/188659158-95624a10-bd5e-4eda-b3f9-64bd79d2cc90.png)

![image](https://user-images.githubusercontent.com/89781344/188659183-9d1f4c30-11f7-40f4-b59a-6f9ece797c23.png)

![image](https://user-images.githubusercontent.com/89781344/188659243-5ea8dcbb-ff8c-43ec-9a11-df3ec68a692b.png)
