### PR TITLE
SCP 173 tweaks

### DIFF
--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 	/// Cooldown for defecation...
 	var/defecation_cooldown
 	/// How much time you have to wait before defecating again
-	var/defecation_cooldown_time = 60 SECONDS
+	var/defecation_cooldown_time = 45 SECONDS
 	/// What kind of objects/effects we spawn on defecation. Also used when checking the area
 	var/list/defecation_types = list(/obj/effect/decal/cleanable/blood/gibs/red, /obj/effect/decal/cleanable/vomit, /obj/effect/decal/cleanable/mucus)
 
@@ -56,14 +56,9 @@ GLOBAL_LIST_EMPTY(scp173s)
 	/// This one to avoid sound spam when opening doors
 	var/door_cooldown
 
-	/// Is 173 caged?
-	var/is_caged = FALSE
-	/// 173's current cage.
-	var/obj/structure/scp173_cage/cage
-
 /mob/living/scp_173/Initialize()
 	GLOB.scp173s += src
-	defecation_cooldown = world.time + 15 MINUTES // Give everyone some time to prepare
+	defecation_cooldown = world.time + 10 MINUTES // Give everyone some time to prepare
 	spawn_area = get_area(src)
 	add_language(LANGUAGE_EAL, FALSE)
 	add_language(LANGUAGE_SKRELLIAN, FALSE)
@@ -77,7 +72,6 @@ GLOBAL_LIST_EMPTY(scp173s)
 		H.disable_blink(src)
 	next_blinks = null
 	next_blinks_join_time = null
-	cage = null
 
 	GLOB.scp173s -= src
 	return ..()
@@ -99,19 +93,6 @@ GLOBAL_LIST_EMPTY(scp173s)
 	return -5
 
 /mob/living/scp_173/UnarmedAttack(atom/A)
-	if(is_caged) // We can't do anything while caged
-		if(!IsBeingWatched() && istype(A, /obj/structure/scp173_cage)) //Can only attack the cage when not being watched and inside the cage
-			if(snap_cooldown <= world.time)
-				var/obj/structure/scp173_cage/cage = A
-				cage.attack_hand(src)
-				snap_cooldown = world.time + snap_cooldown_time
-				to_chat(src, SPAN_WARNING("You damage the cage."))
-			else
-				to_chat(src, SPAN_WARNING("You can't attack yet."))
-		else if(IsBeingWatched() && istype(A, /obj/structure/scp173_cage))
-			to_chat(src, SPAN_WARNING("You can't attack the cage while they're looking!"))
-		else
-			return
 	if(IsBeingWatched() || incapacitated())// We can't do anything while being watched
 		return
 	if(ishuman(A))
@@ -178,7 +159,8 @@ GLOBAL_LIST_EMPTY(scp173s)
 	. = ..()
 	if(length(GLOB.clients) <= 30 && !client)
 		return
-	var/list/our_view = dview(7, is_caged ? cage : src)//In case we are caged, we must see if our cage is being looked at rather than us
+	//In case we are caged, we must see if our cage is being looked at rather than us
+	var/list/our_view = dview(7, istype(loc, /obj/structure/scp173_cage) ? loc : src)
 	for(var/mob/living/carbon/human/H in next_blinks)
 		if(!(H in our_view))
 			H.disable_blink(src)
@@ -188,7 +170,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 		next_blinks += H
 	handle_regular_hud_updates()
 	process_blink_hud(src)
-	if(is_caged)
+	if(!isturf(loc)) // Inside of something
 		return
 	if(world.time > defecation_cooldown)
 		Defecate()
@@ -204,7 +186,11 @@ GLOBAL_LIST_EMPTY(scp173s)
 	return TRUE
 
 /mob/living/scp_173/proc/IsBeingWatched()
-	for(var/mob/living/L in dview(7, is_caged ? cage : src)) //same as before, cage needs to be used as reference rather than 173
+	// Same as before, cage needs to be used as reference rather than 173
+	var/atom/A = src
+	if(istype(loc, /obj/structure/scp173_cage))
+		A = loc
+	for(var/mob/living/L in dview(7, A))
 		if((istype(L, /mob/living/simple_animal/scp_131)) && (InCone(L, L.dir)))
 			return TRUE
 		if(!istype(L, /mob/living/carbon/human))
@@ -212,7 +198,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 		var/mob/living/carbon/human/H = L
 		if(H.SCP)
 			continue
-		if(H.can_see(src))
+		if(H.can_see(A))
 			return TRUE
 	return FALSE
 
@@ -308,10 +294,10 @@ GLOBAL_LIST_EMPTY(scp173s)
 				SelfMove(Tdir)
 	// Breach check
 	var/feces_amount = CheckFeces()
-	if(feces_amount >= 60) // Breach, gonna take ~60 minutes
+	if(feces_amount >= 60) // Breach, gonna take ~45 minutes
 		if(breach_cooldown > world.time)
 			return
-		breach_cooldown = world.time + 25 MINUTES
+		breach_cooldown = world.time + 15 MINUTES
 		warning_cooldown = world.time + 5 MINUTES // Just in case 173 doesn't immediately leave the area
 		command_announcement.Announce("ALERT! SCP-173 containment zone security measures have shut down due to severe acidic degradation.")
 		BreachEffect()
@@ -334,142 +320,146 @@ GLOBAL_LIST_EMPTY(scp173s)
 	var/area/A = get_area(src)
 	A.full_breach()
 
-//
-// 173 Cage
-//
-
+// SCP-173 Cage
 /obj/structure/scp173_cage
-	icon = 'icons/SCP/cage.dmi'
-	icon_state = "open"
 	name = "SCP-173 Containment Cage"
 	desc = "An empty cage for containing SCP-173."
+	icon = 'icons/SCP/cage.dmi'
+	icon_state = "open"
 	density = TRUE
 	layer = MOB_LAYER + 0.05
-	plane = OBJ_PLANE
-	// Max damage state before breaking out
-	var/damage_max = 5
-	// Damage state of cage
+	var/resist_cooldown
+	/// Current damage points of the cage
 	var/damage_state = 0
-	// Currently held 173
-	var/mob/living/scp_173/current173
-
+	/// Maximum damage points, upon which cage becomes unusable and 173, if inside, escapes
+	var/damage_state_max = 5
 
 /obj/structure/scp173_cage/MouseDrop_T(atom/movable/dropping, mob/user) // When someone drags 173 onto the cage
-	if(damage_state > damage_max)
-		visible_message(SPAN_WARNING("\The [src] is too damaged to operate!"))
+	if(locate(/mob/living) in contents)
+		to_chat(user, SPAN_WARNING("\The [src] is already full!"))
+		return FALSE
+	if(damage_state >= damage_state_max)
+		to_chat(user, SPAN_WARNING("\The [src] is too damaged to operate!"))
 		return FALSE
 	if(isscp173(dropping))
 		visible_message(SPAN_WARNING("[user] starts to put [dropping] into the cage."))
 		var/oloc = loc
-		if(do_after(user, 10 SECONDS, current173) && loc == oloc)
-			plane = MOB_PLANE
-			current173 = dropping
-			current173.forceMove(src)
-			current173.is_caged = TRUE
-			current173.cage = src
-			updateIconandDesc()
-			visible_message(SPAN_NOTICE("[user] puts [current173] in the cage."))
+		if(do_after(user, 10 SECONDS, dropping) && loc == oloc)
+			dropping.forceMove(src)
+			update_icon()
+			visible_message(SPAN_NOTICE("[user] puts [dropping] in the cage."))
 			playsound(loc, 'sound/machines/bolts_down.ogg', 50, 1)
 			return TRUE
 		return FALSE
-	else if(isliving(dropping))
+	if(isliving(dropping))
 		to_chat(user, SPAN_WARNING("\The [dropping] won't fit in the cage."))
 	return FALSE
 
-/obj/structure/scp173_cage/attack_hand(mob/living/A) //If either a human or 173 interact with the cage
+/obj/structure/scp173_cage/attack_hand(mob/living/L)
 	if(!LAZYLEN(contents))
 		return ..()
-	if(ishuman(A))
-		if(damage_state > damage_max)
-			visible_message(SPAN_WARNING("\The [src] is too damaged to operate!"))
-			return ..()
-		var/mob/living/carbon/human/H = A
-		visible_message(SPAN_WARNING("[H] attempts to open \the [src]."))
-		if(do_after(H, 5 SECONDS, src))
-			visible_message(SPAN_DANGER("[H] opens \the [src]!"))
-			ReleaseContents()
-	else if(isscp173(A)) //Neccesary 173 checks are done from 173's side, not the cage's
-		playsound(loc, 'sound/machines/airlock_creaking.ogg', 50, 1)
-		if(damage_state < damage_max)
-			visible_message(SPAN_WARNING("You hear the sound of metal [pick("groaning","shearing","tearing","bending")]!"))
-			damage_state += 1
-			updateIconandDesc()
-		else
-			visible_message(SPAN_DANGER("[current173] bends open \the [src]!"))
-			damage_state = damage_max + 1
-			ReleaseContents()
+	visible_message(SPAN_WARNING("[L] attempts to open \the [src]."))
+	if(do_after(L, 5 SECONDS, src))
+		visible_message(SPAN_DANGER("[L] opens \the [src]!"))
+		ReleaseContents()
 
