### PR TITLE
Fax fix

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -5673,7 +5673,7 @@
 "oD" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-049 Observation";
-	send_access = list(list(203,304))
+	send_access = list("ACCESS_SCIENCE_LEVEL3","ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -9814,7 +9814,7 @@
 "zU" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "D-Class Primary Security Post";
-	send_access = list(202)
+	send_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -16218,10 +16218,6 @@
 /area/site53/llcz/dclass/cellbubble)
 "SP" = (
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "SCP-247 Observation";
-	send_access = list(303)
-	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp8containment)
@@ -16916,10 +16912,6 @@
 /area/site53/lowertram/archive)
 "Vl" = (
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "SCP-247 Observation";
-	send_access = list(303)
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp8containment)
 "Vm" = (
@@ -18014,7 +18006,7 @@
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Archive";
-	send_access = list(500)
+	send_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/lowertram/archive)
@@ -18117,12 +18109,12 @@
 /area/site53/llcz/dclass/assignmentbubble)
 "Za" = (
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "SCP-008 Observation";
-	send_access = list(204)
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "SCP-008 Observation";
+	send_access = list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/uhcz/scp8containment)

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -5673,7 +5673,7 @@
 "oD" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-049 Observation";
-	send_access = list("ACCESS_SCIENCE_LEVEL3","ACCESS_SECURITY_LEVEL3")
+	send_access = list(list("ACCESS_SCIENCE_LEVEL3","ACCESS_SECURITY_LEVEL3"))
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -9814,7 +9814,7 @@
 "zU" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "D-Class Primary Security Post";
-	send_access = list("ACCESS_SECURITY_LEVEL2")
+	send_access = list(list("ACCESS_SECURITY_LEVEL2"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -18006,7 +18006,7 @@
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "Archive";
-	send_access = list("ACCESS_ADMIN_LEVEL4")
+	send_access = list(list("ACCESS_ADMIN_LEVEL4"))
 	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/lowertram/archive)
@@ -18114,7 +18114,7 @@
 	},
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-008 Observation";
-	send_access = list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3")
+	send_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/uhcz/scp8containment)

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -5173,7 +5173,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	department = "Engineering Monitoring"
+	department = "Engineering Monitoring";
+	send_access = list("ACCESS_ENGINEERING_LEVEL1")
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
@@ -23283,14 +23284,6 @@
 "eQq" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/llcz/entrance_checkpoint)
-"eQX" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "SCP-106 Observation";
-	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/scp106observ)
 "eRk" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -30728,12 +30721,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
 "sHS" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "HCZ Security Center";
-	send_access = list(203)
-	},
 /obj/structure/table/standard,
 /obj/machinery/light,
+/obj/machinery/photocopier/faxmachine{
+	department = "HCZ Security Center";
+	send_access = list("ACCESS_SECURITY_LEVEL3")
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/hczguardgear)
 "sIW" = (
@@ -33401,8 +33394,9 @@
 	},
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	department = "SCP-106 Containment Unit";
-	send_access = list(203)
+	department = "SCP-106 Observation";
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"));
+	send_access = list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
@@ -33773,9 +33767,9 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "HCZ Security Center";
-	send_access = list(203)
+	send_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/turf/unsimulated/mineral,
+/turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "xZE" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -87449,7 +87443,7 @@ aBs
 wvc
 ahS
 arr
-eQX
+aBf
 aBs
 nVI
 nVI

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -5174,7 +5174,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "Engineering Monitoring";
-	send_access = list("ACCESS_ENGINEERING_LEVEL1")
+	send_access = list(list("ACCESS_ENGINEERING_LEVEL1"))
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
@@ -13480,7 +13480,10 @@
 	icon_state = "0-4"
 	},
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine,
+/obj/machinery/photocopier/faxmachine{
+	department = "UHCZ Checkpoint";
+	send_access = list(list("ACCESS_SECURITY_LEVEL3"))
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
 "aLa" = (
@@ -16247,7 +16250,7 @@
 "aUg" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "LCZ Security Center";
-	send_access = list("ACCESS_SECURITY_LEVEL1")
+	send_access = list(list("ACCESS_SECURITY_LEVEL1"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -16672,7 +16675,10 @@
 /area/site53/uhcz/securitypost)
 "aVw" = (
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine,
+/obj/machinery/photocopier/faxmachine{
+	department = "UHCZ Checkpoint";
+	send_access = list(list("ACCESS_SECURITY_LEVEL3"))
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aVx" = (
@@ -22037,7 +22043,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "Heavy Containment Zone Commander";
-	send_access = list("ACCESS_SECURITY_LEVEL4")
+	send_access = list(list("ACCESS_SECURITY_LEVEL4"))
 	},
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 8
@@ -23277,7 +23283,7 @@
 /obj/structure/table/steel_reinforced,
 /obj/machinery/photocopier/faxmachine{
 	department = "Containment Engineer's Office";
-	send_access = list("ACCESS_ENGINEERING_LEVEL4")
+	send_access = list(list("ACCESS_ENGINEERING_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/containment_engineer)
@@ -26166,7 +26172,7 @@
 "kiO" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "General Purpose Chamber";
-	send_access = list("ACCESS_SCIENCE_LEVEL1")
+	send_access = list(list("ACCESS_SCIENCE_LEVEL1"))
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -29269,7 +29275,10 @@
 	dir = 1
 	},
 /obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine,
+/obj/machinery/photocopier/faxmachine{
+	department = "UHCZ Checkpoint";
+	send_access = list(list("ACCESS_SECURITY_LEVEL3"))
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "pPO" = (
@@ -30725,7 +30734,7 @@
 /obj/machinery/light,
 /obj/machinery/photocopier/faxmachine{
 	department = "HCZ Security Center";
-	send_access = list("ACCESS_SECURITY_LEVEL3")
+	send_access = list(list("ACCESS_SECURITY_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/hczguardgear)
@@ -31561,7 +31570,7 @@
 "urN" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "LCZ Security Office";
-	send_access = list("ACCESS_SECURITY_LEVEL1")
+	send_access = list(list("ACCESS_SECURITY_LEVEL1"))
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -33396,7 +33405,7 @@
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-106 Observation";
 	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"));
-	send_access = list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3")
+	send_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
@@ -33767,7 +33776,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "HCZ Security Center";
-	send_access = list("ACCESS_SECURITY_LEVEL3")
+	send_access = list(list("ACCESS_SECURITY_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -4898,7 +4898,7 @@
 "nI" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Entrance Zone Commander's Office";
-	send_access = list(204)
+	send_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -6458,7 +6458,7 @@
 "tq" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "LCZ Zone Commander's Office";
-	send_access = list(204)
+	send_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/effect/floor_decal/corner/blue/border,
 /obj/structure/table/reinforced,
@@ -7872,7 +7872,8 @@
 	},
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	department = "GOI Office"
+	department = "GOI Office";
+	send_access = list("ACCESS_ADMIN_LEVEL1")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -849,7 +849,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "Medical Reception";
-	send_access = list("ACCESS_MEDICAL_LEVEL1")
+	send_access = list(list("ACCESS_MEDICAL_LEVEL1"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmreception)
@@ -4896,11 +4896,11 @@
 /turf/simulated/floor/tiled,
 /area/site53/uez/equipmentroom)
 "nI" = (
+/obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
 	department = "Entrance Zone Commander's Office";
-	send_access = list("ACCESS_SECURITY_LEVEL4")
+	send_access = list(list("ACCESS_SECURITY_LEVEL4"))
 	},
-/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/senioragentoffice)
 "nJ" = (
@@ -5900,14 +5900,14 @@
 /turf/simulated/wall/prepainted,
 /area/site53/uez/o5repoffice)
 "rC" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "O5 Representative's Office";
-	send_access = list("ACCESS_ADMIN_LEVEL5")
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/structure/table/woodentable/walnut,
+/obj/machinery/photocopier/faxmachine{
+	department = "O5 Representative's Office";
+	send_access = list(list("ACCESS_ADMIN_LEVEL5"))
+	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/uez/o5repoffice)
 "rD" = (
@@ -6456,12 +6456,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
 "tq" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "LCZ Zone Commander's Office";
-	send_access = list("ACCESS_SECURITY_LEVEL4")
-	},
 /obj/effect/floor_decal/corner/blue/border,
 /obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Zone Commander's Office";
+	send_access = list(list("ACCESS_SECURITY_LEVEL4"))
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
 "tr" = (
@@ -7873,7 +7873,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "GOI Office";
-	send_access = list("ACCESS_ADMIN_LEVEL1")
+	send_access = list(list("ACCESS_ADMIN_LEVEL1"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -414,7 +414,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
 	department = "Head of Personnel's Office";
-	send_access = list("ACCESS_ADMIN_LEVEL4")
+	send_access = list(list("ACCESS_ADMIN_LEVEL4"))
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/hallway)
@@ -454,7 +454,7 @@
 "bv" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Main Control Room";
-	send_access = list("ACCESS_ADMIN_LEVEL1")
+	send_access = list(list("ACCESS_ADMIN_LEVEL1"))
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/blue/border{
@@ -711,7 +711,7 @@
 "cm" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Site Director's Office";
-	send_access = list("ACCESS_ADMIN_LEVEL5")
+	send_access = list(list("ACCESS_ADMIN_LEVEL5"))
 	},
 /obj/structure/table/woodentable_reinforced/mahogany,
 /turf/simulated/floor/carpet/purple,
@@ -1039,7 +1039,7 @@
 "dj" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Research Director's Office";
-	send_access = list("ACCESS_SCIENCE_LEVEL5")
+	send_access = list(list("ACCESS_SCIENCE_LEVEL5"))
 	},
 /obj/machinery/light{
 	dir = 1
@@ -1250,7 +1250,7 @@
 "dL" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Guard Commander's Office";
-	send_access = list("ACCESS_SECURITY_LEVEL5")
+	send_access = list(list("ACCESS_SECURITY_LEVEL5"))
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techmaint,
@@ -1383,7 +1383,7 @@
 "ek" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Chief Medical Officer's Office";
-	send_access = list("ACCESS_MEDICAL_LEVEL5")
+	send_access = list(list("ACCESS_MEDICAL_LEVEL5"))
 	},
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -1394,7 +1394,7 @@
 "el" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Chief Engineer's Office";
-	send_access = list("ACCESS_ENGINEERING_LEVEL5")
+	send_access = list(list("ACCESS_ENGINEERING_LEVEL5"))
 	},
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -2763,7 +2763,7 @@
 "iT" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Logistics Breakroom";
-	send_access = list("ACCESS_ADMIN_LEVEL1")
+	send_access = list(list("ACCESS_ADMIN_LEVEL1"))
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -4105,7 +4105,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "Comms Tower";
-	send_access = list("ACCESS_ADMIN_LEVEL2")
+	send_access = list(list("ACCESS_ADMIN_LEVEL2"))
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
@@ -4482,7 +4482,7 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
 	department = "Command Meeting Room";
-	send_access = list("ACCESS_ADMIN_LEVEL4")
+	send_access = list(list("ACCESS_ADMIN_LEVEL4"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -4481,7 +4481,8 @@
 "UU" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	department = "Command Meeting Room"
+	department = "Command Meeting Room";
+	send_access = list("ACCESS_ADMIN_LEVEL4")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)


### PR DESCRIPTION
## About the Pull Request

Many faxes (I counted 13) don't work because they have the wrong access.
I changed that.
Also removed several fax machines that were in close proximity.

## Why It's Good For The Game

Now all the faxes work, and employees can send reports in peace.

## Changelog

:cl:
add: added a floor under the fax in the HCZ Gear room.
del: Deleted several faxes.
fix: fixed a access in faxes that don't work
/:cl: