### PR TITLE
Disabled 173 on lowpop

### DIFF
--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 	. = ..()
 	if(isobj(loc))
 		return
-	if(length(GLOB.clients) <= 24)
+	if(length(GLOB.clients) >= 30 && !client)
 		return
 	var/list/our_view = view(7, src)
 	for(var/A in next_blinks)

--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -99,7 +99,6 @@ GLOBAL_LIST_EMPTY(scp173s)
 		visible_message("<span class='danger'>[src] snaps [H]'s neck!</span>")
 		playsound(loc, pick('sound/scp/spook/NeckSnap1.ogg', 'sound/scp/spook/NeckSnap3.ogg'), 50, 1)
 		H.death()
-		H.scp173_killed = TRUE
 		return
 	if(istype(A, /obj/machinery/door))
 		OpenDoor(A)
@@ -120,6 +119,8 @@ GLOBAL_LIST_EMPTY(scp173s)
 /mob/living/scp_173/Life()
 	. = ..()
 	if(isobj(loc))
+		return
+	if(length(GLOB.clients) <= 24)
 		return
 	var/list/our_view = view(7, src)
 	for(var/A in next_blinks)
@@ -294,12 +295,6 @@ GLOBAL_LIST_EMPTY(scp173s)
 /mob/living/scp_173/proc/BreachEffect()
 	var/area/A = get_area(src)
 	A.full_breach()
-
-// humans
-/mob/living/carbon/human/set_stat(_new)
-	..(_new)
-	if (stat != DEAD)
-		scp173_killed = FALSE
 
 // the cage
 /obj/structure/scp173_cage

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -119,9 +119,6 @@
 	var/scp_013_instance = FALSE
 	var/scp_013_stage = 0
 
-	// SCP-173
-	var/scp173_killed = FALSE
-
 	// SCP-049
 	var/pre_scp049_name = ""
 	var/pre_scp049_real_name = ""

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -626,7 +626,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		// no whitelist required
 		for (var/scp173 in GLOB.scp173s)
 			var/mob/M = scp173
-			if (!M.client)
+			if (!M.client && (length(GLOB.clients) >= 30))
 				scps += M
 
 		// add new humanoid SCPs here or they won't be playable - Kachnov


### PR DESCRIPTION
## About the Pull Request

Added a piece of code to disable SCP-173 under 30 pop.

## Why It's Good For The Game

It prevents 173 from murderboning people on lowpop, and to calm peoples nerves while playing on lowpop.

## Changelog

:cl:
del: Removed old kill function from SCP-173
balance: Disabled 173 on lowpop (Under 30 players)
code: SCP-173 code changed a little.
/:cl: