### PR TITLE
Change min players for malf AIC to 20

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -3,7 +3,7 @@
 	round_description = "The AI is behaving abnormally and must be stopped."
 	extended_round_description = "The AI will attempt to hack the APCs in order to gain as much control as possible."
 	config_tag = "malfunction"
-	required_players = 2
+	required_players = 20
 	required_enemies = 1
 	end_on_antag_death = FALSE
 	auto_recall_shuttle = FALSE


### PR DESCRIPTION
## About the Pull Request

For some reason, this was on required_players = 2.
A malf AIC that can remotely blow people up and nuke the site after 30 minutes, with a fully armored 20 blast doors chamber, and the ability to place forcefields to prevent people from getting into its chamber in the first place by being really annoying... does not belong on 10 pop. It is quite literally nigh impossible to fight, and sometimes impossible to detect.

## Why It's Good For The Game

muh murderbone aic on 5 player

## Changelog

:cl:
balance: Changed Malfunctioning AIC gamemode from 2 minimum players to 20
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
