### PR TITLE
Tank fixes and additions

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -15,7 +15,7 @@
 #define MIN_TOXIN_DAMAGE 1
 #define MAX_TOXIN_DAMAGE 10
 
-#define STD_BREATH_VOLUME      12 // Liters in a normal breath.
+#define STD_BREATH_VOLUME      0.5 // Liters in a normal breath.
 
 #define HUMAN_HEAT_CAPACITY 280000 //J/K For 80kg person
 

--- a/code/game/objects/items/weapons/tanks/tank_types.dm
+++ b/code/game/objects/items/weapons/tanks/tank_types.dm
@@ -52,7 +52,6 @@
 	desc = "Mixed anyone?"
 	icon_state = GAS_OXYGEN
 	starting_pressure = list(GAS_OXYGEN = 6*ONE_ATMOSPHERE*O2STANDARD, GAS_NITROGEN = 6*ONE_ATMOSPHERE*N2STANDARD)
-	volume = 180
 
 /*
  * Phoron
@@ -93,7 +92,7 @@
 	attack_cooldown = DEFAULT_WEAPON_COOLDOWN
 	melee_accuracy_bonus = -10
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
-	volume = 40 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
+	volume = 2 //Tiny. Real life equivalents only have 21 breaths of oxygen in them. They're EMERGENCY tanks anyway -errorage (dangercon 2011)
 
 /obj/item/tank/emergency/oxygen
 	name = "emergency oxygen tank"
@@ -105,13 +104,13 @@
 /obj/item/tank/emergency/oxygen/engi
 	name = "extended-capacity emergency oxygen tank"
 	icon_state = "emergency_engi"
-	volume = 60
+	volume = 6
 
 /obj/item/tank/emergency/oxygen/double
 	name = "double emergency oxygen tank"
 	icon_state = "emergency_double"
 	gauge_icon = "indicator_emergency_double"
-	volume = 90
+	volume = 10
 	w_class = ITEM_SIZE_NORMAL
 
 /obj/item/tank/emergency/oxygen/double/red	//firefighting tank, fits on belt, back or suitslot
@@ -131,14 +130,14 @@
 	name = "double emergency nitrogen tank"
 	icon_state = "emergency_double_nitrogen"
 	gauge_icon = "indicator_emergency_double"
-	volume = 60
+	volume = 10
 
 /obj/item/tank/emergency/air_sac
 	name = "air sac"
 	desc = "A small, compressed air sac that fills with breathable air, to be used in emergencies."
 	icon_state = "air_sac"
 	gauge_icon = "indicator_emergency"
-	volume = 20
+	volume = 1
 	unacidable = TRUE
 
 /*
@@ -150,4 +149,3 @@
 	icon_state = "nitrogen"
 	distribute_pressure = ONE_ATMOSPHERE*O2STANDARD
 	starting_pressure = list(GAS_NITROGEN = 10*ONE_ATMOSPHERE)
-	volume = 180

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -226,9 +226,20 @@ var/list/global/tank_gauge_cache = list()
 						to_chat(user, "<span class='danger'>You accidentally rake \the [W] across \the [src]!</span>")
 						maxintegrity -= rand(2,6)
 						integrity = min(integrity,maxintegrity)
-						air_contents.add_thermal_energy(rand(2000,50000))
 			else
 				to_chat(user, "<span class='notice'>The emergency pressure relief valve has already been welded.</span>")
+			if(src.air_contents)
+				var/const/welder_temperature = 1893.15
+				var/const/welder_mean_energy = 26000
+				var/const/welder_heat_capacity = welder_mean_energy / welder_temperature
+
+				var/current_energy = src.air_contents.heat_capacity() * src.air_contents.temperature
+				var/total_capacity = src.air_contents.heat_capacity() + welder_heat_capacity
+				var/total_energy = current_energy + welder_mean_energy
+
+				var/new_temperature = total_energy / total_capacity
+
+				src.air_contents.temperature = new_temperature
 
 	if(istype(W, /obj/item/flamethrower))
 		var/obj/item/flamethrower/F = W
@@ -623,7 +634,18 @@ var/list/global/tank_gauge_cache = list()
 	qdel(assy)
 	update_icon(TRUE)
 
-	air_contents.add_thermal_energy(15000)
+	if(src.air_contents)
+		var/const/igniter_temperature = 6000
+		var/const/igniter_mean_energy = 15000
+		var/const/igniter_heat_capacity = igniter_mean_energy / igniter_temperature
+
+		var/current_energy = src.air_contents.heat_capacity() * src.air_contents.temperature
+		var/total_capacity = src.air_contents.heat_capacity() + igniter_heat_capacity
+		var/total_energy = current_energy + igniter_mean_energy
+
+		var/new_temperature = total_energy / total_capacity
+
+		src.air_contents.temperature = new_temperature
 
 /obj/item/device/tankassemblyproxy/on_update_icon()
 	tank.update_icon()


### PR DESCRIPTION
## About the Pull Request

Lowered the volume of all small tanks from 40-90 to 2-10. Lowered single breath volume from 12 liters (!) to 0.5.

Now when you click tank with welder, it heats up (when you weld it, it heats up after you have welded it).

Also ports a fix for infinite pressure by EditorRUS.

## Why It's Good For The Game

Opens up a path to some fun stuff!

## Changelog

:cl:
add: You can now heat up tanks using welder.
/:cl:
