### PR TITLE
Removes wall overlapping door in LCZ security FOR REAL

### DIFF
--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -16781,7 +16781,7 @@
 /obj/machinery/door/airlock/glass/security{
 	name = "Break Room"
 	},
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aVn" = (
 /obj/effect/floor_decal/chapel{


### PR DESCRIPTION
## About the Pull Request

The door to the break room in LCZ had a wall placed on top of it, this has been replaced with a floor tile.

Closes #970 

(didn't fuck up this time)

## Why It's Good For The Game

Bugs are bad

## Changelog

:cl:
fix: Break room in LCZ security is now actually accessible.
/:cl:
