### PR TITLE
Same char name respawn blocking

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -148,7 +148,7 @@ SUBSYSTEM_DEF(jobs)
 	for(var/mob/living/carbon/human/C in SSmobs.mob_list)
 		var/char_name = joining.client.prefs.real_name
 		if(char_name == C.real_name)
-			to_chat (usr, "<span class='danger'>There is a character that already exists with the same name: <b>[C.real_name]</b>, please join with a different one.</span>")
+			to_chat (usr, "<span class='danger'>A character with the name <b>[C.real_name]</b> already exists. Please join with a different name.</span>")
 			return FALSE
 	return TRUE
 

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -145,6 +145,11 @@ SUBSYSTEM_DEF(jobs)
 	if(SSticker.mode && SSticker.mode.explosion_in_progress)
 		to_chat(joining, "<span class='warning'>The [station_name()] is currently exploding. Joining would go poorly.</span>")
 		return FALSE
+	for(var/mob/living/carbon/human/C in SSmobs.mob_list)
+		var/char_name = joining.client.prefs.real_name
+		if(char_name == C.real_name)
+			to_chat (usr, "<span class='danger'>There is a character that already exists with the same name: <b>[C.real_name]</b>, please join with a different one.</span>")
+			return FALSE
 	return TRUE
 
 /datum/controller/subsystem/jobs/proc/check_latejoin_blockers(var/mob/new_player/joining, var/datum/job/job)


### PR DESCRIPTION
## About the Pull Request

Removes the ability to join the game if character with same name already exists. You won't be able to have 10 Johns Smiths anymore, not sure if it's a good or bad idea.

![image](https://user-images.githubusercontent.com/41485301/199473546-e60844e8-0b08-4ffd-ab39-43558b8cd95d.png)

close #730

## Why It's Good For The Game

Literally no idea.

## Changelog

:cl:
add: You can no longer respawn with the same character name.
/:cl:
