### PR TITLE
Fixes SSinput init "for" real

### DIFF
--- a/code/controllers/subsystems/input.dm
+++ b/code/controllers/subsystems/input.dm
@@ -28,9 +28,10 @@ SUBSYSTEM_DEF(input)
 // Badmins just wanna have fun d
 /datum/controller/subsystem/input/proc/refresh_client_macro_sets()
 	init_queue = GLOB.clients.Copy()
-	for(var/client/C in init_queue)
+	while(length(init_queue)) //for list loops keep local copy >:( ~Tsu
+		var/client/C = init_queue[1]
 		C.set_macros()
-	init_queue.Cut()
+		init_queue -= C
 
 /datum/controller/subsystem/input/fire()
 	for(var/client/C in GLOB.clients)


### PR DESCRIPTION
## About the Pull Request

It has `for` in name but removes `for` from init >:)

No local testing done, TMs needed.

## Changelog

:cl:
fix: Fixed movement keys not working on roundstart. Again.
/:cl:
