### PR TITLE
Chaos Base armory rework

### DIFF
--- a/maps/site53/z1_admin.dmm
+++ b/maps/site53/z1_admin.dmm
@@ -2359,17 +2359,22 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "ld" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 4
+	},
 /obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/turf/simulated/floor/tiled/techfloor,
+/obj/item/clothing/mask/chameleon/voice{
+	desc = "A face-covering mask that can be connected to an air supply. It seems to house some odd electronics. Literally a voice changer";
+	name = "SCP-1996-RU"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "le" = (
 /obj/structure/closet{
@@ -2380,8 +2385,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/centcom/chaos)
 "lj" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/turf/simulated/floor/exoplanet/snow,
+/obj/structure/table/rack/dark,
+/obj/item/gun/projectile/automatic/scp/rpk,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
 /area/centcom/chaos)
 "ll" = (
 /obj/effect/landmark{
@@ -2400,12 +2410,7 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "lu" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 1
-	},
-/turf/simulated/floor/lino,
-/area/centcom/chaos)
-"lv" = (
+/obj/structure/table/woodentable,
 /obj/machinery/light,
 /turf/simulated/floor/lino,
 /area/centcom/chaos)
@@ -2652,18 +2657,17 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/centcom/chaos)
 "mJ" = (
-/obj/machinery/door/airlock/highsecurity,
-/obj/machinery/door/blast/shutters{
-	explosion_resistance = 100
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/table/rack/dark,
+/obj/item/gun/projectile/automatic/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/turf/simulated/floor/tiled/dark,
 /area/centcom/chaos)
 "mK" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/steel_grid,
+/obj/machinery/door/airlock/highsecurity,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "mL" = (
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -2719,10 +2723,22 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/centcom/chaos)
 "nc" = (
-/obj/structure/table/reinforced,
-/obj/random/smokes,
-/obj/random/smokes,
-/obj/random/smokes,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
+/obj/item/device/chameleon,
+/obj/machinery/door/window/brigdoor/southright{
+	dir = 4
+	},
+/obj/structure/table/rack,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "nd" = (
@@ -2773,8 +2789,26 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/centcom/chaos)
 "np" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/obj/item/ammo_magazine/scp/svd,
+/turf/simulated/floor/tiled/techfloor,
 /area/centcom/chaos)
 "nq" = (
 /turf/unsimulated/wall{
@@ -2785,11 +2819,6 @@
 	name = "Sleeping Quarters"
 	},
 /area/centcom)
-"nr" = (
-/obj/structure/table/reinforced,
-/obj/item/ammo_casing/rocket,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
 "ns" = (
 /obj/structure/sign/warning/secure_area/armory{
 	pixel_y = -26
@@ -2832,10 +2861,12 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/centcom/chaos)
 "ny" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/structure/table/rack/dark,
+/obj/item/gun/projectile/automatic/scp/rpk,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/turf/simulated/floor/tiled/dark,
 /area/centcom/chaos)
 "nz" = (
 /obj/structure/table/rack,
@@ -2892,49 +2923,6 @@
 /obj/item/bodybag,
 /turf/simulated/floor/tiled/old_tile,
 /area/centcom/chaos)
-"nJ" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southleft,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
-"nK" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southright,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
-"nL" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/southleft,
-/obj/item/device/chameleon,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
 "nN" = (
 /obj/effect/landmark{
 	name = "endgame_exit"
@@ -2942,14 +2930,10 @@
 /turf/unsimulated/beach/sand,
 /area/beach)
 "nO" = (
-/obj/machinery/door/airlock/highsecurity,
-/obj/machinery/door/blast/shutters{
-	dir = 4;
-	explosion_resistance = 100;
-	id_tag = "alpha1";
-	name = "Alpha-1"
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/lino,
 /area/centcom/chaos)
 "nQ" = (
 /obj/structure/table/rack,
@@ -2985,18 +2969,11 @@
 	},
 /area/centcom)
 "nW" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/obj/item/ammo_magazine/scp/m16_mag,
-/turf/simulated/floor/tiled/techfloor,
+/obj/structure/table/steel_reinforced,
+/obj/random/smokes,
+/obj/random/smokes,
+/obj/random/smokes,
+/turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "nX" = (
 /obj/effect/floor_decal/corner/blue/border{
@@ -3107,33 +3084,23 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/tram/car1)
-"om" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/northleft,
-/obj/item/clothing/mask/chameleon/voice{
-	desc = "A face-covering mask that can be connected to an air supply. It seems to house some odd electronics. Literally a voice changer";
-	name = "SCP-1996-RU"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
 "on" = (
-/obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/suit/storage/vest/tactical,
+/obj/item/gun/projectile/automatic/scp/ak74,
+/obj/item/clothing/head/helmet/nt{
+	name = "temp chaos helm"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor/northright,
-/turf/simulated/floor/tiled/techfloor/grid,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/clothing/mask/balaclava/tactical,
+/obj/item/storage/backpack/rucksack/tan,
+/obj/item/gun/projectile/pistol,
+/obj/structure/closet,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
 /area/centcom/chaos)
 "oo" = (
 /obj/effect/floor_decal/corner/blue/border{
@@ -3174,21 +3141,26 @@
 	},
 /turf/unsimulated/floor/plating,
 /area/centcom)
-"ou" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/field_generator,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/centcom/chaos)
 "ow" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/tiled/steel_grid,
 /area/centcom/chaos)
 "ox" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/item/storage/belt/holster/security/tactical,
+/obj/item/clothing/accessory/storage/black_vest,
+/obj/item/clothing/suit/storage/vest/tactical,
+/obj/item/gun/projectile/automatic/scp/ak74,
+/obj/item/clothing/head/helmet/nt{
+	name = "temp chaos helm"
+	},
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/ammo_magazine/scp/ak,
+/obj/item/clothing/mask/balaclava/tactical,
+/obj/item/storage/backpack/rucksack/tan,
+/obj/item/gun/projectile/pistol,
+/obj/structure/closet,
+/turf/simulated/floor/tiled/dark,
 /area/centcom/chaos)
 "oy" = (
 /obj/machinery/button/blast_door{
@@ -23696,12 +23668,12 @@ uU
 uU
 uU
 uU
+cw
 uU
-uU
 ek
 ek
-ek
-ac
+cw
+cw
 cw
 as
 tq
@@ -23883,21 +23855,21 @@ jU
 cw
 cw
 uU
+cw
+cw
+cw
 uU
-ek
-ek
-uU
-lj
+cw
 ek
 ek
 ek
 ek
 ek
-uU
-uU
-ac
 uU
 uU
+cw
+cw
+cw
 ek
 ek
 ek
@@ -24087,18 +24059,18 @@ cw
 uU
 uU
 uU
+cw
+uU
+uU
+cw
+cw
 ek
-uU
-uU
 ek
-ek
-ek
-ek
+cw
+cw
 uU
 uU
-uU
-uU
-uU
+cw
 uU
 uU
 ek
@@ -24286,24 +24258,24 @@ cw
 cw
 cw
 cw
-uU
 cw
-ac
-ek
-uU
-ek
-ek
+cw
+cw
+cw
+cw
+cw
+cw
 di
 eU
 eU
 di
-uU
-uU
-uU
-uU
-uU
-uU
-uU
+cw
+cw
+cw
+cw
+cw
+cw
+cw
 uU
 uU
 uU
@@ -24488,11 +24460,11 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-ek
-ek
+di
+di
+di
+di
+di
 di
 di
 di
@@ -24690,13 +24662,13 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
-cw
 di
-cw
+kx
+kM
+kM
+nO
+kM
+kM
 di
 eU
 eU
@@ -24893,12 +24865,12 @@ cw
 cw
 cw
 di
-di
-di
-di
-di
-di
-di
+kx
+kM
+nO
+kY
+nO
+nO
 di
 eU
 eU
@@ -25097,10 +25069,10 @@ cw
 di
 kp
 kM
-kP
 kX
 kX
-lu
+kX
+kX
 di
 eU
 eU
@@ -25298,8 +25270,8 @@ di
 di
 di
 kx
-kM
-kM
+kP
+kX
 kY
 kX
 lu
@@ -25501,10 +25473,10 @@ jS
 di
 ky
 kM
-kM
 kZ
-kM
-lv
+kZ
+kZ
+kZ
 di
 eU
 eU
@@ -26116,9 +26088,9 @@ eU
 kE
 di
 nc
+ld
 nd
-nd
-nd
+no
 di
 cw
 cw
@@ -26316,15 +26288,15 @@ eU
 lE
 eU
 eU
-mJ
+di
 nd
 nd
-nJ
+nd
 oe
 di
-cw
-cw
-cw
+di
+di
+di
 cw
 cw
 cw
@@ -26513,20 +26485,20 @@ kE
 lX
 eU
 lb
-lo
+nW
 eU
 lE
 eU
 eU
 di
+oI
 nd
 nd
-nK
 nd
+nd
+nd
+ox
 di
-cw
-cw
-cw
 cw
 cw
 cw
@@ -26711,7 +26683,7 @@ jS
 jT
 jS
 di
-eU
+ow
 eU
 eU
 eU
@@ -26725,9 +26697,9 @@ ne
 nd
 nd
 nd
-di
-di
-di
+nd
+nd
+ox
 di
 cw
 cw
@@ -26923,13 +26895,13 @@ lE
 eU
 eU
 di
-no
+oI
 nd
 nd
 nd
 nd
 nd
-nd
+ox
 di
 cw
 cw
@@ -27125,13 +27097,13 @@ lF
 eU
 eU
 di
-np
-nd
-nL
-nd
 oI
-om
 nd
+nd
+nd
+nd
+nd
+ox
 di
 cw
 cw
@@ -27327,13 +27299,13 @@ di
 eU
 lX
 di
-np
 nd
-nK
+nd
+nd
+nd
 nd
 nd
 on
-oe
 di
 cw
 cw
@@ -27529,13 +27501,13 @@ di
 eU
 eU
 di
-nr
-ny
-ou
-oI
 nd
 nd
 nd
+nd
+nd
+nd
+ox
 di
 cw
 cw
@@ -27731,13 +27703,13 @@ di
 lO
 eU
 di
-di
-di
-di
-di
-di
-nO
-di
+nd
+nd
+nd
+nd
+nd
+nd
+ox
 di
 cw
 cw
@@ -27933,13 +27905,13 @@ di
 eU
 eU
 mK
-eU
-eU
-eU
-eU
-eU
-eU
-ow
+nd
+nd
+nd
+nd
+nd
+nd
+ox
 di
 cw
 cw
@@ -28134,13 +28106,13 @@ TQ
 lG
 eU
 eU
-eU
-eU
-eU
-eU
-eU
-eU
-eU
+mK
+nd
+nd
+nd
+nd
+nd
+nd
 ox
 di
 cw
@@ -28337,12 +28309,12 @@ di
 lQ
 eU
 di
-lG
-di
-di
-di
-di
-di
+nd
+nd
+nd
+nd
+nd
+nd
 di
 di
 cw
@@ -28541,11 +28513,11 @@ eU
 di
 TQ
 nz
-Fo
-nA
+nz
+np
+TQ
+ny
 di
-cw
-cw
 cw
 cw
 cw
@@ -28744,10 +28716,10 @@ di
 kS
 TQ
 TQ
-lz
+TQ
+TQ
+lj
 di
-cw
-cw
 cw
 cw
 cw
@@ -28944,12 +28916,12 @@ mw
 mi
 di
 TQ
-ld
-nW
+Fo
+Fo
 nA
+TQ
+mJ
 di
-cw
-cw
 cw
 cw
 cw
@@ -29149,9 +29121,9 @@ di
 di
 di
 di
+TQ
+mJ
 di
-cw
-cw
 cw
 cw
 cw
@@ -29350,10 +29322,10 @@ cw
 cw
 cw
 cw
-cw
-cw
-cw
-cw
+di
+di
+di
+di
 cw
 cw
 cw


### PR DESCRIPTION
## About the Pull Request

Changed the Chaos base a little bit, mostly the armory.
added 5 chameleon projectors for stealth chaos
What was added to the closet can be seen in the screenshot.
Also enlarged the table so everyone could sit down and discuss offensive tactics.

## Why It's Good For The Game

Chaos base now has full chaos fighter kits.

## Changelog

🆑
add: Added several tables,added 1 random snack.
add: Added several chairs.
add: added 5 chameleon projectors.
add: Added 9 weapon closet,Added more of the right ammo.
add: Added 2 SVD and magazine for it.
add: Added 2 RPK-74.
add: expanded the base of chaos a little near the tables, added some rock.
del: Removed table and chair in the armory, Removed rocket shell in the armory.
del: Removed unneeded ammo.
/🆑
![2A](https://user-images.githubusercontent.com/80586098/188988517-6a620914-3892-4074-a6b3-7ce63fcf28fc.png)
![4a](https://user-images.githubusercontent.com/80586098/188988530-0f0542bf-7737-465d-9c37-dde4b3d5d522.png)