### PR TITLE
Improves Hot Foods vending machine

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1439,7 +1439,7 @@
 					/obj/item/reagent_containers/food/snacks/cheeseburger = 2,
 					/obj/item/reagent_containers/food/snacks/taco = 1,
 					/obj/item/reagent_containers/food/snacks/hotdog = 1,
-					/obj/item/reagent_containers/food/snacks/fries = 2,
+					/obj/item/reagent_containers/food/snacks/fries = 2
 					)
 
 /obj/machinery/vending/hotfood/on_update_icon()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1435,13 +1435,11 @@
 	icon_state = "hotfood"
 	icon_deny = "hotfood-deny"
 	icon_vend = "hotfood-vend"
-	products = list(/obj/item/reagent_containers/food/snacks/grilledcheese = 1,
-					/obj/item/reagent_containers/food/snacks/meatsteak = 1,
-					/obj/item/reagent_containers/food/snacks/cheeseburger = 1,
+	products = list(/obj/item/reagent_containers/food/snacks/meatsteak = 1,
+					/obj/item/reagent_containers/food/snacks/cheeseburger = 2,
 					/obj/item/reagent_containers/food/snacks/taco = 1,
 					/obj/item/reagent_containers/food/snacks/hotdog = 1,
 					/obj/item/reagent_containers/food/snacks/fries = 2,
-					/obj/item/reagent_containers/food/snacks/onionrings = 1,
 					)
 
 /obj/machinery/vending/hotfood/on_update_icon()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -1428,19 +1428,20 @@
 
 /obj/machinery/vending/hotfood
 	name = "\improper Hot Foods"
-	desc = "An old vending machine promising 'hot foods'. You doubt any of its contents are still edible."
+	desc = "A vending machine dispensing meals for people too lazy to walk to the cafeteria."
 	vend_delay = 40
 	base_type = /obj/machinery/vending/hotfood
 
 	icon_state = "hotfood"
 	icon_deny = "hotfood-deny"
 	icon_vend = "hotfood-vend"
-	products = list(/obj/item/reagent_containers/food/snacks/old/pizza = 1,
-					/obj/item/reagent_containers/food/snacks/old/burger = 1,
-					/obj/item/reagent_containers/food/snacks/old/hamburger = 1,
-					/obj/item/reagent_containers/food/snacks/old/fries = 1,
-					/obj/item/reagent_containers/food/snacks/old/hotdog = 1,
-					/obj/item/reagent_containers/food/snacks/old/taco = 1
+	products = list(/obj/item/reagent_containers/food/snacks/grilledcheese = 1,
+					/obj/item/reagent_containers/food/snacks/meatsteak = 1,
+					/obj/item/reagent_containers/food/snacks/cheeseburger = 1,
+					/obj/item/reagent_containers/food/snacks/taco = 1,
+					/obj/item/reagent_containers/food/snacks/hotdog = 1,
+					/obj/item/reagent_containers/food/snacks/fries = 2,
+					/obj/item/reagent_containers/food/snacks/onionrings = 1,
 					)
 
 /obj/machinery/vending/hotfood/on_update_icon()


### PR DESCRIPTION
## About the Pull Request

The "Hot foods" machine that's in, among other places, the Administrative Department's break room, has nothing but inedible and toxic food. This PR fixes that.

## Why It's Good For The Game

Staff should have food options when there's no cook (other than protein bars and raisins), and improving this semi-broken vending machine seemed to be a good way to lessen downtime for important roles.

## Possible changes/improvements

Could implement a feature where cooks can put in their own food items, then cooks would have a reason to exit the kitchen and wander the site, as well as reducing the single possible bad effect of this PR (that players might go to the bar less).

## Changelog

:cl:
fix: The "Hot Foods" vendor now actually has edible food.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
