### PR TITLE
Better 012 can_affect check

### DIFF
--- a/code/modules/SCP/SCPs/SCP-012.dm
+++ b/code/modules/SCP/SCPs/SCP-012.dm
@@ -66,4 +66,5 @@ GLOBAL_LIST_EMPTY(scp012s)
 				playsound(affecting, "sound/voice/emotes/[gender2text(affecting.gender)]_cry[pick(1,2)].ogg", 100)
 
 /obj/item/paper/proc/can_affect(var/mob/living/carbon/human/H)
-	return H.stat == CONSCIOUS && !H.blinded && !istype(H.glasses, /obj/item/clothing/glasses/sunglasses)
+	// technically 012 is memetic, but having no counter and being insta-GBJ'd seems dumb
+	return H.stat == CONSCIOUS && H.equipment_tint_total != TINT_BLIND


### PR DESCRIPTION
## About the Pull Request

what it says on the tin
closes #903 

## Why It's Good For The Game

sunglasses shouldn't be able to block it lol wtf

## Changelog

:cl:
fix: Blindfolds now block being effected by 012, sunglasses do not
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
