### PR TITLE
173 Lighting tweaks and intergration

### DIFF
--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -64,6 +64,12 @@ var/list/floor_light_cache = list()
 			if(isnull(damaged)) damaged = 0
 		return TRUE
 
+/obj/machinery/floor_light/proc/shatter()
+	visible_message("<span class='danger'>\The [src] shatters!</span>")
+	playsound(src, "shatter", 70, 1)
+	set_broken(TRUE)
+	return TRUE
+
 /obj/machinery/floor_light/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -64,12 +64,6 @@ var/list/floor_light_cache = list()
 			if(isnull(damaged)) damaged = 0
 		return TRUE
 
-/obj/machinery/floor_light/proc/shatter()
-	visible_message("<span class='danger'>\The [src] shatters!</span>")
-	playsound(src, "shatter", 70, 1)
-	set_broken(TRUE)
-	return TRUE
-
 /obj/machinery/floor_light/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE

--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 	/// Current attack cooldown
 	var/snap_cooldown
 	/// Amount of the attack cooldown
-	var/snap_cooldown_time = 2 SECONDS
+	var/snap_cooldown_time = 4 SECONDS
 	/// Current light break cooldown
 	var/light_break_cooldown
 	/// Amount of light fixture break cooldown

--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -185,7 +185,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 			var/lightcount = T.get_lumcount()
 			if(lightcount > max_lightlevel)
 				lightcount = 1 //Light level must be less than max_lightlevel before blink time drop off
-			next_blinks[H] = (world.time + rand(5 SECONDS, 10 SECONDS)) * lightcount // Just encountered SCP 173
+			next_blinks[H] = world.time + (rand(5 SECONDS, 10 SECONDS) * lightcount) // Just encountered SCP 173
 		if(H.SCP)
 			continue
 		if(is_blind(H) || H.eye_blind > 0)
@@ -261,7 +261,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 	var/lightcount = T.get_lumcount()
 	if(lightcount > max_lightlevel)
 		lightcount = 1 //Light level must be less than max_lightlevel before blink time drop off
-	next_blinks[H] = (world.time + rand(15 SECONDS, 25 SECONDS)) * lightcount
+	next_blinks[H] = world.time + (rand(15 SECONDS, 25 SECONDS) * lightcount)
 
 /mob/living/scp_173/proc/AIAttemptAttack()
 	var/mob/living/carbon/human/target

--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -116,7 +116,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 			to_chat(src, "<span class='warning'>You can't break that yet.</span>")
 			return
 		var/obj/machinery/floor_light/W = A
-		W.shatter()
+		W.physical_attack_hand(src)
 		light_break_cooldown = world.time + light_break_cooldown_time
 		return
 	if(istype(A,/obj/machinery/light))

--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -109,6 +109,9 @@ GLOBAL_LIST_EMPTY(scp173s)
 		OpenDoor(A)
 		return
 	if(istype(A,/obj/machinery/floor_light))
+		if(get_area(A) == spawn_area)
+			to_chat(src, "<span class='warning'>You can't reach the lights in your own containment zone.</span>")
+			return
 		if(light_break_cooldown > world.time) //cooldown
 			to_chat(src, "<span class='warning'>You can't break that yet.</span>")
 			return
@@ -117,6 +120,9 @@ GLOBAL_LIST_EMPTY(scp173s)
 		light_break_cooldown = world.time + light_break_cooldown_time
 		return
 	if(istype(A,/obj/machinery/light))
+		if(get_area(A) == spawn_area)
+			to_chat(src, "<span class='warning'>You can't reach the lights in your own containment zone.</span>")
+			return
 		if(light_break_cooldown > world.time) //cooldown
 			to_chat(src, "<span class='warning'>You can't break that yet.</span>")
 			return


### PR DESCRIPTION
## About the Pull Request

Makes it so that 173 can now break lights, and the light level of the tile that 173 is on now affects the blink cooldown.

## Why It's Good For The Game

Adds a bit more gameplay to 173 besides waiting, trying to get near a person, and left-clicking. In full darkness, 173 can move un-impeded even if he is "being looked at" meaning 173 players can try to be more tactical about their approach and take out lights in areas they might come in contact with people. 173 players can also now try to make a getaway in certain situations. For example, if four people are staring it down, but it manages to break a nearby light, it can still escape. On the other hand, security now also has to worry about keeping flashlights around, and power outages become a serious threat if 173 is breached. Finally, the power outage that happens in 173's chamber during a breach now actually impacts the situation instead of just being an aesthetic choice.

P.S.: Im aware this is somewhat of a buff but because it's in the form of a new gameplay mechanic and breaching takes an HOUR, that's right, a full HOUR, I think it's fair.

## Changelog

:cl:
add: 173 can now break lights
add: Light level now affects blink cooldown
/:cl:
