### PR TITLE
fix 151 while blindfolded

### DIFF
--- a/code/modules/SCP/SCPs/SCP-151.dm
+++ b/code/modules/SCP/SCPs/SCP-151.dm
@@ -26,6 +26,14 @@
 
 /obj/structure/scp151/examine(mob/living/user)
 	. = ..()
+
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(H.equipment_tint_total == TINT_BLIND)
+			return
+	if(user.stat)
+		return
+
 	if(!(user in victims) && istype(user))
 		victims += user //on examine, adds user into victims list
 	if (user in victims)


### PR DESCRIPTION
## About the Pull Request

previously when you examined 151 with a blindfold on (or while unconscious/ghost in dead body), still became victim
i copied over the check from 096 to make this not happen
#888 

## Why It's Good For The Game

cant fucking see it lmao why would it give effects

## Changelog

:cl:
fix: Examining 151 with a blindfold on no longer effects you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
