### PR TITLE
Special check in timer.dm for invalid wait values

### DIFF
--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -457,6 +457,9 @@ SUBSYSTEM_DEF(timer)
 	if (!callback)
 		CRASH("addtimer called without a callback")
 
+	if (!isnum(wait))
+		crash_with("addtimer called with an invalid wait.")
+
 	if (wait < 0)
 		crash_with("addtimer called with a negative wait. Converting to [world.tick_lag]")
 


### PR DESCRIPTION
## About the Pull Request

Small change, should help to identify runtimes.

Related to #191 

## Why It's Good For The Game

Doesn't prevent errors, but helps clarify with the runtime message.

## Changelog

:cl:
code: addtimer() in timer.dm has better crash message if wait value is invalid.
/:cl:
