### PR TITLE
Fixes Email Clients not generating logins/AIC eye toggle

### DIFF
--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -508,7 +508,7 @@ var/global/datum/controller/occupations/job_master
 			else
 				var/datum/computer_file/data/email_account/EA = new/datum/computer_file/data/email_account()
 				EA.password = GenerateKey()
-				EA.login = 	complete_login
+				EA.login = complete_login
 				to_chat(H, "Your email account address is <b>[EA.login]</b> and the password is <b>[EA.password]</b>. This information has also been placed into your notes.")
 				H.mind.store_memory("Your email account address is [EA.login] and the password is [EA.password].")
 			// END EMAIL GENERATION

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -33,7 +33,7 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/ai_power_override,
 	/mob/living/silicon/ai/proc/ai_shutdown,
 	/mob/living/silicon/ai/proc/ai_reset_radio_keys,
-	/mob/living/silicon/ai/proc/eyepuppettoggle
+	/mob/living/silicon/ai/proc/eye_puppet_toggle
 )
 
 //Not sure why this is necessary...

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -32,7 +32,8 @@ var/list/ai_verbs_default = list(
 	/mob/living/silicon/ai/proc/show_crew_manifest,
 	/mob/living/silicon/ai/proc/ai_power_override,
 	/mob/living/silicon/ai/proc/ai_shutdown,
-	/mob/living/silicon/ai/proc/ai_reset_radio_keys
+	/mob/living/silicon/ai/proc/ai_reset_radio_keys,
+	/mob/living/silicon/ai/proc/eyepuppettoggle
 )
 
 //Not sure why this is necessary...

--- a/code/modules/mob/observer/freelook/ai/eye.dm
+++ b/code/modules/mob/observer/freelook/ai/eye.dm
@@ -107,7 +107,7 @@
 	eyeobj.acceleration = !eyeobj.acceleration
 	to_chat(usr, "Camera acceleration has been toggled [eyeobj.acceleration ? "on" : "off"].")
 
-/mob/living/silicon/ai/proc/eyepuppettoggle() //Messing with the SEE_INVISIBLE_TAG renders the lighting differently so I'd rather just swap out the icon for nothing and still render lights correctly.
+/mob/living/silicon/ai/proc/eye_puppet_toggle() //Messing with the SEE_INVISIBLE_TAG renders the lighting differently so I'd rather just swap out the icon for nothing and still render lights correctly.
 	set category = "Silicon Commands"
 	set name = "Toggle AIC Eye"
 	var/mob/living/silicon/ai/AI = usr

--- a/code/modules/mob/observer/freelook/ai/eye.dm
+++ b/code/modules/mob/observer/freelook/ai/eye.dm
@@ -106,3 +106,16 @@
 
 	eyeobj.acceleration = !eyeobj.acceleration
 	to_chat(usr, "Camera acceleration has been toggled [eyeobj.acceleration ? "on" : "off"].")
+
+/mob/living/silicon/ai/proc/eyepuppettoggle() //Messing with the SEE_INVISIBLE_TAG renders the lighting differently so I'd rather just swap out the icon for nothing and still render lights correctly.
+	set category = "Silicon Commands"
+	set name = "Toggle AIC Eye"
+	var/mob/living/silicon/ai/AI = usr
+
+
+	if(AI.eyeobj.icon_state == "AI-eye") //Eye is on so we turn it off.
+		AI.eyeobj.icon_state = ""
+	else //Eye is off, so we turn it on
+		AI.eyeobj.icon_state = "AI-eye"
+
+

--- a/code/modules/modular_computers/NTNet/NTNet.dm
+++ b/code/modules/modular_computers/NTNet/NTNet.dm
@@ -212,6 +212,7 @@ var/global/datum/ntnet/ntnet_global = new()
 	else
 		var/datum/computer_file/data/email_account/EA = new/datum/computer_file/data/email_account(login, user.real_name, assignment)
 		EA.password = desired_password ? desired_password : GenerateKey()
+		EA.login = login
 		if(user.mind)
 			user.mind.initial_email_login["login"] = EA.login
 			user.mind.initial_email_login["password"] = EA.password

--- a/code/modules/tgui/modules/ntos-only/configurator.dm
+++ b/code/modules/tgui/modules/ntos-only/configurator.dm
@@ -2,6 +2,7 @@
 	name = "NTOS Computer Configuration Tool"
 	ntos = TRUE
 	tgui_id = "Configuration"
+	available_to_ai = FALSE
 	var/obj/item/modular_computer/movable = null
 
 /datum/tgui_module/computer_configurator/tgui_data(mob/user, datum/tgui/ui, datum/tgui_state/state)


### PR DESCRIPTION
## About the Pull Request

Fixes the email clients not properly generating logins/usernames which prevented accounts from being created properly at the beginning of the round.

Adds in an AIC Eye Toggle that lets you disable the A.I face that indicates your center of view. It's still there, it just makes the Icon disappear. It can be toggled back on by pressing the command again.

Disables the NTOS computer configuration tool from the subsystems tab. 
It was added when DTraitor fixed everything up and added the base nano_modules to the list.

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfixes are lovely!

The AIC Eye always bothered me and I think having the option to toggle it without explicitly turning it off is great for anything that's not mechanically impacting the round.

## Changelog

:cl:
fix: Fixed email clients not properly generating login/username at round start.
fix: Removes Computer Configuration Tool from subsystems tab.
Add: AIC Eye Toggle
/:cl:

<!-- Please add a short description of why you think these changes would benefit the game.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
