### PR TITLE
Backpack hotfix

### DIFF
--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -13,7 +13,6 @@
 	suit = /obj/item/clothing/suit/storage/toggle/suit/black
 	id_types = list(/obj/item/card/id/adminlvl5)
 	l_ear = /obj/item/device/radio/headset/heads/captain
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 	l_hand = /obj/item/storage/briefcase/foundation/jerraman
@@ -25,7 +24,6 @@
 	suit = /obj/item/clothing/suit/storage/toggle/suit/black
 	id_types = list(/obj/item/card/id/adminlvl4)
 	l_ear = /obj/item/device/radio/headset/heads/hop
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/command/commsofficer
 	name = OUTFIT_JOB_NAME("Communications Officer")
@@ -34,7 +32,6 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/commslvl4)
 	l_ear = /obj/item/device/radio/headset/heads/commsofficer
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 
 
@@ -47,7 +44,6 @@
 	id_types = list(/obj/item/card/id/commslvl1)
 	belt = /obj/item/storage/belt/utility/full
 	l_ear = /obj/item/device/radio/headset/commsdispatcher
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 
 /decl/hierarchy/outfit/job/ds90/crew/command/chief_engineer
@@ -58,7 +54,6 @@
 	belt = /obj/item/storage/belt/utility/full
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/ce
-	//back = /obj/item/storage/backpack/industrial
 
 //Don't touch these yet, Working on em! - Kepler
 // Cell Guards
@@ -69,7 +64,6 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/seclvl4
 	l_ear = /obj/item/device/radio/headset/heads/cw
-	//back = null
 
 /decl/hierarchy/outfit/job/site90/crew/security/brigofficer
 	name = OUTFIT_JOB_NAME("Cell Guard")
@@ -78,7 +72,6 @@
 	id_types = list(/obj/item/card/id/seclvl2
 	l_ear = /obj/item/device/radio/headset/headset_sec
 	l_pocket = /obj/item/book/manual/scp/secsop
-	//back = null
 */
 
 
@@ -93,7 +86,6 @@
 	suit = /obj/item/clothing/suit/armor/hos/jensen
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/clothing/head/helmet/scp/hczsecurityguard = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmateba
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/goggles
@@ -113,7 +105,6 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/tactical
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/clothing/head/beret/sec = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/hczsecurityguard
@@ -133,7 +124,6 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/handcuffs = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/security
@@ -149,7 +139,6 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/clothing/head/beret/sec/corporate/hos = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -169,7 +158,6 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec_lcz
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/handcuffs = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/security
@@ -187,7 +175,6 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec_hcz
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/hczsecurityguard
@@ -204,7 +191,6 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -222,7 +208,6 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/storage/firstaid/adv = 1, /obj/item/storage/firstaid/stab = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -240,7 +225,6 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -255,7 +239,6 @@
 	suit = /obj/item/clothing/suit/storage/det_trench/grey
 	id_types = list(/obj/item/card/id/zcseclvl4ez)
 	l_ear = /obj/item/device/radio/headset/heads/cos
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	belt = /obj/item/storage/belt/holster/security/fullrhino
 	l_hand = /obj/item/storage/briefcase/crimekit
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/goggles
@@ -272,7 +255,6 @@
 	suit = /obj/item/clothing/suit/storage/det_trench
 	id_types = list(/obj/item/card/id/zcseclvl4ez)
 	l_ear = /obj/item/device/radio/headset/heads/cos
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	belt = /obj/item/storage/belt/holster/security/fullrhino
 	l_hand = /obj/item/storage/briefcase/crimekit
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/goggles
@@ -294,7 +276,6 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec_lcz
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/handcuffs = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/security
@@ -311,7 +292,6 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/tactical
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/hczsecurityguard
@@ -326,7 +306,6 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	id_types = list(/obj/item/card/id/sciencelvl1)
 	l_ear = /obj/item/device/radio/headset/headset_sci
-	//back = /obj/item/storage/backpack/satchel/tox
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/science/scientist
@@ -338,7 +317,6 @@
 	l_ear = /obj/item/device/radio/headset/headset_sci
 	l_pocket = /obj/item/book/manual/scp/scisop
 	glasses = /obj/item/clothing/glasses/science
-	//back = /obj/item/storage/backpack/messenger/tox
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/science/seniorroboticist
@@ -386,7 +364,6 @@
 	l_pocket = /obj/item/book/manual/scp/scisop
 	l_ear = /obj/item/device/radio/headset/headset_sci
 	glasses = /obj/item/clothing/glasses/science
-	//back = /obj/item/storage/backpack/messenger/tox
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/science/researchdirector
@@ -398,7 +375,6 @@
 	gloves = /obj/item/clothing/gloves/latex/nitrile
 	l_ear = /obj/item/device/radio/headset/heads/rd
 	l_pocket = /obj/item/book/manual/scp/scisop
-	//back = /obj/item/storage/backpack/messenger/tox
 	glasses = /obj/item/clothing/glasses/hud/science
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
@@ -409,7 +385,6 @@
 	uniform = /obj/item/clothing/under/scp/dclass
 	shoes = /obj/item/clothing/shoes/workboots
 	l_ear = null
-	//back = null
 	l_pocket = /obj/item/paper/dclass_orientation
 	id_types = list(/obj/item/card/id/classd)
 
@@ -425,7 +400,6 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/sciencelvl1)
-	//back = /obj/item/storage/backpack/satchel
 	l_ear = /obj/item/device/radio/headset/headset_service
 
 /decl/hierarchy/outfit/job/site90/crew/civ/chef
@@ -434,7 +408,6 @@
 	shoes = /obj/item/clothing/shoes/white
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/chef)
-	//back = /obj/item/storage/backpack/satchel
 	l_ear = /obj/item/device/radio/headset/headset_service
 
 /decl/hierarchy/outfit/job/site90/crew/civ/bartender
@@ -444,7 +417,6 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/bartender)
 	l_ear = /obj/item/device/radio/headset/headset_service
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/civ/archivist
 	name = OUTFIT_JOB_NAME("Archivist")
@@ -452,7 +424,6 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/archivist)
-	//back = /obj/item/storage/backpack/satchel
 	l_ear = /obj/item/device/radio/headset/headset_arch
 
 /decl/hierarchy/outfit/job/site90/crew/civ/gocrep
@@ -466,7 +437,6 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl3)
 	l_ear = /obj/item/device/radio/headset/heads/goc
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/usp45 = 1)
 	belt = /obj/item/gun/projectile/pistol/usp45
 
@@ -479,7 +449,6 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl3)
 	l_ear = /obj/item/device/radio/headset/heads/uiu
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 
@@ -491,7 +460,6 @@
 	pda_type = /obj/item/modular_computer/pda/medical
 	l_ear = /obj/item/device/radio/headset/heads/thi
 	belt = /obj/item/gun/projectile/pistol/m1911
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/civ/MCDRep
@@ -504,7 +472,6 @@
 	r_hand = /obj/item/storage/secure/briefcase/money
 	l_hand = /obj/item/cane
 	l_ear = /obj/item/device/radio/headset/heads/mcd
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/c45m = 1)
 	belt = /obj/item/gun/projectile/silenced
 
@@ -515,7 +482,6 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl5)
 	l_ear = /obj/item/device/radio/headset/heads/hop
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 
@@ -526,7 +492,6 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl5)
 	l_ear = /obj/item/device/radio/headset/heads/hop
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 
@@ -557,7 +522,6 @@
 	belt = /obj/item/storage/belt/utility/full
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/ce
-	//back = /obj/item/storage/backpack/industrial
 
 /decl/hierarchy/outfit/job/ds90/crew/engineering/conteng
 	name = OUTFIT_JOB_NAME("Containment Engineer")
@@ -567,7 +531,6 @@
 	belt = /obj/item/storage/belt/utility/full
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/ce
-	//back = /obj/item/storage/backpack/industrial
 
 
 // BRIG OFFICER
@@ -577,7 +540,6 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/seclvl2)
 	l_ear = /obj/item/device/radio/headset/headset_com
-	//back = /obj/item/storage/backpack/satchel/
 
 
 // MEDICAL OUTFITS
@@ -589,7 +551,6 @@
 	id_types = list(/obj/item/card/id/chiefmedicalofficer)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/cmo
-	//back = /obj/item/storage/backpack/medic
 
 /decl/hierarchy/outfit/job/ds90/medical/psychiatrist
 	name = OUTFIT_JOB_NAME("Psychiatrist")
@@ -608,7 +569,6 @@
 	id_types = list(/obj/item/card/id/chemist)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	//back = /obj/item/storage/backpack/medic
 
 /decl/hierarchy/outfit/job/ds90/medical/medicaldoctor
 	name = OUTFIT_JOB_NAME("Medical Doctor")
@@ -618,7 +578,6 @@
 	id_types = list(/obj/item/card/id/doctor)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	//back = /obj/item/storage/backpack/medic
 
 /decl/hierarchy/outfit/job/ds90/medical/surgeon
 	name = OUTFIT_JOB_NAME("Surgeon")
@@ -628,7 +587,6 @@
 	id_types = list(/obj/item/card/id/doctor)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/ds90/medical/emt
 	name = OUTFIT_JOB_NAME("Emergency Medical Technician")
@@ -637,7 +595,6 @@
 	id_types = list(/obj/item/card/id/emt)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	//back = /obj/item/storage/backpack/medic
 
 
 // LOGISTICS OUTFITS
@@ -648,7 +605,6 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/logoff)
 	l_ear = /obj/item/device/radio/headset/headset_deckofficer
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/command/logisticspecialist
 	name = OUTFIT_JOB_NAME("Logistics Specialist")
@@ -658,7 +614,6 @@
 	id_types = list(/obj/item/card/id/logspec)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_cargo
-	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtfbasic
 	name = OUTFIT_JOB_NAME("MTF Epsilon-11 Agent")
@@ -687,7 +642,6 @@
 	r_pocket = /obj/item/grenade/flashbang
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/silenced
-	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 2,/obj/item/grenade/frag = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/ammo_magazine/c45m = 2,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtf_epsilon2
@@ -707,7 +661,6 @@
 	r_pocket = /obj/item/grenade/flashbang
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/silenced
-	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/grenade/frag = 2,/obj/item/ammo_magazine/c45m = 2,/obj/item/clothing/accessory/storage/bandolier = 1,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtf_epsilon3
@@ -727,7 +680,6 @@
 	r_pocket = null
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/revolver/webley/captain
-	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/grenade/frag = 1,/obj/item/crowbar/red = 1,/obj/item/ammo_magazine/scp/m16_mag = 3,/obj/item/ammo_magazine/c44 = 4,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtf_epsilon4
@@ -747,7 +699,6 @@
 	r_pocket = null
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/defibrillator/compact/combat/loaded
-	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/ammo_magazine/scp/p90_mag/ap = 3,/obj/item/clothing/mask/gas = 1,/obj/item/reagent_containers/ivbag/blood/OMinus = 2,/obj/item/storage/pill_bottle/zoom = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/eta_soldier //See No Evil
@@ -767,7 +718,6 @@
 	r_pocket = /obj/item/ammo_magazine/scp
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/pistol
-	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 1,/obj/item/grenade/frag = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/beta_soldier //Maz Hatters
@@ -787,7 +737,6 @@
 	r_pocket = /obj/item/ammo_magazine/scp
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/pistol
-	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/hammerdown //if this ever sees use, an admin really wants someone dead
@@ -807,7 +756,6 @@
 	r_pocket = /obj/item/grenade/flashbang/clusterbang //gods must be strong
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/ammo_magazine/t12 = 15) //all you need is kill
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_soldier
@@ -827,7 +775,6 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/automatic/machine_pistol
-	//back = /obj/item/storage/backpack/rucksack/green
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/clothing/mask/gas = 1,/obj/item/ammo_magazine/scp/ak = 3,/obj/item/ammo_magazine/c45uzi = 2,/obj/item/grenade/smokebomb = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_soldier_alt
@@ -847,7 +794,6 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/shotgun/doublebarrel/sawn
-	//back = /obj/item/storage/backpack/rucksack/green
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/ammo_magazine/scp/ak/big = 5,/obj/item/clothing/mask/gas = 1,/obj/item/grenade/frag = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_leader
@@ -867,7 +813,6 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/material/sword/katana
-	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 3)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc
@@ -887,7 +832,6 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/gunner
@@ -907,7 +851,6 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1, /obj/item/ammo_magazine/box/machinegun = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/grenadier
@@ -927,7 +870,6 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/fragshells = 8,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1,/obj/item/clothing/accessory/storage/bandolier = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/leader
@@ -946,7 +888,6 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak/big = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 // FULLY GEARED (for zombies)
@@ -962,7 +903,6 @@
 	l_pocket = /obj/item/device/radio
 	r_pocket = /obj/item/ammo_magazine/scp/p90_mag
 	suit_store = /obj/item/gun/projectile/automatic/scp/p90
-	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -974,7 +914,6 @@
 	id_types = list(/obj/item/card/id/sciencelvl1)
 	gloves = /obj/item/clothing/gloves/latex
 	l_ear = /obj/item/device/radio/headset/headset_sci
-	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -986,7 +925,6 @@
 	id_types = list(/obj/item/card/id/sciencelvl2)
 	gloves = /obj/item/clothing/gloves/latex
 	l_ear = /obj/item/device/radio/headset/headset_sci
-	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -998,7 +936,6 @@
 	id_types = list(/obj/item/card/id/doctor)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -1008,7 +945,6 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	id_types = list(/obj/item/card/id/classd)
 	l_ear = null
-	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -1018,7 +954,6 @@
 	uniform = /obj/item/clothing/under/scp/suittie
 	shoes = /obj/item/clothing/shoes/laceup
 	id_types = list(/obj/item/card/id/officeworker)
-	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/paper_bin = 1,/obj/item/device/radio =1,/obj/item/pen = 1)
 	l_ear = /obj/item/device/radio/headset/headset_service
 	r_ear = /obj/item/pen

--- a/maps/site53/job/outfits.dm
+++ b/maps/site53/job/outfits.dm
@@ -3,7 +3,7 @@
 
 //SITE DS90 OUTFITS
 //Keeping them simple for now, just spawning with basic uniforms, and pretty much no gear. Gear instead goes in lockers. Keep this in mind if editing.
-
+//Note: backpack items conflict with the built-in backpack selection
 
 // SCP COMMAND OUTFITS
 /decl/hierarchy/outfit/job/site90/crew/command/facilitydir
@@ -13,7 +13,7 @@
 	suit = /obj/item/clothing/suit/storage/toggle/suit/black
 	id_types = list(/obj/item/card/id/adminlvl5)
 	l_ear = /obj/item/device/radio/headset/heads/captain
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 	l_hand = /obj/item/storage/briefcase/foundation/jerraman
@@ -25,7 +25,7 @@
 	suit = /obj/item/clothing/suit/storage/toggle/suit/black
 	id_types = list(/obj/item/card/id/adminlvl4)
 	l_ear = /obj/item/device/radio/headset/heads/hop
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/command/commsofficer
 	name = OUTFIT_JOB_NAME("Communications Officer")
@@ -34,7 +34,7 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/commslvl4)
 	l_ear = /obj/item/device/radio/headset/heads/commsofficer
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 
 
@@ -47,7 +47,7 @@
 	id_types = list(/obj/item/card/id/commslvl1)
 	belt = /obj/item/storage/belt/utility/full
 	l_ear = /obj/item/device/radio/headset/commsdispatcher
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 
 /decl/hierarchy/outfit/job/ds90/crew/command/chief_engineer
@@ -58,7 +58,7 @@
 	belt = /obj/item/storage/belt/utility/full
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/ce
-	back = /obj/item/storage/backpack/industrial
+	//back = /obj/item/storage/backpack/industrial
 
 //Don't touch these yet, Working on em! - Kepler
 // Cell Guards
@@ -69,7 +69,7 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/seclvl4
 	l_ear = /obj/item/device/radio/headset/heads/cw
-	back = null
+	//back = null
 
 /decl/hierarchy/outfit/job/site90/crew/security/brigofficer
 	name = OUTFIT_JOB_NAME("Cell Guard")
@@ -78,7 +78,7 @@
 	id_types = list(/obj/item/card/id/seclvl2
 	l_ear = /obj/item/device/radio/headset/headset_sec
 	l_pocket = /obj/item/book/manual/scp/secsop
-	back = null
+	//back = null
 */
 
 
@@ -93,7 +93,7 @@
 	suit = /obj/item/clothing/suit/armor/hos/jensen
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/clothing/head/helmet/scp/hczsecurityguard = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmateba
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/goggles
@@ -113,7 +113,7 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/tactical
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/clothing/head/beret/sec = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/hczsecurityguard
@@ -133,7 +133,7 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/handcuffs = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/security
@@ -149,7 +149,7 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/clothing/head/beret/sec/corporate/hos = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -169,7 +169,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec_lcz
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/handcuffs = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/security
@@ -187,7 +187,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec_hcz
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/hczsecurityguard
@@ -204,7 +204,7 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -222,7 +222,7 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/storage/firstaid/adv = 1, /obj/item/storage/firstaid/stab = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -240,7 +240,7 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/medium
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud
@@ -255,7 +255,7 @@
 	suit = /obj/item/clothing/suit/storage/det_trench/grey
 	id_types = list(/obj/item/card/id/zcseclvl4ez)
 	l_ear = /obj/item/device/radio/headset/heads/cos
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	belt = /obj/item/storage/belt/holster/security/fullrhino
 	l_hand = /obj/item/storage/briefcase/crimekit
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/goggles
@@ -272,7 +272,7 @@
 	suit = /obj/item/clothing/suit/storage/det_trench
 	id_types = list(/obj/item/card/id/zcseclvl4ez)
 	l_ear = /obj/item/device/radio/headset/heads/cos
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	belt = /obj/item/storage/belt/holster/security/fullrhino
 	l_hand = /obj/item/storage/briefcase/crimekit
 	glasses = /obj/item/clothing/glasses/sunglasses/sechud/goggles
@@ -294,7 +294,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_sec_lcz
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/handcuffs = 1)
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/security
@@ -311,7 +311,7 @@
 	suit = /obj/item/clothing/suit/armor/pcarrier/scp/tactical
 	l_pocket = /obj/item/handcuffs
 	r_pocket = /obj/item/melee/telebaton
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list()
 	belt = /obj/item/storage/belt/holster/security/fullmk9
 	head = /obj/item/clothing/head/helmet/scp/hczsecurityguard
@@ -326,7 +326,7 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	id_types = list(/obj/item/card/id/sciencelvl1)
 	l_ear = /obj/item/device/radio/headset/headset_sci
-	back = /obj/item/storage/backpack/satchel/tox
+	//back = /obj/item/storage/backpack/satchel/tox
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/science/scientist
@@ -338,7 +338,7 @@
 	l_ear = /obj/item/device/radio/headset/headset_sci
 	l_pocket = /obj/item/book/manual/scp/scisop
 	glasses = /obj/item/clothing/glasses/science
-	back = /obj/item/storage/backpack/messenger/tox
+	//back = /obj/item/storage/backpack/messenger/tox
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/science/seniorroboticist
@@ -386,7 +386,7 @@
 	l_pocket = /obj/item/book/manual/scp/scisop
 	l_ear = /obj/item/device/radio/headset/headset_sci
 	glasses = /obj/item/clothing/glasses/science
-	back = /obj/item/storage/backpack/messenger/tox
+	//back = /obj/item/storage/backpack/messenger/tox
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/science/researchdirector
@@ -398,7 +398,7 @@
 	gloves = /obj/item/clothing/gloves/latex/nitrile
 	l_ear = /obj/item/device/radio/headset/heads/rd
 	l_pocket = /obj/item/book/manual/scp/scisop
-	back = /obj/item/storage/backpack/messenger/tox
+	//back = /obj/item/storage/backpack/messenger/tox
 	glasses = /obj/item/clothing/glasses/hud/science
 	backpack_contents = list(/obj/item/clothing/accessory/tunic = 1)
 
@@ -409,7 +409,7 @@
 	uniform = /obj/item/clothing/under/scp/dclass
 	shoes = /obj/item/clothing/shoes/workboots
 	l_ear = null
-	back = null
+	//back = null
 	l_pocket = /obj/item/paper/dclass_orientation
 	id_types = list(/obj/item/card/id/classd)
 
@@ -425,7 +425,7 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/sciencelvl1)
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	l_ear = /obj/item/device/radio/headset/headset_service
 
 /decl/hierarchy/outfit/job/site90/crew/civ/chef
@@ -434,7 +434,7 @@
 	shoes = /obj/item/clothing/shoes/white
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/chef)
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	l_ear = /obj/item/device/radio/headset/headset_service
 
 /decl/hierarchy/outfit/job/site90/crew/civ/bartender
@@ -444,7 +444,7 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/bartender)
 	l_ear = /obj/item/device/radio/headset/headset_service
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/civ/archivist
 	name = OUTFIT_JOB_NAME("Archivist")
@@ -452,7 +452,7 @@
 	shoes = /obj/item/clothing/shoes/laceup
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/archivist)
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	l_ear = /obj/item/device/radio/headset/headset_arch
 
 /decl/hierarchy/outfit/job/site90/crew/civ/gocrep
@@ -466,7 +466,7 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl3)
 	l_ear = /obj/item/device/radio/headset/heads/goc
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/usp45 = 1)
 	belt = /obj/item/gun/projectile/pistol/usp45
 
@@ -479,7 +479,7 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl3)
 	l_ear = /obj/item/device/radio/headset/heads/uiu
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 
@@ -491,7 +491,7 @@
 	pda_type = /obj/item/modular_computer/pda/medical
 	l_ear = /obj/item/device/radio/headset/heads/thi
 	belt = /obj/item/gun/projectile/pistol/m1911
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/civ/MCDRep
@@ -504,7 +504,7 @@
 	r_hand = /obj/item/storage/secure/briefcase/money
 	l_hand = /obj/item/cane
 	l_ear = /obj/item/device/radio/headset/heads/mcd
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/c45m = 1)
 	belt = /obj/item/gun/projectile/silenced
 
@@ -515,7 +515,7 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl5)
 	l_ear = /obj/item/device/radio/headset/heads/hop
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 
@@ -526,7 +526,7 @@
 	l_pocket = /obj/item/device/radio
 	id_types = list(/obj/item/card/id/adminlvl5)
 	l_ear = /obj/item/device/radio/headset/heads/hop
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
 
@@ -557,7 +557,7 @@
 	belt = /obj/item/storage/belt/utility/full
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/ce
-	back = /obj/item/storage/backpack/industrial
+	//back = /obj/item/storage/backpack/industrial
 
 /decl/hierarchy/outfit/job/ds90/crew/engineering/conteng
 	name = OUTFIT_JOB_NAME("Containment Engineer")
@@ -567,7 +567,7 @@
 	belt = /obj/item/storage/belt/utility/full
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/ce
-	back = /obj/item/storage/backpack/industrial
+	//back = /obj/item/storage/backpack/industrial
 
 
 // BRIG OFFICER
@@ -577,7 +577,7 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/seclvl2)
 	l_ear = /obj/item/device/radio/headset/headset_com
-	back = /obj/item/storage/backpack/satchel/
+	//back = /obj/item/storage/backpack/satchel/
 
 
 // MEDICAL OUTFITS
@@ -589,7 +589,7 @@
 	id_types = list(/obj/item/card/id/chiefmedicalofficer)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/heads/cmo
-	back = /obj/item/storage/backpack/medic
+	//back = /obj/item/storage/backpack/medic
 
 /decl/hierarchy/outfit/job/ds90/medical/psychiatrist
 	name = OUTFIT_JOB_NAME("Psychiatrist")
@@ -608,7 +608,7 @@
 	id_types = list(/obj/item/card/id/chemist)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	back = /obj/item/storage/backpack/medic
+	//back = /obj/item/storage/backpack/medic
 
 /decl/hierarchy/outfit/job/ds90/medical/medicaldoctor
 	name = OUTFIT_JOB_NAME("Medical Doctor")
@@ -618,7 +618,7 @@
 	id_types = list(/obj/item/card/id/doctor)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	back = /obj/item/storage/backpack/medic
+	//back = /obj/item/storage/backpack/medic
 
 /decl/hierarchy/outfit/job/ds90/medical/surgeon
 	name = OUTFIT_JOB_NAME("Surgeon")
@@ -628,7 +628,7 @@
 	id_types = list(/obj/item/card/id/doctor)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/ds90/medical/emt
 	name = OUTFIT_JOB_NAME("Emergency Medical Technician")
@@ -637,7 +637,7 @@
 	id_types = list(/obj/item/card/id/emt)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	back = /obj/item/storage/backpack/medic
+	//back = /obj/item/storage/backpack/medic
 
 
 // LOGISTICS OUTFITS
@@ -648,7 +648,7 @@
 	shoes = /obj/item/clothing/shoes/dutyboots
 	id_types = list(/obj/item/card/id/logoff)
 	l_ear = /obj/item/device/radio/headset/headset_deckofficer
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/command/logisticspecialist
 	name = OUTFIT_JOB_NAME("Logistics Specialist")
@@ -658,7 +658,7 @@
 	id_types = list(/obj/item/card/id/logspec)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_cargo
-	back = /obj/item/storage/backpack/satchel/pocketbook
+	//back = /obj/item/storage/backpack/satchel/pocketbook
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtfbasic
 	name = OUTFIT_JOB_NAME("MTF Epsilon-11 Agent")
@@ -687,7 +687,7 @@
 	r_pocket = /obj/item/grenade/flashbang
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/silenced
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 2,/obj/item/grenade/frag = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/ammo_magazine/c45m = 2,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtf_epsilon2
@@ -707,7 +707,7 @@
 	r_pocket = /obj/item/grenade/flashbang
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/silenced
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/grenade/frag = 2,/obj/item/ammo_magazine/c45m = 2,/obj/item/clothing/accessory/storage/bandolier = 1,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtf_epsilon3
@@ -727,7 +727,7 @@
 	r_pocket = null
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/revolver/webley/captain
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/grenade/frag = 1,/obj/item/crowbar/red = 1,/obj/item/ammo_magazine/scp/m16_mag = 3,/obj/item/ammo_magazine/c44 = 4,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/mtf_epsilon4
@@ -747,7 +747,7 @@
 	r_pocket = null
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/defibrillator/compact/combat/loaded
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/ammo_magazine/scp/p90_mag/ap = 3,/obj/item/clothing/mask/gas = 1,/obj/item/reagent_containers/ivbag/blood/OMinus = 2,/obj/item/storage/pill_bottle/zoom = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/eta_soldier //See No Evil
@@ -767,7 +767,7 @@
 	r_pocket = /obj/item/ammo_magazine/scp
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/pistol
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 1,/obj/item/grenade/frag = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/beta_soldier //Maz Hatters
@@ -787,7 +787,7 @@
 	r_pocket = /obj/item/ammo_magazine/scp
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/pistol
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/hammerdown //if this ever sees use, an admin really wants someone dead
@@ -807,7 +807,7 @@
 	r_pocket = /obj/item/grenade/flashbang/clusterbang //gods must be strong
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	back = /obj/item/storage/backpack/rucksack
+	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/ammo_magazine/t12 = 15) //all you need is kill
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_soldier
@@ -827,7 +827,7 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/automatic/machine_pistol
-	back = /obj/item/storage/backpack/rucksack/green
+	//back = /obj/item/storage/backpack/rucksack/green
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/clothing/mask/gas = 1,/obj/item/ammo_magazine/scp/ak = 3,/obj/item/ammo_magazine/c45uzi = 2,/obj/item/grenade/smokebomb = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_soldier_alt
@@ -847,7 +847,7 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/gun/projectile/shotgun/doublebarrel/sawn
-	back = /obj/item/storage/backpack/rucksack/green
+	//back = /obj/item/storage/backpack/rucksack/green
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/ammo_magazine/scp/ak/big = 5,/obj/item/clothing/mask/gas = 1,/obj/item/grenade/frag = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/chaos_leader
@@ -867,7 +867,7 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/material/sword/katana
-	back = /obj/item/storage/backpack/satchel
+	//back = /obj/item/storage/backpack/satchel
 	backpack_contents = list(/obj/item/storage/box/ifak = 1, /obj/item/grenade/smokebomb = 3)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc
@@ -887,7 +887,7 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	back = /obj/item/storage/backpack/rucksack
+	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/gunner
@@ -907,7 +907,7 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	back = /obj/item/storage/backpack/rucksack
+	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1, /obj/item/ammo_magazine/box/machinegun = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/grenadier
@@ -927,7 +927,7 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	back = /obj/item/storage/backpack/rucksack
+	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/fragshells = 8,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1,/obj/item/clothing/accessory/storage/bandolier = 1)
 
 /decl/hierarchy/outfit/job/site90/crew/command/event/ungoc/leader
@@ -946,7 +946,7 @@
 	r_pocket = /obj/item/card/emag
 	l_ear = /obj/item/device/radio/headset/ert
 	belt = /obj/item/storage/belt/holster/security/tactical
-	back = /obj/item/storage/backpack/rucksack
+	//back = /obj/item/storage/backpack/rucksack
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/storage/box/handcuffs = 1,/obj/item/ammo_magazine/scp/ak/big = 10,/obj/item/clothing/accessory/ubac/green = 1,/obj/item/clothing/accessory/armor/helmcover/blue/sol = 1)
 
 // FULLY GEARED (for zombies)
@@ -962,7 +962,7 @@
 	l_pocket = /obj/item/device/radio
 	r_pocket = /obj/item/ammo_magazine/scp/p90_mag
 	suit_store = /obj/item/gun/projectile/automatic/scp/p90
-	back = null
+	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -974,7 +974,7 @@
 	id_types = list(/obj/item/card/id/sciencelvl1)
 	gloves = /obj/item/clothing/gloves/latex
 	l_ear = /obj/item/device/radio/headset/headset_sci
-	back = null
+	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -986,7 +986,7 @@
 	id_types = list(/obj/item/card/id/sciencelvl2)
 	gloves = /obj/item/clothing/gloves/latex
 	l_ear = /obj/item/device/radio/headset/headset_sci
-	back = null
+	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -998,7 +998,7 @@
 	id_types = list(/obj/item/card/id/doctor)
 	l_pocket = /obj/item/device/radio
 	l_ear = /obj/item/device/radio/headset/headset_med
-	back = null
+	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -1008,7 +1008,7 @@
 	shoes = /obj/item/clothing/shoes/workboots
 	id_types = list(/obj/item/card/id/classd)
 	l_ear = null
-	back = null
+	//back = null
 	l_hand = null
 	r_hand = null
 
@@ -1018,12 +1018,11 @@
 	uniform = /obj/item/clothing/under/scp/suittie
 	shoes = /obj/item/clothing/shoes/laceup
 	id_types = list(/obj/item/card/id/officeworker)
-	back = /obj/item/storage/backpack/satchel/leather/black
+	//back = /obj/item/storage/backpack/satchel/leather/black
 	backpack_contents = list(/obj/item/paper_bin = 1,/obj/item/device/radio =1,/obj/item/pen = 1)
 	l_ear = /obj/item/device/radio/headset/headset_service
 	r_ear = /obj/item/pen
 	l_pocket = /obj/item/material/clipboard
 	r_pocket = /obj/item/folder
-	back = null
 	l_hand = null
 	r_hand = null


### PR DESCRIPTION
## About the Pull Request

This PR fixes the bug where people (both start-of-round and latejoin) spawn in with two backpack-type items. Previously, most of the jobs that you started with would provide its own backpack item (e.g. the site director starts with a black pocketbook). However, there is also a preference in character creation that allows you to set your default backpack.  Due to these, the game creates 2 backpacks on spawn, one based on role and the other based on preference. This PR simply removes the role-backpacks.

It would also work to remove the equipment preference system from the game, but I felt that was a worse option.

Closes #967

## Why It's Good For The Game

Bugs are bad.

## Future improvements

More options could be added to the equipment preference menu.

Equipment preference could be altered on-spawn by the player's job (e.g. if you spawn in as a science department role, your backpack/satchel/rucksack would switch to a science-themed version).

Equipment preference could be expanded to other areas of the loadout, which would cut down on the clutter in the loadout purchasing system.

## Changelog

:cl:
del: Backpacks in role-based loadouts were removed.
fix: Double backpack on spawn fixed.
/:cl: