### PR TITLE
Fixes bug introduced with 457 PR

### DIFF
--- a/code/modules/SCP/SCPs/SCP-457.dm
+++ b/code/modules/SCP/SCPs/SCP-457.dm
@@ -134,12 +134,6 @@
 	var/check = A.open(1)
 	visible_message("\The [src] melts \the [A]'s controls[check ? ", and rips it open!" : ", and breaks it!"]")
 
-/datum/reagent/water/touch_mob(var/mob/living/scp_457/M)
-	if(istype(M))
-		M.adjustBruteLoss(30)
-		to_chat(M,	SPAN_USERDANGER("FUEL LESSENS, MAKE THEM PAY..."))
-		return ..()
-
 /mob/living/scp_457/Life()
 	if(health <= 0)
 		death(FALSE, "falls on their knees, the flame withering away.")

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -151,8 +151,8 @@
 			if (!istype(C) || !(C.body_parts_covered & FACE))
 				S.extinguish()
 
-	if(istype(L, var/mob/living/scp_457))
-		M.adjustBruteLoss(30)
+	if(istype(L, /mob/living/scp_457))
+		L.adjustBruteLoss(30)
 		to_chat(L,	SPAN_USERDANGER("FUEL LESSENS, MAKE THEM PAY..."))
 
 	if(istype(L))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -152,8 +152,9 @@
 				S.extinguish()
 
 	if(istype(L, /mob/living/scp_457))
-		L.adjustBruteLoss(30)
+		L.adjustBruteLoss(amount * 2)
 		to_chat(L,	SPAN_USERDANGER("FUEL LESSENS, MAKE THEM PAY..."))
+		remove_self(amount)
 
 	if(istype(L))
 		var/needed = L.fire_stacks * 10

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -151,6 +151,10 @@
 			if (!istype(C) || !(C.body_parts_covered & FACE))
 				S.extinguish()
 
+	if(istype(L, var/mob/living/scp_457))
+		M.adjustBruteLoss(30)
+		to_chat(L,	SPAN_USERDANGER("FUEL LESSENS, MAKE THEM PAY..."))
+
 	if(istype(L))
 		var/needed = L.fire_stacks * 10
 		if(amount > needed)


### PR DESCRIPTION
## About the Pull Request

This was not rectified in the original PR so I'm creating a new one to fix this. The original code completely overwrote reagent/water/touch_mob(), plus it left snowflakey code in a completely unrelated place. Also, wrote in some improvements to the function.

## Why It's Good For The Game

Bugs are bad, shitcode is bad.

## Changelog

:cl:
add: Amount of water matters for extinguishing 457
code: Fixed 457 code overwriting water code
/:cl: