### PR TITLE
Fixes tiny overesight with lockers and full_breach proc

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -306,6 +306,10 @@ var/list/mob/living/forced_ambiance_list = new
 // Open everything and then kill APC
 /area/proc/full_breach()
 	for(var/obj/machinery/door/temp_door in src)
+		if(istype(temp_door, /obj/machinery/door/blast))
+			var/obj/machinery/door/blast/BD = temp_door
+			BD.force_open()
+			continue
 		temp_door.open(TRUE) // Forced
 	for(var/obj/machinery/power/apc/temp_apc in src)
 		temp_apc.energy_fail(30 SECONDS)

--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -166,6 +166,12 @@ GLOBAL_LIST_EMPTY(scp173s)
 	if(istype(A, /obj/structure/inflatable))
 		var/obj/structure/inflatable/W = A
 		W.deflate(violent=1)
+	if(istype(A, /obj/structure/closet))
+		var/obj/structure/closet/C = A
+		if(C.open())
+			return
+		C.dump_contents()
+		QDEL_NULL(C)
 	return
 
 /mob/living/scp_173/Life()


### PR DESCRIPTION
## About the Pull Request

- SCP-173 can open/break lockers/crates now.
- Full breach area proc will now force open blastdoors.

## Why It's Good For The Game

- People were using lockers as ultimate defense against 173. Well, no more.
- Turn off power in the area and blastdoors wouldn't open. This fixes it.

## Changelog

:cl:
tweak: SCP-173 can now open/break lockers and crates.
fix: Full breach on area will now force-open blastdoors. This is mainly used by 173's breach effect.
/:cl:
