### PR TITLE
Non-human can no longer be antags.

### DIFF
--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -134,6 +134,8 @@
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!")
 		else if(player_is_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
+		else if(ishuman(player))
+			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are not a human!")
 		else
 			candidates |= player
 

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -134,7 +134,7 @@
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are blacklisted for this role!")
 		else if(player_is_antag(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are already an antagonist!")
-		else if(ishuman(player))
+		else if(!ishuman(player))
 			log_debug("[key_name(player)] is not eligible to become a [role_text]: They are not a human!")
 		else
 			candidates |= player


### PR DESCRIPTION
## About the Pull Request

Fixed the issue of non-humans being forced as antags by the server.

## Why It's Good For The Game

Fixes an issue that only an admin can fix during the game.

## Changelog

:cl:

fix: Non-humans no longer able to become antags without admin intervention.

/:cl: