### PR TITLE
Makes 3349 easier to test with

### DIFF
--- a/code/modules/SCP/SCPs/SCP-3349.dm
+++ b/code/modules/SCP/SCPs/SCP-3349.dm
@@ -26,35 +26,21 @@
 
 // SETUP
 
-GLOBAL_VAR(scp3349_precedentA)
-GLOBAL_VAR(scp3349_precedentB)
-
-GLOBAL_VAR(scp3349_fake_precedentA)
-GLOBAL_VAR(scp3349_fake_precedentB)
+GLOBAL_VAR(scp3349_precedent)
+GLOBAL_VAR(scp3349_fake_precedent)
 
 /proc/initialize_scp3349_precedents()
 
-	// group A is common medicines, group B is standard metals
-	var/list/groupA = list(
+	// common medicines
+	var/list/reagents = list(
 		/datum/reagent/medicine/inaprovaline,
-		/datum/reagent/medicine/bicaridine,
 		/datum/reagent/medicine/kelotane,
 		/datum/reagent/medicine/dylovene,
 		/datum/reagent/medicine/dexalin
 	)
 
-	var/list/groupB = list(
-		/datum/reagent/aluminium,
-		/datum/reagent/copper,
-		/datum/reagent/iron,
-		/datum/reagent/tungsten
-	)
-
-	GLOB.scp3349_precedentA = pick_n_take(groupA)
-	GLOB.scp3349_precedentB = pick_n_take(groupB)
-
-	GLOB.scp3349_fake_precedentA = pick_n_take(groupA)
-	GLOB.scp3349_fake_precedentB = pick_n_take(groupB)
+	GLOB.scp3349_precedent = pick_n_take(reagents)
+	GLOB.scp3349_fake_precedent = pick_n_take(reagents)
 
 // PAPER
 

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -316,15 +316,11 @@
 /datum/reagent/sodium/affect_blood(mob/living/carbon/M, alien, removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		// 5u and 1u, decreased a bit to give room for error
-		if((H.chem_doses[GLOB.scp3349_precedentA] > 4.4) && (H.chem_doses[GLOB.scp3349_precedentB] > 0.6))
-
-			//make sure we have none of the fake precedents (to stop people just jamming all 4 in a single person)
-			for(var/datum/reagent/current in H.chem_doses)
-				if((current.type == GLOB.scp3349_fake_precedentA) || (current.type == GLOB.scp3349_fake_precedentB))
-					return
-
+		if((H.chem_doses[GLOB.scp3349_precedent] > 4.4) && (H.chem_doses[GLOB.scp3349_fake_precedent] < 0.6))
 			H.RegisterSignal(H, COMSIG_CARBON_LIFE, /mob/living/carbon/human/proc/handle_3349, TRUE)
+
+			var/obj/item/organ/internal/heart/heart = H.internal_organs_by_name[BP_HEART]
+			heart.scp3349_induced = TRUE
 
 /datum/reagent/sugar
 	name = "Sugar"

--- a/maps/site53/items/manuals.dm
+++ b/maps/site53/items/manuals.dm
@@ -893,13 +893,11 @@ SCP-939 exhale minute traces of an aerosolized Class C amnestic, designated AMN-
 /obj/item/paper/scp/keter/scp3349/Initialize()	// documentation is slightly randomized every round, so we need to put the description in Initialize()
 	. = ..()
 
-	if(isnull(GLOB.scp3349_precedentA) || isnull(GLOB.scp3349_precedentB) || isnull(GLOB.scp3349_fake_precedentA) || isnull(GLOB.scp3349_fake_precedentB))
+	if(isnull(GLOB.scp3349_precedent) && isnull(GLOB.scp3349_fake_precedent))
 		initialize_scp3349_precedents()
 
-	var/datum/reagent/precedentA = GLOB.scp3349_precedentA
-	var/datum/reagent/precedentB = GLOB.scp3349_precedentB
-	var/datum/reagent/precedentA_f = GLOB.scp3349_fake_precedentA
-	var/datum/reagent/precedentB_f = GLOB.scp3349_fake_precedentB
+	var/datum/reagent/precedent = GLOB.scp3349_precedent
+	var/datum/reagent/precedentF = GLOB.scp3349_fake_precedent
 
 	info = {"
 		<tt><center><b><font color='red'>KETER: SCP-3349</font></b>
@@ -918,8 +916,7 @@ SCP-939 exhale minute traces of an aerosolized Class C amnestic, designated AMN-
 	<br>
 	<b>Description:</b> SCP-3349 is a nonfatal cardiac arrhythmia that has a 42.8% incidence following a specific sequence of drug administrations. This sequence has not been fully identified, but has been narrowed down to the following process:
 	<br><ol>
-	<li>5u of: [prob(50) ? "[initial(precedentA.name)] OR [initial(precedentA_f.name)]" : "[initial(precedentA_f.name)] OR [initial(precedentA.name)]"]</li><br>
-	<li>1u of: [prob(50) ? "[initial(precedentB.name)] OR [initial(precedentB_f.name)]" : "[initial(precedentB_f.name)] OR [initial(precedentB.name)]"]</li><br>
+	<li>5u of: [prob(50) ? "[initial(precedent.name)] OR [initial(precedentF.name)]" : "[initial(precedentF.name)] OR [initial(precedent.name)]"]</li><br>
 	<li>1u of: Sodium</li><br>
 	</ol>
 	SCP-3349 is not constant and appears periodically in the affected individual with an average of nine occurrences per day, lasting for an average of three minutes per occurrence. Subjectively, patients report feeling comforted, elated, and euphoric. Objectively, SCP-3349 produces a \"fluttering\" central and peripheral pulse upon palpation, often described as tactilely similar to a purr of <i>Felis catus</i> (the common house cat), and can be auscultated with a stethoscope, the clinical descriptions also citing the purr of <i>Felis catus</i>.


### PR DESCRIPTION
## About the Pull Request

Reduces the requirements for inflicting SCP-3349, plus doing it right will give immediate results.

## Why It's Good For The Game

Tried testing SCP-3349 in-game and it's hard as hell since there's zero indication that the procedure was performed properly.

## Changelog

:cl:
balance: SCP-3349 is easier to test with
/:cl: