### PR TITLE
Cryopod potential runtime fixed.

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -432,8 +432,7 @@
 	occupant.ckey = null
 	if(!g) // Player didn't ghost. Ghost then delete.
 		g = occupant.ghostize(FALSE)
-	if(!g) // Player STILL didn't ghost. Should only happen if the CKEY is null
-		g.skip_respawn_timer = TRUE
+	g?.skip_respawn_timer = TRUE
 	qdel(occupant)
 	set_occupant(null)
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -432,7 +432,8 @@
 	occupant.ckey = null
 	if(!g) // Player didn't ghost. Ghost then delete.
 		g = occupant.ghostize(FALSE)
-	g.skip_respawn_timer = TRUE
+	if(!g) // Player STILL didn't ghost. Should only happen if the CKEY is null
+		g.skip_respawn_timer = TRUE
 	qdel(occupant)
 	set_occupant(null)
 


### PR DESCRIPTION
## About the Pull Request

Fixes #194 (I think).

From what I can tell, the runtime noted in #194 happens when a body lacking a CKEY gets despawned. Since there is no CKEY, ghostize() fails to create a ghost, which causes the game to error when a value of a null object tries to get changed.

## Why It's Good For The Game

Runtimes are bad.

## Changelog

:cl:
code: Cryopod runtime on clientless bodies fixed.
/:cl: