### PR TITLE
added common stamps to Zone commanders

### DIFF
--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -27177,6 +27177,8 @@
 	dir = 8
 	},
 /obj/item/sticky_pad/random,
+/obj/item/stamp/denied,
+/obj/item/stamp/approved,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
 "kao" = (

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -6368,6 +6368,8 @@
 /obj/structure/table/reinforced,
 /obj/random/clipboard,
 /obj/effect/floor_decal/carpet/blue2,
+/obj/item/stamp/denied,
+/obj/item/stamp/approved,
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "tb" = (
@@ -9621,6 +9623,8 @@
 "Vf" = (
 /obj/item/storage/pill_bottle/amnesticsb,
 /obj/structure/table/reinforced,
+/obj/item/stamp/approved,
+/obj/item/stamp/denied,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/senioragentoffice)
 "Vi" = (

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -1346,6 +1346,8 @@
 /obj/structure/table/standard,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/item/stamp/approved,
+/obj/item/stamp/denied,
 /turf/simulated/floor/carpet/red,
 /area/site53/uez/hallway)
 "ee" = (
@@ -4517,6 +4519,18 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/upper_surface/commstower)
+"WC" = (
+/obj/structure/table/woodentable,
+/obj/item/stamp/approved,
+/obj/item/stamp/denied,
+/obj/item/stamp/scp/hop,
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/hallway)
+"WM" = (
+/obj/effect/paint/sun,
+/obj/item/stamp/scp/hop,
+/turf/simulated/wall/prepainted,
+/area/site53/uez/hallway)
 "WQ" = (
 /turf/simulated/mineral,
 /area/site53/surface/surface)
@@ -35501,7 +35515,7 @@ rc
 ac
 ev
 bK
-dZ
+WM
 el
 fl
 fl
@@ -37543,7 +37557,7 @@ hk
 hk
 ae
 bn
-bH
+WC
 bn
 bX
 bK


### PR DESCRIPTION
## About the Pull Request

Added stamps(Approved,Denied) to LCZ,EZ,HCZ commanders.
Added to the Head of Personnel office his stamp.

## Why It's Good For The Game

More bureaucracy for commanders.

## Changelog

:cl:
add: Added Approved stamp to LCZ,EZ,HCZ Commanders Office and Head of Personnel office.
add: Added Denied stamp to LCZ,EZ,HCZ Commanders Office and Head of Personnel office.
add: Added head of personnel's rubber stamp to Head of Personnel office.
/:cl: