### PR TITLE
Fixes ID modification program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -8,7 +8,7 @@
 	extended_desc = "Program for programming crew ID cards."
 	requires_ntnet = FALSE
 	size = 8
-	var/operating_access_types = ACCESS_TYPE_NONE | ACCESS_TYPE_STATION | ACCESS_TYPE_CENTCOM
+	var/operating_access_types = ACCESS_TYPE_NONE | ACCESS_TYPE_STATION | ACCESS_TYPE_CENTCOM | ACCESS_TYPE_INNATE
 /datum/nano_module/program/card_mod
 	name = "ID card modification program"
 	var/mod_mode = 1


### PR DESCRIPTION
## About the Pull Request

Someone forgot to put the new ID's in the list

Closes #905

## Why It's Good For The Game

This really annoyed me, and I'm glad it's gonna be fixed.

## Potential Improvements

You can have level 5 access in something while not having level 1 access. That should be fixed, although it's more a problem with ACCESS_TYPE_INNATE than the ID program

## Changelog

:cl:
fix: The ID modification program can now modify innate accesses (e.g. Medical Lvl 4)
/:cl: