### PR TITLE
fix(assemblies): fixes timers

### DIFF
--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -48,10 +48,8 @@
 	return 1
 
 /obj/item/device/assembly/proc/pulse(var/radio = 0)							//Called when this device attempts to act on another device, var/radio determines if it was sent via radio or direct
-	if(holder && (wires & WIRE_RECEIVE))
+	if(holder && (wires & WIRE_RECEIVE|WIRE_PULSE))
 		holder.process_activation(src, 1, 0)
-	if(holder && (wires & WIRE_PULSE_SPECIAL))
-		holder.process_activation(src, 0, 1)
 	return 1
 
 /obj/item/device/assembly/proc/toggle_secure()								//Code that has to happen when the assembly is un\secured goes here

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -54,7 +54,7 @@
 
 /obj/item/device/assembly/timer/Process(delta_time)
 	if(timing && (time > 0))
-		time -= delta_time SECONDS
+		time -= delta_time
 	if(timing && time <= 0)
 		timing = 0
 		timer_end()


### PR DESCRIPTION
Blazing Silver

## Changelog

:cl:
fix: Fixed timer assembly, therefore all grenades on timers should work now.
/:cl:

