### PR TITLE
"Who" verb shows who's in lobby to admins

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -15,6 +15,10 @@
 				Lines += entry
 				continue
 
+			if(isnewplayer(C.mob))
+				entry += " - <b>IN LOBBY</b>"
+				continue
+
 			entry += " - Playing as [C.mob.real_name]"
 			switch(C.mob.stat)
 				if(UNCONSCIOUS)


### PR DESCRIPTION
## About the Pull Request

From #vlggms/tegustation-bay12/pull/346

Instead of showing "Playing as  - DEAD", it will show "- IN LOBBY".

## Why It's Good For The Game

Less ambiguous and more pleasant to the eye.

## Changelog

:cl:
admin: "Who" verb will now properly clarify if the client is in lobby.
/:cl: