### PR TITLE
Skill Math fix

### DIFF
--- a/code/__defines/skills.dm
+++ b/code/__defines/skills.dm
@@ -7,7 +7,7 @@
 
 #define SKILL_MIN      1 // Min skill value selectable
 #define SKILL_MAX      5 // Max skill value selectable
-#define SKILL_DEFAULT  1 //most mobs will default to this
+#define SKILL_DEFAULT  4 //most mobs will default to this
 
 #define SKILL_EASY     (1<<0)
 #define SKILL_AVERAGE  (1<<1)

--- a/code/modules/mob/skills/antag_skill_setter.dm
+++ b/code/modules/mob/skills/antag_skill_setter.dm
@@ -3,7 +3,7 @@
 /datum/antag_skill_setter
 	var/nm_type                        //A nano_module with custom ui, if any.
 	var/list/base_skill_list = list()  //Format: list(path = value).
-	var/default_value = SKILL_DEFAULT  //If not in base_skill_list or added in another way, skill value will be this.
+	var/default_value = SKILL_BASIC  //If not in base_skill_list or added in another way, skill value will be this.
 
 /datum/antag_skill_setter/proc/initialize_skills(datum/skillset/skillset)
 	skillset.skill_list = base_skill_list.Copy()

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -121,7 +121,7 @@
 		if(SKILL_UNTRAINED)
 			return max(0, 1 + 6*factor)
 		else
-			return max(0, 1 + (SKILL_DEFAULT - points) * factor)
+			return max(0, 1 + (((SKILL_DEFAULT-1) - points) * factor))
 
 /mob/proc/do_skilled(base_delay, skill_path , atom/target = null, factor = 0.3, do_flags = DO_DEFAULT)
 	return do_after(src, base_delay * skill_delay_mult(skill_path, factor), target, do_flags)

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -121,7 +121,7 @@
 		if(SKILL_UNTRAINED)
 			return max(0, 1 + 6*factor)
 		else
-			return max(0, 1 + (((SKILL_DEFAULT-1) - points) * factor))
+			return max(0, 1 + ((SKILL_BASIC - points) * factor))
 
 /mob/proc/do_skilled(base_delay, skill_path , atom/target = null, factor = 0.3, do_flags = DO_DEFAULT)
 	return do_after(src, base_delay * skill_delay_mult(skill_path, factor), target, do_flags)


### PR DESCRIPTION
## About the Pull Request

Reverts previously altered default_skill value, which broke all of skill time multipliers. (instnat injection, surgery, construction, etc.)

Also alters the formula itself to use a lower value.

It is supposed to prevent multiplier being 0, while still retaining low values for master skill level.

## Changelog

:cl:
fix: fixed skill-time multiplier being 0 at high skill levels.
/:cl:
