### PR TITLE
Fix photocopies/faxes of 096 photo

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -312,6 +312,10 @@ var/global/photo_count = 0
 	p.photo_size = photo_size
 	p.scribble = scribble
 
+	p.anomalous = anomalous
+	p.anomalymob = anomalymob
+	p.anomalytype = anomalytype
+
 	if(copy_id)
 		p.id = id
 


### PR DESCRIPTION
## About the Pull Request

what it says on the tin
tested with fax machine and photocopier
closes #890 

## Why It's Good For The Game

no more 30000 photo copies of 096 in the hallways and only 1 of them is actually anomalous (actually happened one round)

## Changelog

:cl:
fix: Photocopied/faxed photos of 096 are now anomalous
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