-/obj/structure/scp173_cage/proc/updateIconandDesc() //Updates cage icon and description according to current damage state and contents
+/obj/structure/scp173_cage/relaymove(mob/living/scp_173/user, direction)
+	if(resist_cooldown > world.time)
+		return
+	resist_cooldown = world.time + 5 SECONDS
+	if(user.IsBeingWatched())
+		to_chat(user, SPAN_WARNING("Someone is looking at you!"))
+		return
+	if(!do_after(user, 1 SECONDS, src)) // Some moron suggested putting 173 in a conveyor loop.
+		return
+	if(user.IsBeingWatched())
+		to_chat(user, SPAN_WARNING("Someone is looking at you!"))
+		return
+	damage_state += 1
+	update_icon()
+	if(damage_state < damage_state_max)
+		visible_message(SPAN_WARNING("[user] damages \the [src]!"))
+		playsound(src, 'sound/effects/grillehit.ogg', 35, TRUE)
+		return
+	visible_message(SPAN_DANGER("[user] opens \the [src] from the inside!"))
+	ReleaseContents()
+
+/obj/structure/scp173_cage/examine(mob/user, distance, infix = "", suffix = "")
+	. = ..()
+	for(var/mob/M in contents)
+		to_chat(user, "[icon2html(M, user)] It has [M] inside of it!")
+	switch(damage_state)
+		if(1, 2)
+			to_chat(user, SPAN_NOTICE("It looks slightly damaged."))
+		if(3, 4)
+			to_chat(user, SPAN_WARNING("It is seriously damaged!"))
+		if(5 to INFINITY)
+			to_chat(user, SPAN_DANGER("It is completely broken!"))
+
+// Updates icon state and underlays
+/obj/structure/scp173_cage/update_icon()
 	underlays.Cut()
 
-	if((damage_state <= damage_max) && ((!LAZYLEN(contents)) || !current173))
+	if(!LAZYLEN(contents))
+		plane = initial(plane)
 		icon_state = "open"
-		desc = initial(desc)
-	else if(damage_state == 0)
+	else
+		plane = MOB_PLANE
 		icon_state = "closed"
-		desc = "A cage for containing SCP-173. It is currently holding [current173]."
-	else if(damage_state <= 1)
-		icon_state = "damage_1"
-		desc = "A cage for containing SCP-173. It is currently holding [current173]. It looks slightly damaged."
-	else if((damage_state >= Clamp((damage_max - 1), 2, INFINITY)) && (damage_state <= damage_max)) //Dont want the damage visuals getting fucky because damage_max was too low
-		icon_state = "damage_2"
-		desc = "A cage for containing SCP-173. It is currently holding [current173]. It looks fairly damaged."
-	else if(damage_state > damage_max) //Damage state is equal to damage max last stage before breaking, so this is neccesary
-		icon_state = "damage_3"
-		desc = "An empty cage for containing SCP-173. It appears broken."
 
-	if((LAZYLEN(contents)) && current173)
-		underlays += image(current173)
+	switch(damage_state)
+		if(1, 2)
+			icon_state = "damage_1"
+		if(3, 4)
+			icon_state = "damage_2"
+		if(5 to INFINITY)
+			icon_state = "damage_3"
 
+	for(var/mob/M in contents)
+		underlays += image(M)
 
 /obj/structure/scp173_cage/attackby(obj/item/I, mob/user) //Gotta be able to repair the cage
-	if(user.a_intent != I_HELP)
-		return 0
 	if(!isWelder(I))
-		return 0
-	if(LAZYLEN(contents) || current173)
+		return
+	if(LAZYLEN(contents))
 		to_chat(user, SPAN_WARNING("\The [src] must be empty to complete this task!"))
-		return 0
-	var/obj/item/weldingtool/WT = I
-	if(damage_state == 0)
+		return
+	if(damage_state <= 0)
 		to_chat(user, SPAN_NOTICE("\The [src] is not damaged."))
 		return
-	if(!WT.remove_fuel(0, user))
-		to_chat(user, SPAN_WARNING("\The [I] must be on to complete this task."))
+
+	var/obj/item/weldingtool/WT = I
+	if(!WT.isOn())
+		to_chat(user, SPAN_WARNING("\The [WT] must be on to complete this task."))
 		return
-	if(!src || !WT.isOn())
+	if(WT.get_fuel() < damage_state)
+		to_chat(user, SPAN_WARNING("You will need more fuel to repair [src]."))
 		return
-	playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-	if(do_after(user, 5 SECONDS, src)) //Time to repair depends on how damaged the cage is
-		visible_message(SPAN_NOTICE("\The [user] repairs a section of \the [src]"))
-		damage_state -= 1
-		updateIconandDesc()
-		if(damage_state == 0)
-			visible_message(SPAN_NOTICE("\The [user] repairs \the [src] fully!"))
-		return 1
-	return 0
+	playsound(src, 'sound/items/Welder2.ogg', 30, TRUE)
+	user.visible_message(SPAN_NOTICE("\The [user] starts repairing sections of \the [src]."))
+	if(!do_after(user, (4 SECONDS) + (damage_state SECONDS), src))
+		return FALSE
+	if(!WT.remove_fuel(damage_state, user))
+		return
+	user.visible_message(SPAN_NOTICE("\The [user] successfuly repairs a section of \the [src]."))
+	damage_state -= 1
+	update_icon()
+	if(damage_state <= 0)
+		visible_message(SPAN_NOTICE("\The [src] is completely repaired!"))
+	playsound(src.loc, 'sound/items/Welder.ogg', 30, 1)
+	return TRUE
 
 /obj/structure/scp173_cage/proc/ReleaseContents() //Releases cage contents
 	if(!LAZYLEN(contents))
 		return FALSE
-	if(damage_state <= damage_max) //Dont want the release sound to play if 173 breaks out
-		playsound(loc, 'sound/machines/bolts_up.ogg', 50, 1)
-	for(var/mob/living/scp_173/L in contents)
+	playsound(loc, 'sound/machines/bolts_up.ogg', 50, 1)
+	for(var/mob/living/L in contents)
 		L.forceMove(get_turf(src))
-		L?.is_caged = FALSE
-		L?.cage = null
-	current173 = null
-	plane = initial(plane)
-	updateIconandDesc()
+	update_icon()
 	return TRUE
 
-/obj/structure/scp173_cage/handle_atom_del(atom/deleting_atom)
-	if(deleting_atom == current173)
-		current173  = null
-		return ..()
-
 /obj/structure/scp173_cage/Destroy()
-	current173 = null
+	ReleaseContents()
 	return ..()
 
 /*

--- a/code/procs/hud.dm
+++ b/code/procs/hud.dm
@@ -36,7 +36,7 @@ the HUD updates properly! */
 	if(isscp173(M)) //Only 173 should have a blink HUD (Also this is neccesary for maintaing the blink HUD while caged)
 		var/mob/living/scp_173/S = M
 		var/datum/arranged_hud_process/P = arrange_hud_process(M, Alt, GLOB.scp173s)
-		for(var/mob/living/carbon/human/victim in dview(7, S.is_caged ? S.cage : P.Mob)) //If we're caged we must use the cage as our reference rather than 173. no_light is used as 173 can see in the dark
+		for(var/mob/living/carbon/human/victim in dview(7, istype(S.loc, /obj/structure/scp173_cage) ? S.loc : S))
 			if(victim.stat) //The unconscious cant blink, and therefore do not need to be added to the blink HUD
 				continue
 			P.Client.images += victim.hud_list[BLINK_HUD]


### PR DESCRIPTION
## About the Pull Request

Cleans up 173's code and makes life of 173 players ever so slightly more pleasant.

## Why It's Good For The Game

- A lot of cleanup/code improvements. Mostly just things I didn't like being replaced with something I consider to be more efficient/nice looking.
- Removed obsolete variables from both 173 and its cage.
- 173 will break its cage as before - via trying to move. It is still using the "new" behavior of damaging it.
- Repairing the cage contains proper checks and intended(?) do_after delay that depends on damage state.
- Added some sounds to 173 damaging the cage and repairing the cage.
- POSSIBLY fixed some issues with the cage that I didn't know of.

## Changelog

:cl:
fix: Fixed SCP-173 cage.
tweak: SCP-173 will now attempt to damage its cage upon trying to move, instead of clicking on it.
/:cl:
