### PR TITLE
Fixes 2427-3 enraged check

### DIFF
--- a/code/modules/SCP/SCPs/SCP-2427-3.dm
+++ b/code/modules/SCP/SCPs/SCP-2427-3.dm
@@ -220,6 +220,8 @@ GLOBAL_LIST_EMPTY(scp2427_3s)
 
 /mob/living/simple_animal/hostile/scp_2427_3/proc/IsEnraged()
 	for(var/mob/living/L in dview(7, src))
+		if(L == src)
+			continue
 		if(L in impurity_list)
 			return !L.stat && L.ckey // Conscious and is/was player controlled
 		if(L.stat && istype(get_area(src), spawn_area)) // Hm yes, today I will ignore all the corpses around me to breach


### PR DESCRIPTION
## About the Pull Request

2427-3 would check for itself and thus, prevent it from breaking out. Very silly oversight fixed.

## Why It's Good For The Game

Fix.

## Changelog

:cl:
fix: SCP 2427-3 can break out once again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
