### PR TITLE
O5/Ethics Rework

### DIFF
--- a/code/game/antagonist/station/apostle.dm
+++ b/code/game/antagonist/station/apostle.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	id = "apostle"
 	role_text = "Apostle"
 	role_text_plural = "Apostles"
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/o5rep, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep, /datum/job/ethicsliaison, /datum/job/tribunal)
 	flags = ANTAG_SUSPICIOUS
 	antaghud_indicator = "hudchangeling"
 	faction = "apostle"

--- a/code/game/antagonist/station/apostle.dm
+++ b/code/game/antagonist/station/apostle.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	id = "apostle"
 	role_text = "Apostle"
 	role_text_plural = "Apostles"
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep, /datum/job/ethicsliaison, /datum/job/tribunal)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep,)
 	flags = ANTAG_SUSPICIOUS
 	antaghud_indicator = "hudchangeling"
 	faction = "apostle"

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -5,7 +5,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	role_text = "Changeling"
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/o5rep, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep, /datum/job/o5rep)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep, /datum/job/ethicsliaison, /datum/job/tribunal)
 	welcome_text = "Use say \"%LANGUAGE_PREFIX%g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"

--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -5,7 +5,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	role_text = "Changeling"
 	role_text_plural = "Changelings"
 	feedback_tag = "changeling_objective"
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep, /datum/job/ethicsliaison, /datum/job/tribunal)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep,)
 	welcome_text = "Use say \"%LANGUAGE_PREFIX%g message\" to communicate with your fellow changelings. Remember: you get all of their absorbed DNA if you absorb them."
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	antaghud_indicator = "hudchangeling"

--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -24,7 +24,7 @@ GLOBAL_DATUM_INIT(cult, /datum/antagonist/cultist, new)
 	id = MODE_CULTIST
 	role_text = "Cultist"
 	role_text_plural = "Cultists"
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/o5rep, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep)
 	feedback_tag = "cult_objective"
 	antag_indicator = "hudcultist"
 	welcome_text = "You have a tome in your possession; one that will help you start the cult. Use it well and remember - there are others."

--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -3,7 +3,7 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 /datum/antagonist/renegade
 	role_text = "Renegade"
 	role_text_plural = "Renegades"
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/o5rep, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep)
 //	restricted_jobs = list(/datum/job/officer, /datum/job/warden, /datum/job/captain, /datum/job/hop, /datum/job/hos, /datum/job/chief_engineer, /datum/job/rd, /datum/job/cmo)
 	welcome_text = "Something's going to go wrong today, you can just feel it. You're paranoid, you've got a gun, and you're going to survive."
 	antag_text = "You are a <b>minor</b> antagonist! Within the rules, \

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -4,7 +4,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 /datum/antagonist/traitor
 	id = MODE_TRAITOR
 	antaghud_indicator = "hud_traitor"
-	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/o5rep, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep)
+	blacklisted_jobs = list(/datum/job/ai, /datum/job/classd, /datum/job/captain, /datum/job/hos, /datum/job/rd, /datum/job/ethicsliaison, /datum/job/tribunal, /datum/job/commsofficer, /datum/job/enlistedofficerez, /datum/job/enlistedofficerlcz, /datum/job/enlistedofficerhcz, /datum/job/ncoofficerez, /datum/job/ncoofficerlcz, /datum/job/ncoofficerhcz, /datum/job/ltofficerez, /datum/job/ltofficerlcz, /datum/job/ltofficerhcz, /datum/job/goirep)
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	skill_setter = /datum/antag_skill_setter/station
 

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -115,7 +115,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/civ/classa
+		/datum/mil_rank/civ/classb
 	)
 	hud_icon = "hud05rep"
 	access = list(
@@ -145,7 +145,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/civ/classa
+		/datum/mil_rank/civ/classb
 	)
 
 	access = list(

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -110,14 +110,14 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	economic_power = 4
 	minimal_player_age = 5
 	ideal_character_age = 30
-	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/tribunal
 	allowed_branches = list(
 		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/classa
 	)
-
+	hud_icon = "hud05rep"
 	access = list(
 		ACCESS_ADMIN_LVL1,
 		ACCESS_ADMIN_LVL2,
@@ -178,7 +178,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/classa
 	)
-
+	hud_icon = "hud05rep"
 	access = list(
 		ACCESS_CIV_COMMS,
 		ACCESS_SCI_COMMS,

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -98,20 +98,48 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 
 	minimal_access = list()
 
-/datum/job/o5rep
+/datum/job/tribunal
 
-	title = "O5 Representative"
+	title = "Internal Tribunal Department Officer"
 	department = "Civilian"
 	selection_color = "#2f2f7f"
 	department_flag = COM
 	total_positions = 1
 	spawn_positions = 1
-
-	supervisors = "O-5 Council or the Site Director"
+	supervisors = "The Tribunal Department"
 	economic_power = 4
 	minimal_player_age = 5
 	ideal_character_age = 30
-	alt_titles = list("Ethics Committee Representative")
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
+	allowed_branches = list(
+		/datum/mil_branch/civilian
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/classa
+	)
+
+	access = list(
+		ACCESS_ADMIN_LVL1,
+		ACCESS_ADMIN_LVL2,
+		ACCESS_ADMIN_LVL3,
+		ACCESS_ADMIN_LVL4,
+		ACCESS_ADMIN_LVL5
+	)
+
+	minimal_access = list()
+
+/datum/job/ethicsliaison
+
+	title = "Ethics Committee Liaison"
+	department = "Civilian"
+	selection_color = "#2f2f7f"
+	department_flag = COM
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "The Ethics Committee"
+	economic_power = 4
+	minimal_player_age = 5
+	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
 	allowed_branches = list(
 		/datum/mil_branch/civilian

--- a/maps/site53/job/jobs/command.dm
+++ b/maps/site53/job/jobs/command.dm
@@ -176,14 +176,14 @@ ut // COMMAND
 	economic_power = 4
 	minimal_player_age = 5
 	ideal_character_age = 30
-	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/tribunal
 	allowed_branches = list(
 		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
 		/datum/mil_rank/civ/classa
 	)
-
+	hud_icon = "hud05rep"
 	access = list(
 		ACCESS_ADMIN_LVL1,
 		ACCESS_ADMIN_LVL2,
@@ -213,7 +213,7 @@ ut // COMMAND
 	allowed_ranks = list(
 		/datum/mil_rank/civ/classa
 	)
-
+	hud_icon = "hud05rep"
 	access = list(
 		ACCESS_ADMIN_LVL1,
 		ACCESS_ADMIN_LVL2,
@@ -225,48 +225,6 @@ ut // COMMAND
 	minimal_access = list()
 
 
-/datum/job/archivist
-
-	title = "Archivist"
-	department = "Civilian"
-	selection_color = "#2f2f7f"
-	department_flag = COM|SCI
-	total_positions = 1
-	spawn_positions = 1
-
-	supervisors = "the Site Director"
-	economic_power = 4
-	minimal_player_age = 20
-	ideal_character_age = 45
-	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/archivist
-	allowed_branches = list(
-		/datum/mil_branch/civilian
-	)
-	allowed_ranks = list(
-		/datum/mil_rank/civ/classa
-	)
-
-	access = list(
-		ACCESS_CIV_COMMS,
-		ACCESS_SCI_COMMS,
-		ACCESS_MED_COMMS,
-		ACCESS_RESEARCH,
-		ACCESS_KEYAUTH,
-		ACCESS_ADMIN_LVL1,
-		ACCESS_ADMIN_LVL2,
-		ACCESS_ADMIN_LVL3,
-		ACCESS_ADMIN_LVL4,
-		ACCESS_SCIENCE_LVL1,
-		ACCESS_SCIENCE_LVL2,
-		ACCESS_SCIENCE_LVL3,
-		ACCESS_SCIENCE_LVL4,
-		ACCESS_MEDICAL_LVL1,
-		ACCESS_MEDICAL_LVL2,
-		ACCESS_MEDICAL_LVL3,
-		ACCESS_MEDICAL_LVL4
-	)
-
-	minimal_access = list()
 
 /datum/job/goirep
 	title = "Global Occult Coalition Representative"

--- a/maps/site53/job/jobs/command.dm
+++ b/maps/site53/job/jobs/command.dm
@@ -164,19 +164,18 @@ ut // COMMAND
 
 // MISC
 
-/datum/job/o5rep
-	title = "O5 Representative"
-	department = "Command"
+/datum/job/tribunal
+
+	title = "Internal Tribunal Department Officer"
+	department = "Civilian"
+	selection_color = "#2f2f7f"
 	department_flag = COM
 	total_positions = 1
 	spawn_positions = 1
-//	//duties = "<big><b>As the GOC Representative, your task is to assess the facility and generally advocate for hardline approaches in regards to anomalies and their containment, or destruction. You value human lives far over any anomaly, as does the Global Occult Coalition, and should see to it that lives are preserved where possible, even D-Class ones. Though combat is not your duty, you are issued a revolver to defend yourself with. This job is heavy roleplay: you're expected to be well-versed in actually talking to people on the matters described. Containment of SCPs and direct site matters are not your matters, so don't get involved.</b></big>"
-//	//supervisors = "Global Occult Coalition Regional Command"
-	economic_power = 5
+	supervisors = "The Tribunal Department"
+	economic_power = 4
 	minimal_player_age = 5
-	minimal_player_age = 9
 	ideal_character_age = 30
-	alt_titles = list("Ethics Committee Representative")
 	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
 	allowed_branches = list(
 		/datum/mil_branch/civilian
@@ -184,17 +183,89 @@ ut // COMMAND
 	allowed_ranks = list(
 		/datum/mil_rank/civ/classa
 	)
-	hud_icon = "hud05rep"
 
 	access = list(
-		ACCESS_COM_COMMS,
 		ACCESS_ADMIN_LVL1,
 		ACCESS_ADMIN_LVL2,
 		ACCESS_ADMIN_LVL3,
 		ACCESS_ADMIN_LVL4,
-		ACCESS_ADMIN_LVL5,
-		ACCESS_CHAPEL_OFFICE
+		ACCESS_ADMIN_LVL5
 	)
+
+	minimal_access = list()
+
+/datum/job/ethicsliaison
+
+	title = "Ethics Committee Liaison"
+	department = "Civilian"
+	selection_color = "#2f2f7f"
+	department_flag = COM
+	total_positions = 1
+	spawn_positions = 1
+	supervisors = "The Ethics Committee"
+	economic_power = 4
+	minimal_player_age = 5
+	ideal_character_age = 30
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/o5rep
+	allowed_branches = list(
+		/datum/mil_branch/civilian
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/classa
+	)
+
+	access = list(
+		ACCESS_ADMIN_LVL1,
+		ACCESS_ADMIN_LVL2,
+		ACCESS_ADMIN_LVL3,
+		ACCESS_ADMIN_LVL4,
+		ACCESS_ADMIN_LVL5
+	)
+
+	minimal_access = list()
+
+
+/datum/job/archivist
+
+	title = "Archivist"
+	department = "Civilian"
+	selection_color = "#2f2f7f"
+	department_flag = COM|SCI
+	total_positions = 1
+	spawn_positions = 1
+
+	supervisors = "the Site Director"
+	economic_power = 4
+	minimal_player_age = 20
+	ideal_character_age = 45
+	outfit_type = /decl/hierarchy/outfit/job/site90/crew/civ/archivist
+	allowed_branches = list(
+		/datum/mil_branch/civilian
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/civ/classa
+	)
+
+	access = list(
+		ACCESS_CIV_COMMS,
+		ACCESS_SCI_COMMS,
+		ACCESS_MED_COMMS,
+		ACCESS_RESEARCH,
+		ACCESS_KEYAUTH,
+		ACCESS_ADMIN_LVL1,
+		ACCESS_ADMIN_LVL2,
+		ACCESS_ADMIN_LVL3,
+		ACCESS_ADMIN_LVL4,
+		ACCESS_SCIENCE_LVL1,
+		ACCESS_SCIENCE_LVL2,
+		ACCESS_SCIENCE_LVL3,
+		ACCESS_SCIENCE_LVL4,
+		ACCESS_MEDICAL_LVL1,
+		ACCESS_MEDICAL_LVL2,
+		ACCESS_MEDICAL_LVL3,
+		ACCESS_MEDICAL_LVL4
+	)
+
 	minimal_access = list()
 
 /datum/job/goirep

--- a/maps/site53/job/jobs/command.dm
+++ b/maps/site53/job/jobs/command.dm
@@ -181,7 +181,7 @@ ut // COMMAND
 		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/civ/classa
+		/datum/mil_rank/civ/classb
 	)
 	hud_icon = "hud05rep"
 	access = list(
@@ -211,7 +211,7 @@ ut // COMMAND
 		/datum/mil_branch/civilian
 	)
 	allowed_ranks = list(
-		/datum/mil_rank/civ/classa
+		/datum/mil_rank/civ/classb
 	)
 	hud_icon = "hud05rep"
 	access = list(

--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -519,6 +519,16 @@
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 
+/decl/hierarchy/outfit/job/site90/crew/civ/tribunal
+	name = OUTFIT_JOB_NAME("Tribunal Officer")
+	uniform = /obj/item/clothing/under/lawyer/black
+	shoes = /obj/item/clothing/shoes/laceup
+	l_pocket = /obj/item/device/radio
+	id_types = list(/obj/item/card/id/adminlvl5)
+	l_ear = /obj/item/device/radio/headset/heads/hop
+	back = /obj/item/storage/backpack/satchel/pocketbook
+	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
+	belt = /obj/item/gun/projectile/pistol/m1911
 
 // ENGINEERING STUFF
 /decl/hierarchy/outfit/job/ds90/crew/engineering/juneng

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -6426,22 +6426,6 @@
 /obj/effect/landmark/start{
 	name = "Internal Tribunal Department Officer"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/holofloor/wood,
-/area/site53/uez/o5repoffice)
-"rA" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "west bump"
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rB" = (
@@ -45860,7 +45844,7 @@ rB
 rF
 Zh
 rx
-rA
+rF
 rG
 rB
 bS

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -2966,13 +2966,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"gZ" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/turf/simulated/floor/wood/walnut,
-/area/site53/uez/o5repoffice)
 "ha" = (
 /obj/machinery/holosign/surgery{
 	dir = 8;
@@ -4796,16 +4789,13 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/equipstorage)
 "lE" = (
-/obj/effect/landmark/start{
-	name = "O5 Representative"
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
+/obj/structure/table/woodentable/maple,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "lF" = (
-/obj/effect/wallframe_spawn/reinforced/polarized/full,
+/obj/machinery/door/airlock/command{
+	name = "Ethics Committee Liaison's Office"
+	},
 /turf/simulated/floor/plating,
 /area/site53/uez/o5repoffice)
 "lH" = (
@@ -5896,15 +5886,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"pc" = (
-/obj/item/stamp/approved,
-/obj/item/stamp/denied,
-/obj/structure/table/woodentable/walnut,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/uez/o5repoffice)
 "pd" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/beakers,
@@ -6307,57 +6288,36 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/command{
-	name = "O5 Representative's Office";
-	req_access = list("ACCESS_ADMIN_LEVEL2")
+	name = "Tribunal Department Officer's Office"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/o5repoffice)
-"rj" = (
-/obj/structure/bed/chair/comfy/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/blue,
-/area/site53/uez/o5repoffice)
 "rk" = (
-/obj/structure/table/woodentable/walnut,
-/obj/effect/floor_decal/carpet/blue{
-	dir = 1
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/item/toy/desk/fan,
-/turf/simulated/floor/carpet/blue,
-/area/site53/uez/o5repoffice)
-"rl" = (
-/obj/structure/bed/chair/comfy/red{
-	dir = 8
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
-/obj/effect/floor_decal/carpet/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rm" = (
 /turf/simulated/mineral,
 /area/site53/surface/surface)
 "rn" = (
-/turf/simulated/floor/wood/walnut,
+/obj/machinery/door/window/holowindoor{
+	id_tag = "sitedirect";
+	req_access = list("ACCESS_ADMIN_LEVEL5")
+	},
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "ro" = (
 /obj/machinery/light,
@@ -6377,46 +6337,38 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rq" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/bed/chair/armchair{
+	dir = 1
 	},
-/obj/structure/coatrack,
-/turf/simulated/floor/wood/walnut,
+/obj/effect/landmark/start{
+	name = "Ethics Committee Liaison"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rr" = (
-/obj/structure/bed/chair/comfy/red{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/carpet/blue,
-/obj/effect/floor_decal/carpet/blue{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rs" = (
-/obj/item/device/flashlight/lamp/green,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/table/woodentable/walnut,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rt" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -6427,17 +6379,16 @@
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
 "rv" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/door/window/holowindoor{
+	id_tag = "sitedirect";
+	req_access = list("ACCESS_ADMIN_LEVEL5")
+	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/table/woodentable/walnut,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rw" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -6448,102 +6399,86 @@
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
 "rx" = (
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
+/obj/structure/table/woodentable/maple,
+/obj/item/paper_bin,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "ry" = (
-/obj/item/modular_computer/tablet/preset/custom_loadout/advanced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/table/woodentable/walnut,
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/uez/o5repoffice)
-"rz" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/carpet/blue2,
-/turf/simulated/floor/carpet/blue2,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/holofloor/wood,
+/area/site53/uez/o5repoffice)
+"rz" = (
+/obj/structure/bed/chair/armchair{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "Internal Tribunal Department Officer"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rA" = (
 /obj/machinery/power/apc{
-	dir = 4
+	dir = 4;
+	name = "west bump"
 	},
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rB" = (
-/obj/effect/paint_stripe/red,
+/obj/effect/paint_stripe/orange,
 /turf/simulated/wall/titanium,
 /area/site53/uez/o5repoffice)
 "rC" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "O5 Representative's Office";
-	send_access = list("ACCESS_ADMIN_LEVEL5")
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/wood/walnut,
-/area/site53/uez/o5repoffice)
-"rD" = (
-/obj/machinery/photocopier{
-	pixel_y = 4
-	},
-/obj/structure/table/woodentable/walnut,
-/turf/simulated/floor/wood/walnut,
+/obj/machinery/photocopier/faxmachine,
+/obj/structure/table/woodentable,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rE" = (
-/obj/structure/filingcabinet{
-	pixel_x = -10
-	},
-/obj/machinery/papershredder{
-	pixel_x = 7
-	},
-/turf/simulated/floor/wood/walnut,
+/obj/structure/closet/walllocker,
+/obj/item/storage/box/cdeathalarm_kit,
+/obj/item/storage/box/syringes,
+/obj/item/reagent_containers/ivbag/amnesticsf,
+/obj/item/reagent_containers/pill/amnestics/classb,
+/obj/item/reagent_containers/pill/amnestics/classb,
+/obj/item/reagent_containers/pill/amnestics/classa,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/storage/pill_bottle/amnesticsa,
+/obj/item/reagent_containers/syringe/amnesticsc,
+/obj/item/device/taperecorder,
+/obj/item/pen/fancy,
+/obj/item/stamp/scp/o5rep,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rF" = (
-/obj/machinery/light,
-/turf/simulated/floor/wood/walnut,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rG" = (
-/obj/machinery/button/windowtint{
-	id_tag = "o5rep";
-	pixel_x = 32
-	},
-/obj/structure/closet/secure_closet/personal/empty,
-/obj/item/reagent_containers/syringe/amnesticsc,
-/obj/item/reagent_containers/syringe/amnesticsc,
-/obj/item/reagent_containers/ivbag/amnesticsf,
-/obj/item/reagent_containers/ivbag/amnesticsd,
-/obj/item/implanter,
-/obj/item/implantcase/death_alarm,
-/turf/simulated/floor/wood/walnut,
+/obj/structure/closet/walllocker,
+/obj/item/device/taperecorder,
+/obj/item/storage/briefcase/crimekit,
+/obj/item/pen/fancy,
+/obj/item/stamp/scp/o5rep,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "rH" = (
 /obj/machinery/light,
@@ -8012,17 +7947,15 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
 "xx" = (
-/obj/structure/bed/chair/comfy/red{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/carpet/blue,
-/obj/effect/floor_decal/carpet/blue{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/floor_decal/carpet/blue{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/blue,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "xF" = (
 /obj/effect/paint_stripe/gray,
@@ -9497,9 +9430,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
 "Iy" = (
-/obj/structure/table/woodentable/walnut,
-/obj/effect/floor_decal/carpet/blue,
-/turf/simulated/floor/carpet/blue,
+/obj/structure/bed/chair/office,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "Iz" = (
 /obj/effect/floor_decal/corner/orange/border{
@@ -10926,8 +10858,13 @@
 /turf/simulated/mineral,
 /area/site53/medical/infirmary)
 "VA" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood/walnut,
+/obj/effect/paint_stripe/orange,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/titanium,
 /area/site53/uez/o5repoffice)
 "VG" = (
 /obj/effect/catwalk_plated/dark,
@@ -11336,19 +11273,9 @@
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
 "Zh" = (
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/structure/table/woodentable/walnut,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 5
-	},
-/turf/simulated/floor/carpet/blue2,
+/obj/structure/bed/chair/office,
+/obj/structure/closet/walllocker,
+/turf/simulated/floor/holofloor/wood,
 /area/site53/uez/o5repoffice)
 "Zn" = (
 /turf/simulated/floor/tiled/monotile,
@@ -44130,13 +44057,13 @@ bw
 dt
 lo
 mB
-lF
-lF
-lF
-lF
-lF
-lF
-lF
+rB
+rB
+rB
+rB
+rB
+rB
+rB
 ms
 mu
 Jt
@@ -44387,13 +44314,13 @@ gh
 cD
 lo
 mB
-lF
-rj
+rB
+rF
 rr
 rn
-rn
+rk
 rC
-lF
+rB
 ms
 mu
 Jt
@@ -44644,13 +44571,13 @@ gh
 cD
 lo
 mB
-lF
-rk
+rB
+rF
 Iy
-gZ
-rn
-rD
-lF
+lE
+rq
+rF
+rB
 ms
 mu
 Jt
@@ -44902,12 +44829,12 @@ dt
 lo
 mB
 lF
-rl
+rF
+Iy
+rx
 xx
-VA
-rn
 rE
-lF
+rB
 ms
 mv
 Gi
@@ -45158,13 +45085,13 @@ dA
 dt
 Zv
 WX
-lF
-rn
-rn
-rn
-rn
-rn
-lF
+rB
+rB
+rB
+rB
+VA
+rB
+rB
 ms
 mu
 tR
@@ -45420,8 +45347,8 @@ rp
 rs
 rv
 ry
-rn
-lF
+rC
+rB
 mw
 mx
 Df
@@ -45672,13 +45599,13 @@ dA
 dt
 OK
 ve
-lF
-rn
-pc
+rB
+rF
+Iy
 lE
 rz
 rF
-lF
+rB
 tM
 tM
 Gi
@@ -45929,13 +45856,13 @@ dA
 dt
 lo
 mB
-lF
-rq
+rB
+rF
 Zh
 rx
 rA
 rG
-lF
+rB
 bS
 bm
 YR
@@ -46186,10 +46113,10 @@ dA
 lv
 mT
 ov
-lF
-lF
-lF
-lF
+rB
+rB
+rB
+rB
 rB
 rB
 rB

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -6405,11 +6405,6 @@
 /area/site53/uez/o5repoffice)
 "ry" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"


### PR DESCRIPTION
## About the Pull Request

This update splits the O5 Representative into two separate roles, the Internal Tribunal Department Officer and the Ethics Committee Liaison. The office is also split to allow room for both roles. 

## Why It's Good For The Game

This is a much-needed change, as the O5 Representative is currently without a real purpose. The Internal Tribunal Department focuses solely on laws and regulations, and the Ethics Liaison focuses on Ethical issues.  This gives both roles more of an actual focus, and certainly will help with the recent self-antag issues. Both of these roles don't have much power on their own, and must fax to get most things done. 
## Changelog

:cl:
add: Tribunal Officer and Ethics Liaison
remove: O5 Representative
