### PR TITLE
Mapping checkpoint and maint tunnel + JohnPizzas's and Bjorn's SOP Paperwork and Manual Changes V2

### DIFF
--- a/maps/site53/items/manuals.dm
+++ b/maps/site53/items/manuals.dm
@@ -1,48 +1,3 @@
-/obj/item/book/manual/solgov_law
-	name = "Sol Central Government Law"
-	desc = "A brief overview of SolGov Law."
-	icon_state = "bookSolGovLaw"
-	author = "The Sol Central Government"
-	title = "Sol Central Government Law"
-
-/obj/item/book/manual/solgov_law/Initialize()
-	. = ..()
-	dat = {"
-
-		<html><head>
-		</head>
-
-		<body>
-		<iframe width='100%' height='97%' src="[config.wikiurl]Sol_Central_Government_Law&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-		</body>
-
-		</html>
-
-		"}
-
-
-/obj/item/book/manual/military_law
-	name = "The Sol Code of Military Justice"
-	desc = "A brief overview of military law."
-	icon_state = "bookSolGovLaw"
-	author = "The Sol Central Government"
-	title = "The Sol Code of Military Justice"
-
-/obj/item/book/manual/military_law/Initialize()
-	. = ..()
-	dat = {"
-
-		<html><head>
-		</head>
-
-		<body>
-		<iframe width='100%' height='97%' src="[config.wikiurl]Sol_Gov_Military_Justice&printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
-		</body>
-
-		</html>
-
-		"}
-
 /obj/item/book/manual/scp/fra
 	name = "Foundation Regulations"
 	desc = "A book that has a comprehensive list of Foundation Regulations."
@@ -177,106 +132,6 @@
 
 /obj/item/folder/nt/rd
 
-/obj/item/folder/envelope/blanks
-	desc = "A thick envelope. The Nanotrasen logo is stamped in the corner, along with 'CONFIDENTIAL'."
-
-/obj/item/folder/envelope/blanks/Initialize()
-	. = ..()
-	new/obj/item/paper/blanks(src)
-
-/obj/item/paper/blanks
-	name = "RE: Regarding testing supplies"
-	info = {"
-	<tt><center><b><font color='red'>CONFIDENTIAL: UPPER MANAGEMENT ONLY</font></b>
-	<h3>NANOTRASEN RESEARCH DIVISION</h3>
-	<img src = ntlogo.png>
-	</center>
-	<b>FROM:</b> Hieronimus Blackstone, Overseer of Torch Cooperation Project<br>
-	<b>TO:</b> Research Director of SEV Torch branch<br>
-	<b>CC:</b> Liason with SCG services aboard SEV Torch<br>
-	<b>SUBJECT:</b> RE: Testing Materials<br>
-	<hr>
-	We have reviewed your request, and would like to make an addition to the list of needed materials.<br>
-	As we hold very high hopes for this branch, it would be only right to provide our scientists with the most accurate testing environment. And by that we mean the living human subjects. Our Ethics Review Board suggested a workaround for that pesky 'consent' requierment.<br>
-	In the Research Wing you should find a small section labeled 'Aux Custodial Supplies'. Inside we have provided several mind-blank vatgrown clones. Our Law Special Response Team so far had not found SCG legislation that explicitly forbids their use in research.<br>
-	They come in self-contained life support bags, with additional measures to make them easier to use for, let's say, more sensitive personnel. As our preliminary study showed, 75% more subjects were more willing to harm a (consenting) intern if their face was fully hidden.<br>
-	We are expecting great results from this program. Do not disappoint us.<br>
-	<i>H.B.</i></tt>
-	"}
-
-/obj/item/folder/envelope/captain
-	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - TORCH UMBRA'."
-
-/obj/item/folder/envelope/captain/Initialize()
-	. = ..()
-/*	var/obj/effect/overmap/torch = map_sectors["[z]"]
-	var/memo = {"
-	<tt><center><b><font color='red'>SECRET - CODE WORDS: TORCH</font></b>
-	<h3>SOL CENTRAL GOVERNMENT EXPEDITIONARY COMMAND</h3>
-	<img src = sollogo.png>
-	</center>
-	<b>FROM:</b> ADM William Lau<br>
-	<b>TO:</b> Commanding Officer of SEV Torch<br>
-	<b>SUBJECT:</b> Standing Orders<br>
-	<hr>
-	Captain.<br>
-	Your orders are to visit the following star systems. Keep in mind that your supplies are limited; ration exploration time accordingly.
-	<li>[generate_system_name()]</li>
-	<li>[generate_system_name()]</li>
-	<li>[generate_system_name()]</li>
-	<li>[generate_system_name()]</li>
-	<li>[generate_system_name()]</li>
-	<li>[GLOB.using_map.system_name]</li>
-	<li>[generate_system_name()]</li>
-	<li>[generate_system_name()]</li>
-	<li>[generate_system_name()]</li>
-	<br>
-	Priority targets are artifacts of uncontacted alien species and signal sources of unknown origin.<br>
-	None of these systems are claimed by any entity recognized by the SCG, so you have full salvage rights on any derelicts discovered.<br>
-	Investigate and mark any prospective colony worlds as per usual procedures.<br>
-	There is no SCG presence in that area. In case of distress calls, you will be the only vessel available; do not ignore them. We cannot afford any more PR backlash.<br>
-	The current docking code is: [torch.docking_codes]<br>
-	Report all findings via bluespace comm buoys during inter-system jumps.<br>
-
-	<i>ADM Lau.</i></tt>
-	<i>This paper has been stamped with the stamp of SCG Expeditionary Command.</i>
-	"}*/
-//	new/obj/item/paper(src, memo, "Standing Orders")
-
-	new/obj/item/paper/umbra(src)
-
-/obj/item/folder/envelope/rep
-	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - UMBRA'."
-
-/obj/item/folder/envelope/rep/Initialize()
-	. = ..()
-	new/obj/item/paper/umbra(src)
-
-/obj/item/paper/umbra
-	name = "UMBRA Protocol"
-	info = {"
-	<tt><center><b><font color='red'>TOP SECRET - CODE WORDS: TORCH UMBRA</font></b>
-	<h3>OFFICE OF THE SECRETARY GENERAL OF SOL CENTRAL GOVERNMENT</h3>
-	<img src = sollogo.png>
-	</center>
-	<b>FROM:</b> Johnathan Smitherson, Special Aide of the Secretary General<br>
-	<b>TO:</b> Commanding Officer of the SEV Torch<br>
-	<b>CC:</b> Special Representative aboard the SEV Torch<br>
-	<b>SUBJECT:</b> UMBRA protocol<br>
-	<hr>
-	This is a small addendum to the usual operating procedures. Unlike the rest of SOP, this is not left to the Commanding Officer's discretion and is mandatory. As unconventional as this is, we felt it is essential for smooth operation of this mission.<br>
-	Procedure can be initiated only by transmission from SCG Expeditionary Command via secure channel. The sender may not introduce themselves, but you shouldn't have trouble confirming the transmission source, I believe.<br>
-	The signal to initiate the procedure are codewords 'GOOD NIGHT WORLD' used in this order as one phrase. You do not need to send acknowledgement.
-	<li>Information about this expedition's findings is to be treated as secret and vital to SCG's national security, and is protected under codeword UMBRA. Only SCG government employees, NT personnel and Skrell citizens aboard the SEV Torch are allowed access to this information on a need-to-know basis.</li>
-	<li>The secrecy of this information is to be applied retroactively. Any non-cleared personnel who were exposed to such information are to be secured and transferred to DIA on arrival at home port.</li>
-	<li>Any devices capable of transmitting data on interstellar range are to be confiscated from private possession.</li>
-	<li>Disregard any systems remaining in your flight plan and set course for Sol, Neptune orbit. You will be contacted upon your arrival. Do not make stops in ports on the way unless absolutely necessary.</li>
-	<br>
-	While drastic, I assure you this is a simple precaution, lest any issues. Just keep the option open, and carry on with your normal duties.
-	<i>Regards, John.</i></tt>
-	<i>This paper has been stamped with the stamp of Office of the General Secretary of SCG.</i>
-	"}
-
 /obj/item/paper/reactor
 	name = "Reactor Startup Procedure"
 	info = {"
@@ -291,6 +146,29 @@
 	Once the power output is 250kW or higher, return to the R-UST room and turn off the PACMAN-generator. It may explode if you leave it running for too long.<br>
 	You can now adjust the gyrotron power to a lower setting, such as fire delay 3, power output 3. Check that the instability is staying low after adjusting the gyrotron.
 	"}
+
+/obj/item/paper/sec_ctp
+	name = "Checkpoint Testing Procedures"
+	info = {"<center><h1>Checkpoint Testing Procedures</h1></center><br>
+	<center><b><font size="1">Site 53</font></b></center><br>
+	<center><img src = sec.png></center><br>
+	<center><b>Secure. Contain. Protect.</b></center><br>
+	<hr>
+	STEP ONE: Check what the current site-wise security level is:<br>
+	<ul><li>CODE GREEN: Testing is to be conducted as normal.<br>
+	<li>CODE YELLOW: Testing can be refused at the discretion of the checkpoint officer.<br>
+	<li>CODE ORANGE and RED: No tests are to be conducted. Currently active tests may be ended at the discretion of the Zone Commander and above.<br>
+	<li>CODE BLACK and PITCHBLACK: No tests are to be conducted. All currently active tests are to be ended as soon as possible.</ul>
+	STEP TWO: Check the legitimacy of given paperwork and credentials. If paper is incorrect or forged, detain all involved personnel and report to your zone's Sargeant.<br>
+	Paperwork must clearly state the SCP(s) and materials involved in the test, the approving personnel, and the testing plan.<br>
+	Testing on a Safe or Euclid SCP requires approval from the Research Director, and testing on a Keter SCP requires approval from the Site Director.<br>
+	STEP THREE: Notify the Site Director of the test. The Site Director has authority to veto all tests.<br>
+	If the test is not vetoed, thoroughly search all personnel and material transferring through the checkpoint.<br>
+	Copy all testing-related paperwork before allowing personnel through.<br>
+	STEP FOUR: Ensure they are escorted throughout the zone, with at least one officer overseeing the test.<br>
+	When returning, all personnel and material must be searched again before transferring through the checkpoint, and testing records must be made.<br>
+	Certain anomalies may have Special Containment Procedures that may impact testing protocol. You are allowed to alter the procedure to maintain these containment procedures.
+	<hr>"}
 
 /////////////
 //SCP BOOKS//

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -6302,8 +6302,12 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp8containment)
 "oN" = (
-/obj/effect/paint_stripe/white,
-/turf/simulated/wall/titanium,
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
 /area/space)
 "oO" = (
 /obj/effect/catwalk_plated/dark,
@@ -8157,18 +8161,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
 "to" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable{
-	dir = 1
-	},
-/obj/machinery/power/apc/hyper{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/site53/engineering/maintenance/llczmaint)
+/obj/effect/paint_stripe/white,
+/turf/simulated/wall/prepainted,
+/area/space)
 "tp" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
@@ -9585,6 +9580,10 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentline)
+"wF" = (
+/obj/effect/paint_stripe/white,
+/turf/simulated/wall/prepainted,
+/area/site53/engineering/maintenance/llczmaint)
 "wG" = (
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
@@ -10228,6 +10227,13 @@
 /obj/structure/closet,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/kitchenbotanybubble)
+"yj" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/space)
 "yk" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/door/airlock/multi_tile/glass/security{
@@ -10496,6 +10502,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp1102room)
+"zh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/space)
 "zi" = (
 /obj/machinery/camera/network/lcz{
 	dir = 1
@@ -16987,6 +17000,17 @@
 	},
 /turf/simulated/floor,
 /area/site53/lhcz/scp049containment)
+"QN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/engineering/maintenance/llczmaint)
 "QO" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/railing/mapped,
@@ -18583,6 +18607,19 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp8containment)
+"Vq" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "Vs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -46014,10 +46051,10 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
+to
+to
+to
+to
 Eh
 gq
 pC
@@ -46271,10 +46308,10 @@ gq
 gq
 gq
 gq
-gq
-gq
+to
+Vq
 oN
-aN
+wF
 bV
 aN
 aN
@@ -46528,14 +46565,14 @@ gq
 gq
 gq
 gq
-gq
-gq
-oN
 to
+yj
+zh
+ri
 ab
 cj
 ri
-ri
+QN
 ri
 ri
 Uz

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -6308,7 +6308,7 @@
 /obj/structure/cable,
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
-/area/space)
+/area/site53/engineering/maintenance/llczmaint)
 "oO" = (
 /obj/effect/catwalk_plated/dark,
 /obj/effect/floor_decal/industrial/warning,
@@ -8160,10 +8160,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
-"to" = (
-/obj/effect/paint_stripe/white,
-/turf/simulated/wall/prepainted,
-/area/space)
 "tp" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
@@ -10233,7 +10229,7 @@
 	},
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
-/area/space)
+/area/site53/engineering/maintenance/llczmaint)
 "yk" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/door/airlock/multi_tile/glass/security{
@@ -10502,13 +10498,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/scp1102room)
-"zh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
-/area/space)
 "zi" = (
 /obj/machinery/camera/network/lcz{
 	dir = 1
@@ -18619,7 +18608,7 @@
 	icon_state = "bulb1"
 	},
 /turf/simulated/floor/plating,
-/area/space)
+/area/site53/engineering/maintenance/llczmaint)
 "Vs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -46051,10 +46040,10 @@ gq
 gq
 gq
 gq
-to
-to
-to
-to
+wF
+wF
+wF
+wF
 Eh
 gq
 pC
@@ -46308,7 +46297,7 @@ gq
 gq
 gq
 gq
-to
+wF
 Vq
 oN
 wF
@@ -46565,9 +46554,9 @@ gq
 gq
 gq
 gq
-to
+wF
 yj
-zh
+ri
 ri
 ab
 cj

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -8,30 +8,25 @@
 /turf/simulated/floor/carpet/purple,
 /area/site53/lowertram/archive)
 "ab" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/llczmaint)
 "ac" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/llczmaint)
@@ -100,6 +95,7 @@
 /area/site53/lowertram/archive)
 "am" = (
 /obj/structure/ladder/up,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/llczmaint)
 "an" = (
@@ -203,7 +199,7 @@
 /obj/machinery/power/apc/hyper{
 	dir = 8
 	},
-/obj/structure/cable/green,
+/obj/structure/cable,
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertram/archive)
 "aB" = (
@@ -360,11 +356,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertram/archive)
 "aU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -515,11 +506,6 @@
 /obj/machinery/door/airlock/glass/research{
 	name = "Hallway"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
@@ -641,11 +627,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/hallways)
 "bz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -858,6 +839,13 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/maintenance)
+"bV" = (
+/obj/effect/paint_stripe/white,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/site53/engineering/maintenance/llczmaint)
 "bW" = (
 /obj/machinery/camera/network/lcz{
 	dir = 8
@@ -883,11 +871,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/entrance_checkpoint)
 "ca" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -947,25 +930,23 @@
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "ci" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/paint_stripe/gray,
 /obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
+/turf/simulated/wall/prepainted,
 /area/site53/llcz/hallways)
 "cj" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/llczmaint)
@@ -981,13 +962,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
 "cl" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertram/archive)
@@ -1143,17 +1122,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/mining/miningops)
-"cE" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/catwalk_plated/white,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/site53/llcz/hallways)
 "cF" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1186,11 +1154,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "cJ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -1301,11 +1264,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip)
 "cW" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1596,11 +1554,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost/storage)
 "dx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1726,11 +1679,6 @@
 /obj/machinery/door/airlock/glass/research{
 	name = "Hallway"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1788,11 +1736,6 @@
 /turf/simulated/floor,
 /area/site53/llcz/dclass/primaryhallway)
 "dR" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -2146,11 +2089,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/hallways)
 "eL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2425,15 +2363,6 @@
 	},
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/checkcryo)
-"fn" = (
-/obj/effect/paint_stripe/white,
-/obj/machinery/button/blast_door{
-	id_tag = "Lower LCZ Maint Access";
-	name = "Lower LCZ Maint Access";
-	req_access = list("ACCESS_ENGINEERING_LEVEL1","ACCESS_ADMIN_LEVEL2")
-	},
-/turf/simulated/wall/titanium,
-/area/site53/engineering/maintenance/llczmaint)
 "fo" = (
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/titanium,
@@ -2744,11 +2673,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/recreationhallway)
 "gb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/glass/research{
@@ -2981,9 +2905,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/kitchenbotanybubble)
 "gH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -3202,18 +3124,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
 "ho" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/effect/catwalk_plated/white,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/site53/engineering/maintenance/llczmaint)
+/turf/unsimulated/mineral,
+/area/space)
 "hp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
@@ -3238,18 +3154,6 @@
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/llcz/mining/miningops)
-"hu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/engineering/maintenance/llczmaint)
 "hv" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -3398,11 +3302,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/hallways)
 "hQ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/white,
@@ -4537,22 +4436,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/checkpoint)
-"kq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/blast/regular{
-	id_tag = "LLCZ Maintenance (NO ENTRY)";
-	name = "LLCZ Maintenance (NO ENTRY)"
-	},
-/turf/simulated/floor,
-/area/site53/engineering/maintenance/llczmaint)
 "kr" = (
 /obj/machinery/door/airlock/glass/civilian{
 	name = "Library"
@@ -4575,21 +4458,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500)
 "kt" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/hatch{
-	name = "LLCZ Maintenance"
+	name = "Maintenance"
 	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/blast/regular{
-	id_tag = "Lower LCZ Maint Access";
-	name = "Lower LCZ Maint Access"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/site53/lowertram/archive)
@@ -4720,19 +4599,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/canteen)
 "kH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/blast/regular{
-	id_tag = "LLCZ Maintenance (NO ENTRY)";
-	name = "LLCZ Maintenance (NO ENTRY)"
-	},
-/turf/simulated/floor,
-/area/site53/engineering/maintenance/llczmaint)
+/turf/unsimulated/mineral,
+/area/space)
 "kJ" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/monotile/white,
@@ -4911,22 +4780,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/canteen)
-"lg" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/blast/regular{
-	id_tag = "Lower LCZ Maint Access";
-	name = "Lower LCZ Maint Access"
-	},
-/turf/simulated/floor,
-/area/site53/engineering/maintenance/llczmaint)
 "lh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5127,15 +4980,6 @@
 	},
 /turf/simulated/floor/lino,
 /area/site53/llcz/dclass/canteen)
-"lI" = (
-/obj/machinery/button/blast_door{
-	id_tag = "LLCZ Maintenance (NO ENTRY)";
-	name = "LLCZ Maintenance (NO ENTRY)";
-	pixel_y = 32;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/hallways)
 "lJ" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
@@ -6457,6 +6301,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp8containment)
+"oN" = (
+/obj/effect/paint_stripe/white,
+/turf/simulated/wall/titanium,
+/area/space)
 "oO" = (
 /obj/effect/catwalk_plated/dark,
 /obj/effect/floor_decal/industrial/warning,
@@ -7529,19 +7377,17 @@
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "ri" = (
-/obj/machinery/door/blast/regular{
-	id_tag = "Lower LCZ Maint Access";
-	name = "Lower LCZ Maint Access"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/llczmaint)
 "rj" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -7571,7 +7417,7 @@
 /turf/simulated/floor,
 /area/site53/lhcz/scp049containment)
 "rm" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -7599,7 +7445,7 @@
 	id_tag = "archive";
 	name = "Archive"
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -7641,9 +7487,7 @@
 /turf/simulated/floor/carpet/purple,
 /area/site53/lowertram/archive)
 "ru" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -7852,24 +7696,6 @@
 /obj/item/storage/pill_bottle/amnesticsa,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
-"rY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/white,
-/obj/machinery/button/blast_door{
-	id_tag = "LLCZ Maintenance (NO ENTRY)";
-	name = "LLCZ Maintenance (NO ENTRY)";
-	pixel_y = 32;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/turf/simulated/floor,
-/area/site53/engineering/maintenance/llczmaint)
 "sa" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8330,6 +8156,19 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
+"to" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable{
+	dir = 1
+	},
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/engineering/maintenance/llczmaint)
 "tp" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
@@ -9189,11 +9028,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -10153,13 +9987,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/luxuryhall)
-"xz" = (
-/obj/effect/paint_stripe/white,
-/obj/structure/sign/directions/lcz{
-	dir = 8
-	},
-/turf/simulated/wall/titanium,
-/area/site53/lowertram/archive)
 "xA" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/shutters/open{
@@ -12522,22 +12349,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 18
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/engineering/maintenance/llczmaint)
+/turf/unsimulated/mineral,
+/area/space)
 "Ei" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/button/flasher{
@@ -14484,15 +14297,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uhcz/scp106parts)
-"Jt" = (
-/obj/effect/paint_stripe/white,
-/obj/machinery/button/blast_door{
-	id_tag = "Lower LCZ Maint Access";
-	name = "Lower LCZ Maint Access";
-	req_access = list("ACCESS_ENGINEERING_LEVEL1","ACCESS_ADMIN_LEVEL2")
-	},
-/turf/simulated/wall/prepainted,
-/area/site53/lowertram/archive)
 "Ju" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -18470,6 +18274,13 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
 "Uz" = (
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/llczmaint)
 "UB" = (
@@ -34658,7 +34469,7 @@ ca
 hQ
 gb
 hQ
-cE
+hQ
 vt
 cd
 cd
@@ -36183,11 +35994,11 @@ gq
 gq
 gq
 gq
-aN
-aN
-aN
+gq
+gq
+gq
 cQ
-lI
+cc
 aU
 cc
 cQ
@@ -36440,11 +36251,11 @@ gq
 gq
 gq
 gq
-aN
+gq
 ho
 kH
 ci
-ci
+sv
 eL
 cc
 cQ
@@ -36697,9 +36508,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 cQ
 cc
 Tl
@@ -36954,9 +36765,9 @@ gq
 gq
 gq
 gq
-aN
-kq
-aN
+gq
+Eh
+gq
 cQ
 cc
 cw
@@ -37211,9 +37022,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 cQ
 cQ
 cQ
@@ -37468,9 +37279,9 @@ gq
 gq
 gq
 gq
-aN
+gq
 Eh
-aN
+gq
 pC
 pC
 pC
@@ -37725,9 +37536,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 pC
@@ -37982,9 +37793,9 @@ gq
 gq
 gq
 gq
-aN
-kq
-aN
+gq
+Eh
+gq
 pC
 Fh
 pC
@@ -38239,9 +38050,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 pC
@@ -38496,9 +38307,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 pC
@@ -38753,9 +38564,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 pC
@@ -39010,9 +38821,9 @@ gq
 gq
 gq
 gq
-aN
-kq
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -39267,9 +39078,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -39524,9 +39335,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 Fh
 ua
@@ -39781,9 +39592,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -40038,9 +39849,9 @@ gq
 gq
 gq
 gq
-aN
-kq
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -40295,9 +40106,9 @@ gq
 gq
 gq
 gq
-aN
-rY
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -40552,9 +40363,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -40809,9 +40620,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -41066,9 +40877,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -41323,9 +41134,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -41580,9 +41391,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -41837,9 +41648,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -42094,9 +41905,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -42351,9 +42162,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -42608,9 +42419,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -42865,9 +42676,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -43122,9 +42933,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -43379,9 +43190,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -43636,9 +43447,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -43893,9 +43704,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -44150,9 +43961,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -44407,9 +44218,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -44664,9 +44475,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 Fh
 ua
@@ -44921,9 +44732,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -45178,9 +44989,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -45435,9 +45246,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -45692,9 +45503,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 Fh
@@ -45949,9 +45760,9 @@ gq
 gq
 gq
 gq
-aN
-hu
-aN
+gq
+Eh
+gq
 pC
 ua
 ua
@@ -46206,9 +46017,9 @@ gq
 gq
 gq
 gq
-fn
-hu
-aN
+gq
+Eh
+gq
 pC
 pC
 pC
@@ -46462,9 +46273,9 @@ gq
 gq
 gq
 gq
-gq
+oN
 aN
-lg
+bV
 aN
 aN
 aN
@@ -46719,14 +46530,14 @@ gq
 gq
 gq
 gq
-gq
-aN
+oN
+to
 ab
 cj
 ri
-Uz
-Uz
-Uz
+ri
+ri
+ri
 Uz
 am
 aN
@@ -47235,10 +47046,10 @@ aw
 ax
 aL
 aW
-xz
+Nt
 kt
 Nt
-Jt
+aW
 qB
 iz
 aW

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -99,10 +99,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
 "aao" = (
-/obj/effect/floor_decal/corner/black/full,
-/obj/effect/floor_decal/corner/black/full,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "aap" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -110,6 +114,11 @@
 	},
 /obj/machinery/door/airlock/glass/security{
 	name = "Red Line HCZ"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
@@ -172,10 +181,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/sleeproom)
 "aaA" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "aaB" = (
 /obj/structure/sign/warning/engineering_access,
 /obj/effect/paint_stripe/yellow,
@@ -242,41 +255,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/sleeproom)
 "aaH" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/pen,
-/obj/machinery/camera/network/lcz,
-/obj/item/stamp/cmo{
-	name = "LCZ Entry Checkpoint Stamp"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
-"aaI" = (
+/obj/structure/closet/secure_closet/guard/hcz,
 /obj/machinery/light,
-/obj/machinery/power/apc/hyper{
-	pixel_y = -25
-	},
-/obj/structure/cable/green,
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "UHCZ Checkpoint Gate 2";
-	name = "UHCZ Checkpoint Gate 2";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
+"aaI" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/reinforced,
+/area/site53/uhcz/scp106containment)
 "aaJ" = (
 /obj/structure/table/standard,
-/obj/item/device/megaphone,
-/obj/item/boombox,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
 "aaL" = (
 /obj/effect/paint_stripe/red,
 /obj/structure/sign/SecureArealv1mtf,
@@ -639,9 +629,9 @@
 /area/site53/surface/explorers/surrounding)
 "abV" = (
 /obj/effect/floor_decal/corner/black/full,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/closet,
+/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
+/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "abW" = (
@@ -735,22 +725,35 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp131)
 "acp" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "HCZ Security Center";
+	send_access = list(203)
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "acq" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
 "acs" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/unsimulated/mineral,
+/area/site53/llcz/entrance_checkpoint)
 "acu" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/light{
@@ -813,11 +816,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
@@ -958,6 +956,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "adg" = (
@@ -1155,10 +1154,23 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/lowertrams/hczmaint)
 "adP" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/floor_decal/corner/brown/mono,
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
+/area/site53/uhcz/securitypost)
 "adU" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
@@ -1252,10 +1264,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/blast/regular{
-	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
-	name = "UHCZ Secure Maintenance Tunnel Lockdown"
-	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "ael" = (
@@ -1482,18 +1491,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
 "afl" = (
-/obj/machinery/power/apc/hyper{
+/obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/camera/network/hcz{
-	name = "HCZ Guard Office"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "afm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1724,10 +1726,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular{
-	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
-	name = "UHCZ Secure Maintenance Tunnel Lockdown"
-	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "afV" = (
@@ -1836,18 +1835,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/unsimulated/mineral,
 /area/site53/ulcz/maintenance)
 "agi" = (
 /obj/structure/cable/green{
@@ -1889,42 +1877,16 @@
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
 "agm" = (
+/obj/effect/paint_stripe/gray,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/wall/r_wall/prepainted,
 /area/site53/ulcz/maintenance)
 "agn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/obj/effect/floor_decal/corner/brown/mono,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "agp" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1993,26 +1955,15 @@
 /turf/simulated/floor/reinforced,
 /area/site53/reswing/robotics)
 "agy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/light/small{
+/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/light/small/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/hygiene/toilet{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "agz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -2023,14 +1974,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "agA" = (
 /turf/unsimulated/mask,
 /area/site53/uhcz/scp106observ)
@@ -2122,14 +2067,7 @@
 /area/site53/reswing/robotics)
 "agQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/unsimulated/mineral,
 /area/site53/ulcz/maintenance)
 "agR" = (
 /obj/structure/cable/green{
@@ -2138,7 +2076,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "agT" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -2210,7 +2148,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahe" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled/monotile,
@@ -2259,7 +2197,7 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "aho" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2353,7 +2291,7 @@
 	RCon_tag = "Upper Light Containment Bypass"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -2366,10 +2304,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahy" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2379,8 +2315,11 @@
 /obj/machinery/power/sensor{
 	name_tag = "#LIGHT CONTAINMENT ZONE SENSOR#"
 	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -2418,8 +2357,12 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -2442,14 +2385,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2477,14 +2414,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahM" = (
 /obj/machinery/door/airlock/hatch{
 	id_tag = "escape";
@@ -2566,20 +2497,17 @@
 	name = "ULCZ Maintenance";
 	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "ahX" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
@@ -2619,16 +2547,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
 "aig" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/lowertrams/brownline)
 "aih" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Research Wing";
@@ -2700,24 +2621,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	begins_closed = 1;
-	icon_state = "pdoor0";
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/unsimulated/mineral,
 /area/site53/ulcz/maintenance)
 "ais" = (
 /turf/simulated/floor/plating,
@@ -2788,17 +2692,11 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "aiD" = (
 /obj/structure/cable{
 	d1 = 32;
@@ -2815,7 +2713,7 @@
 	},
 /obj/structure/lattice,
 /turf/simulated/open,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "aiF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5148,11 +5046,39 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/auxstorage)
 "aow" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/table/standard,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
-/turf/simulated/floor/reinforced,
-/area/site53/lowertrams/escape)
+/obj/effect/catwalk_plated/dark,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small/red{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "aox" = (
 /obj/machinery/light{
 	dir = 1
@@ -9693,8 +9619,8 @@
 /turf/simulated/floor/plating,
 /area/site53/engineering/primaryhallway)
 "azx" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "azz" = (
 /turf/simulated/floor/tiled/monotile,
@@ -10704,39 +10630,18 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/power/apc{
-	dir = 4
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "aBW" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/uhcz/scp106maintup)
 "aBX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/bed/chair/padded/black{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/hatch/maintenance{
-	name = "Heavy Containment Maintenance";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "UHCZ Lockdown";
-	name = "UHCZ Lockdown"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "aBZ" = (
 /turf/simulated/floor/tiled/monotile,
@@ -10747,15 +10652,13 @@
 /turf/simulated/floor/plating,
 /area/site53/ulcz/scp173)
 "aCb" = (
-/obj/machinery/door/airlock/glass/research{
-	name = "Brown Line"
-	},
+/obj/effect/catwalk_plated/dark,
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
+	id_tag = "ULCZ Exit Point";
+	name = "ULCZ Exit Point"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "aCc" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -10811,17 +10714,17 @@
 /area/site53/science/seniorresearcherb)
 "aCm" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "aCn" = (
@@ -10874,6 +10777,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "aCu" = (
@@ -10887,6 +10791,7 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "aCv" = (
@@ -10952,6 +10857,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "aCD" = (
@@ -10979,18 +10885,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
 "aCE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/glass/security{
+	name = "Corridor";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/blast/regular{
-	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
-	name = "UHCZ Secure Maintenance Tunnel Lockdown"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/site53/lowertrams/hczmaint/east)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lhcz/hczguardgear)
 "aCF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11112,6 +11017,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "aCP" = (
@@ -11384,14 +11290,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp895)
-"aDz" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/hallways)
 "aDA" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -11406,17 +11304,37 @@
 	dir = 8;
 	network = list("Heavy Containment Zone Network")
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "aDB" = (
-/obj/structure/bed/chair/padded/black,
-/obj/effect/floor_decal/corner/black/full,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Maint Access";
+	name = "UHCZ Maint Access"
+	},
+/turf/simulated/floor,
+/area/site53/lowertrams/hczmaint/south)
 "aDD" = (
-/obj/effect/floor_decal/corner/black/full,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Western Lockdown";
+	name = "UHCZ Western Lockdown"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "aDF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -11424,13 +11342,29 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp895)
 "aDG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/hallways)
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "aDH" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
@@ -11449,8 +11383,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aDK" = (
-/obj/machinery/photocopier,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "aDL" = (
 /obj/structure/flora/ausbushes/pointybush,
@@ -11462,11 +11399,37 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/logistics/logistics)
 "aDO" = (
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/item/stamp/cmo{
+	name = "LCZ Entry Checkpoint Stamp"
+	},
+/obj/machinery/button/flasher{
+	id_tag = "ULCZ Checkpoint Flash";
+	pixel_y = -32;
+	name = "ULCZ Checkpoint Flash"
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Central Window";
+	name = "ULCZ Checkpoint Central Window"
+	},
+/obj/item/paper/sec_ctp,
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "aDR" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aDS" = (
 /obj/turbolift_map_holder/logistics{
@@ -11609,12 +11572,12 @@
 /turf/simulated/open,
 /area/site53/uhcz/scp106maintup)
 "aEl" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/security{
+	name = "Termination";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "aEm" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -11633,9 +11596,22 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp895)
 "aEq" = (
-/obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id_tag = "ULCZ Checkpoint Flash";
+	name = "ULCZ Checkpoint Flash"
+	},
+/obj/machinery/camera/network/lcz{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "aEr" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4;
@@ -11690,24 +11666,23 @@
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "aEA" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/llcz/entrance_checkpoint)
 "aEC" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "aEE" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
-"aEF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/llcz/entrance_checkpoint)
+"aEF" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "aEH" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/door/airlock/security{
@@ -11716,9 +11691,8 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lhcz/hczguardgear)
 "aEK" = (
-/obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/scp106containment)
 "aEL" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11734,15 +11708,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "aEM" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/obj/machinery/door/airlock/glass/security{
+	name = "HCZ Checkpoint Western Office";
+	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Checkpoint Access Door";
+	name = "UHCZ Eastern Checkpoint Access Door"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "aEO" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -11757,6 +11737,11 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -12004,13 +11989,12 @@
 /turf/simulated/wall/titanium,
 /area/site53/uhcz/scp895)
 "aFD" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/table/standard,
+/obj/machinery/photocopier{
+	pixel_y = 3
 	},
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aFE" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
@@ -12036,32 +12020,26 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
 "aFS" = (
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "UHCZ Lockdown";
-	name = "UHCZ Lockdown"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "aFT" = (
-/obj/machinery/vending/cola,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/turf/unsimulated/mineral,
+/area/site53/uhcz/hallways)
 "aFU" = (
-/obj/structure/table/reinforced,
-/obj/item/deck/cards,
-/obj/effect/floor_decal/corner/black/full,
-/obj/machinery/light/small/red{
+/obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "aFX" = (
 /obj/machinery/cooker/cereal,
 /obj/structure/table/standard,
@@ -12210,11 +12188,22 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aGA" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ Checkpoint Lockdown Upper";
+	name = "ULCZ Checkpoint Lockdown Upper";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ Checkpoint Lockdown Lower";
+	name = "ULCZ Checkpoint Lockdown Lower";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
+/area/site53/llcz/entrance_checkpoint)
 "aGB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -12266,13 +12255,14 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "aGZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Lockdown Upper";
+	name = "ULCZ Checkpoint Lockdown Upper"
 	},
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "aHb" = (
 /obj/machinery/power/apc{
 	dir = 1
@@ -12489,12 +12479,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHy" = (
@@ -14048,9 +14036,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
 "aMd" = (
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/prepainted,
-/area/site53/ulcz/scp173)
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "aMe" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14077,10 +14065,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
 "aMi" = (
-/obj/machinery/light,
-/obj/structure/coatrack,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/office)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera/network/hcz{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "aMj" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -14186,21 +14178,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	pixel_y = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "aMB" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
@@ -14219,9 +14198,12 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/ulcz/scp999)
 "aMH" = (
-/obj/machinery/computer/guestpass,
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aMI" = (
 /obj/machinery/door/airlock/research{
@@ -14296,15 +14278,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aMU" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
-"aMV" = (
-/obj/structure/closet{
-	name = "Confiscated items"
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/structure/closet/secure_closet/guard/zone_commander,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "aMW" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Hallway"
@@ -14542,7 +14521,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/area/site53/llcz/checkequip)
 "aNH" = (
 /obj/machinery/vending/security{
 	req_access = list()
@@ -14901,12 +14880,12 @@
 /area/site53/lowertrams/restaurantkitchenarea)
 "aOA" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/catwalk,
 /obj/machinery/camera/network/scp106{
 	dir = 1;
 	name = "SCP-106 Upper Observation Catwalk South"
@@ -15117,10 +15096,19 @@
 /turf/simulated/wall/prepainted,
 /area/site53/ulcz/scp151)
 "aPh" = (
-/obj/machinery/status_display,
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/prepainted,
-/area/site53/ulcz/scp173)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
 "aPj" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -15272,6 +15260,11 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "aPB" = (
@@ -15321,6 +15314,11 @@
 "aPL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -15374,6 +15372,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "aPR" = (
@@ -15408,6 +15411,7 @@
 /obj/machinery/camera/network/lcz{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aPX" = (
@@ -15529,6 +15533,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "aQz" = (
@@ -16318,8 +16327,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTy" = (
-/obj/structure/closet/secure_closet/personal,
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aTA" = (
@@ -16611,6 +16623,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUI" = (
@@ -16732,14 +16747,7 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/armory)
 "aVb" = (
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "ULCZ Checkpoint Booth";
-	name = "ULCZ Checkpoint Booth";
-	pixel_x = 24;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aVf" = (
 /obj/structure/cable/green{
@@ -16767,27 +16775,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod)
 "aVi" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Checkpoint Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/bed/chair/shuttle{
+	name = "Reeducation Chair"
 	},
-/obj/machinery/door/blast/shutters{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Booth Exit";
-	name = "ULCZ Checkpoint Booth Exit"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/uhcz/securitypost)
 "aVk" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -16876,10 +16869,21 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aVw" = (
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/structure/table/rack,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "aVx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -16927,7 +16931,7 @@
 	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/area/site53/llcz/checkequip)
 "aVD" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
@@ -16974,17 +16978,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/armory)
 "aVK" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "aVL" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -17009,13 +17010,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
 "aVQ" = (
-/obj/structure/cable/green{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/airlock/hatch/maintenance{
+	name = "Heavy Containment Maintenance";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Maint Access";
+	name = "UHCZ Maint Access"
+	},
+/turf/simulated/floor,
+/area/site53/uhcz/securitypost)
 "aVR" = (
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
@@ -17029,26 +17039,27 @@
 /turf/simulated/wall/prepainted,
 /area/site53/ulcz/hallways)
 "aVW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/red/border{
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/structure/railing/mapped{
 	dir = 1
 	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
 "aVY" = (
-/obj/structure/closet/crate/bin,
+/obj/machinery/door/airlock/glass/security{
+	name = "ULCZ Checkpoint Interior";
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Office Access S";
+	name = "ULCZ Checkpoint Office Access S"
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/llcz/entrance_checkpoint)
 "aVZ" = (
 /obj/item/device/taperecorder,
 /obj/item/device/camera,
@@ -17614,43 +17625,92 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "aXJ" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "UHCZ Isocell 1";
+	name = "UHCZ Isocell 1";
+	pixel_x = -25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "aXK" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/gray,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/wall/titanium,
+/area/site53/llcz/entrance_checkpoint)
 "aXL" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fernybush,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4;
+	icon_state = "bordercolor"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "aXM" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/machinery/disposal/deliveryChute{
+	dir = 4;
+	name = "Food delivery"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/northleft{
+	dir = 4;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/site53/uhcz/scp106containment)
 "aXN" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/palebush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/reinforced,
+/area/site53/uhcz/scp106containment)
 "aXO" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fernybush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "aXP" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/table/standard,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "aXQ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/genericbush,
@@ -17658,20 +17718,22 @@
 /turf/simulated/floor/grass,
 /area/site53/lowertrams/brownline)
 "aXR" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "aXS" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/site53/lowertrams/hub)
 "aXT" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
-/area/site53/lowertrams/brownline)
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
+"aXV" = (
+/obj/structure/table/marble,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "aXX" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
@@ -17783,12 +17845,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmtunnel)
 "aYw" = (
-/obj/machinery/door/blast/regular,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown"
 	},
-/turf/simulated/floor/reinforced,
-/area/site53/lowertrams/escape)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "aYx" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -18017,13 +18085,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
 "aZt" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "aZu" = (
 /obj/machinery/vending/coffee{
 	dir = 4
@@ -20218,7 +20285,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "bgn" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -20306,135 +20373,48 @@
 /obj/structure/scp173_cage,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
-"bgD" = (
-/obj/structure/table/standard,
-/obj/machinery/light,
-/obj/machinery/button/blast_door{
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
 "bgE" = (
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "bgF" = (
-/obj/structure/table/standard,
-/obj/machinery/button/blast_door{
-	dir = 3;
-	id_tag = "ULCZ Western Gate";
-	name = "ULCZ Western Gate";
-	pixel_x = -6;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/machinery/button/blast_door{
-	dir = 3;
-	id_tag = "ULCZ Eastern Gate";
-	name = "ULCZ Eastern Gate";
-	pixel_x = 4;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bgI" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Checkpoint Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/door/blast/shutters{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Booth";
-	name = "ULCZ Checkpoint Booth"
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bgK" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
-/obj/machinery/door/blast/shutters{
-	id_tag = "ULCZ Internal Windows";
-	name = "ULCZ Internal Windows"
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bgV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/obj/effect/paint_stripe/gray,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/prepainted,
+/area/site53/ulcz/hallways)
 "bgW" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
-	},
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	pixel_y = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "bgX" = (
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	pixel_x = 24;
-	req_access = list("ACCESS_ADMIN_LEVEL5")
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/unsimulated/mineral,
 /area/site53/ulcz/maintenance)
 "bgY" = (
 /obj/effect/floor_decal/industrial/outline/orange,
@@ -20450,30 +20430,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular/open{
-	begins_closed = 1;
-	icon_state = "pdoor0";
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "bhb" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/blast/regular/open{
-	begins_closed = 1;
-	icon_state = "pdoor0";
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)"
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "bhc" = (
 /obj/structure/ladder,
 /obj/structure/cable{
@@ -20482,31 +20448,44 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	name = "ULCZ Maintenance Tunnel Access (EMERGENCY ONLY)";
-	pixel_x = 24;
-	req_access = list("ACCESS_ADMIN_LEVEL5")
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/ulcz/maintenance)
+/area/site53/ulcz/hallways)
 "bhf" = (
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/window/reinforced{
+	dir = 0
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Central Window";
+	name = "ULCZ Checkpoint Central Window"
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "ULCZ Exit Point";
+	name = "ULCZ Exit Point";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "bhg" = (
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown";
-	pixel_y = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 6
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "bhh" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "ULCZ Secure Armoury";
@@ -20611,19 +20590,26 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bhB" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Northern Window";
+	name = "ULCZ Checkpoint Northern Window"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Western Gate";
-	name = "ULCZ Western Gate"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bhD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -20634,16 +20620,10 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "bhE" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/mre/random,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Guard Office"
-	},
 /obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed/chair/padded/black,
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "bhF" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/monotile,
@@ -20663,217 +20643,215 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"bhI" = (
-/obj/machinery/light{
+"bhK" = (
+/obj/machinery/door/airlock/hatch/maintenance{
+	name = "ULCZ Maintenance"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
-"bhK" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/site53/ulcz/maintenance)
 "bhL" = (
-/obj/machinery/vending/coffee,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "bhO" = (
-/obj/machinery/door/airlock/security{
-	name = "Heavy Containment Zone Gate Security Post"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
-"bhP" = (
-/obj/machinery/door/airlock/security{
-	name = "Solitary Confinement";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bhQ" = (
-/obj/structure/bed/chair/padded/black{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bhR" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bhS" = (
-/obj/structure/table/standard,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/head/helmet/facecover,
-/obj/item/clothing/head/helmet/facecover,
-/obj/item/clothing/head/helmet/facecover,
-/obj/item/clothing/head/helmet/facecover,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/glasses/blindfold,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/ears/earmuffs,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/mask/muzzle,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bhT" = (
-/obj/structure/table/standard,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bhU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
-"bhV" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bhW" = (
-/obj/structure/bed/chair/padded/black,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
-"bhX" = (
-/obj/structure/table/standard,
-/obj/item/storage/mre/random,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
-"bhZ" = (
-/obj/machinery/camera/network/hcz{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
+"bhP" = (
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/office)
+"bhR" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Checkpoint Outer Window East";
+	name = "UHCZ Checkpoint Outer Window East"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"bhT" = (
+/obj/machinery/camera/network/hcz{
 	name = "HCZ Guard Office"
 	},
+/obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
-"bia" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bib" = (
-/obj/effect/floor_decal/corner/red/border{
+/area/site53/uhcz/securitypost)
+"bhU" = (
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
+"bhV" = (
+/obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bid" = (
-/obj/effect/floor_decal/corner/red/border{
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"bhW" = (
+/obj/structure/skele_stand,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/hyper{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/commanderoffice)
+"bhZ" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
+"bia" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "ULCZ Checkpoint Interior";
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
+"bib" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/wall/titanium,
+/area/site53/uhcz/scp106containment)
 "bie" = (
 /obj/structure/table/standard,
-/obj/item/deck/cards,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Booth Window 1";
+	name = "UHCZ Booth Window 1";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Checkpoint Access";
+	name = "UHCZ Checkpoint Access";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/camera/network/hcz{
+	name = "HCZ Security Post"
+	},
+/obj/machinery/button/flasher{
+	id_tag = "HCZCheckpointflash";
+	pixel_x = 26;
+	pixel_y = 32;
+	name = "HCZCheckpointflash"
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "big" = (
 /obj/machinery/light,
 /obj/effect/landmark/test/safe_turf,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
 "bii" = (
-/obj/structure/table/standard,
-/obj/item/storage/fancy/cigarettes/case,
-/obj/item/flame/lighter/random,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/bed/chair/padded/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
 "bij" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small/red{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "bik" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
-	id_tag = "UHCZ Lockdown";
-	name = "UHCZ Lockdown"
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/hallways)
+/area/site53/uhcz/securitypost)
 "bim" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
 "bip" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/standard,
-/obj/item/device/megaphone,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "biq" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/bed/chair/office/comfy,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bis" = (
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Central Window";
+	name = "ULCZ Checkpoint Central Window"
+	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "bit" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -20881,36 +20859,47 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "biw" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc/hyper{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "0-1"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bix" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
 "biy" = (
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Western Gate";
-	name = "ULCZ Western Gate"
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/prepainted,
 /area/site53/llcz/entrance_checkpoint)
 "biz" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/table/reinforced,
+/obj/item/deck/cards,
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "biA" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
+/obj/structure/table/rack,
+/obj/item/gun/projectile/revolver/rhino,
+/obj/item/gun/projectile/revolver/rhino,
+/obj/effect/floor_decal/corner/black/full,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -20924,24 +20913,15 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "biD" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "biF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -20964,46 +20944,49 @@
 	},
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/south)
-"biH" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
 "biI" = (
-/obj/structure/bed/chair/office/dark,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
-"biK" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/item/stool,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/highsecurity{
+	name = "HCZ Secure Armoury";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "HCZ Secure Armoury";
+	name = "HCZ Secure Armoury"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
-"biM" = (
-/obj/structure/table/standard,
-/obj/machinery/door/window/brigdoor{
-	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/machinery/door/blast/shutters{
-	begins_closed = 0;
-	id_tag = "UHCZ Booth Window 1";
-	name = "UHCZ Booth Window 1"
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/securitypost)
-"biQ" = (
-/obj/structure/bed/chair/padded/black{
-	dir = 1
+"biK" = (
+/obj/structure/bed/chair,
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/llcz/entrance_checkpoint)
+"biM" = (
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "UHCZ Isocell 2";
+	name = "UHCZ Isocell 2";
+	pixel_x = -25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
+"biQ" = (
+/obj/structure/closet{
+	name = "Confiscated items"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "biS" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -21026,61 +21009,59 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
-"biU" = (
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
 "biV" = (
 /obj/effect/floor_decal/corner/red,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "biX" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 4
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/machinery/camera/network/hcz{
-	dir = 1
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "biY" = (
-/obj/machinery/door/airlock/security{
-	name = "Heavy Containment Holding Cell";
+/obj/machinery/door/airlock/glass/security{
+	name = "Interrogation";
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "bjd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "bje" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/ulcz/generalpurpose)
 "bjf" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Western Lockdown";
+	name = "UHCZ Western Lockdown";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "bjg" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -21097,70 +21078,71 @@
 "bjh" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
-	id_tag = "UHCZ Lockdown";
-	name = "UHCZ Lockdown"
+	id_tag = "UHCZ Western Shutter";
+	name = "UHCZ Western Shutter"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "bji" = (
-/obj/structure/bed/chair/padded/black{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/reinforced,
+/area/site53/uhcz/scp106containment)
 "bjk" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bjl" = (
-/obj/structure/table/reinforced,
-/obj/item/deck/cards,
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Guard Office"
-	},
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bjm" = (
-/obj/structure/bed/chair/padded/black{
+/obj/effect/floor_decal/corner/blue/border{
 	dir = 8
 	},
+/obj/structure/table/standard,
+/obj/item/sticky_pad/random,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
+"bjm" = (
 /obj/effect/floor_decal/corner/red/border{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "bjn" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bjo" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
+/obj/structure/bed/chair/padded/black{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "bjp" = (
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Guard Office"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "bjr" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/site53/lowertrams/hczmaint/south)
 "bjs" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -21169,92 +21151,80 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "bjt" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
+/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
 "bju" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bjv" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/llcz/entrance_checkpoint)
 "bjw" = (
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bjy" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
+"bjy" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "bjz" = (
-/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/machinery/door/airlock/security{
-	name = "Briefing Hall";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "bjA" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
-"bjB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
 "bjC" = (
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Equipment Room"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -21264,23 +21234,16 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "bjD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"bjE" = (
-/obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/camera/network/hcz,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "bjH" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
@@ -21337,16 +21300,12 @@
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/south)
 "bjT" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "bjU" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Heavy Containment Maintenance";
@@ -21443,20 +21402,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "bkh" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown";
-	pixel_x = 24;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Lockdown Lower";
+	name = "ULCZ Checkpoint Lockdown Lower"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
-"bkm" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "bkn" = (
 /obj/machinery/light{
 	dir = 4;
@@ -21464,17 +21417,14 @@
 	},
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/area/site53/llcz/checkequip)
 "bko" = (
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
-"bkp" = (
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/area/site53/llcz/checkequip)
 "bkq" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
@@ -21482,14 +21432,14 @@
 "bkr" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/area/site53/llcz/checkequip)
 "bks" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Center";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/area/site53/llcz/checkequip)
 "bkt" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -21516,7 +21466,7 @@
 	name = "D-Class Prep"
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/area/site53/llcz/checkequip)
 "bkw" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/door/airlock/glass/security{
@@ -21524,14 +21474,7 @@
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor,
-/area/site53/ulcz/hallways)
-"bkx" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/area/site53/llcz/checkequip)
 "bkL" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
@@ -21548,18 +21491,44 @@
 	},
 /turf/simulated/floor,
 /area/site53/surface/bunker)
-"blf" = (
+"blb" = (
+/obj/effect/paint_stripe/red,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/humanoidcontainment)
+"blf" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "blg" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ North Gate";
+	name = "ULCZ North Gate";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ South Gate";
+	name = "ULCZ South Gate";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "bmF" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -21586,15 +21555,17 @@
 /turf/simulated/floor/reinforced,
 /area/site53/reswing/robotics)
 "bnp" = (
-/obj/machinery/photocopier/faxmachine,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
-"bpz" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/scp106containment)
+"bpz" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "bpN" = (
 /turf/simulated/floor/tiled/monotile/white,
@@ -21604,11 +21575,18 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Eastern Shutter Window";
+	name = "UHCZ Eastern Shutter Window"
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "brk" = (
 /obj/machinery/light{
@@ -21616,6 +21594,24 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
+"brK" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "brU" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
@@ -21680,6 +21676,13 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"buA" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "buV" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -21770,7 +21773,7 @@
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/hallways)
 "bzi" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -21778,6 +21781,13 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Maint Access";
+	name = "UHCZ Maint Access";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -21842,6 +21852,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/reswing/xenobiology)
+"bHN" = (
+/obj/machinery/vending/hydronutrients/generic{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "bHX" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/orange/border{
@@ -21853,9 +21869,23 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/ulcz/scp2427_3)
+"bIx" = (
+/obj/machinery/gibber{
+	emagged = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
 "bIZ" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bKj" = (
 /obj/structure/bed/chair/office/light,
@@ -21921,6 +21951,17 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/controlroom)
+"bPM" = (
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "bQJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Zone Gate Security Post";
@@ -21984,6 +22025,12 @@
 	id_tag = "HCZCheckpointflash";
 	name = "HCZCheckpointflash"
 	},
+/obj/item/device/radio/intercom/locked{
+	dir = 8;
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = 32;
+	channels = list(1)
+	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bTG" = (
@@ -21997,6 +22044,27 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
+"bTJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/hub)
+"bTK" = (
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "bUi" = (
 /obj/structure/closet,
 /obj/machinery/light{
@@ -22019,16 +22087,21 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
 "bVr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
+"bWr" = (
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/site53/lowertrams/hczmaint/east)
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "bWu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22047,6 +22120,17 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"bWT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "bXc" = (
 /obj/structure/table/rack,
 /obj/item/modular_computer/pda/science,
@@ -22068,13 +22152,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
 "bYK" = (
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "bYZ" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -22159,12 +22248,12 @@
 /area/site53/uhcz/scp247containment)
 "ciE" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "ciN" = (
@@ -22183,6 +22272,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
+"cjx" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
 "cjG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22201,39 +22296,18 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
 "clC" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL3");
-	dir = 4
-	},
-/obj/machinery/button/blast_door{
-	dir = 4;
-	id_tag = "UHCZ Checkpoint Gate 1";
-	name = "UHCZ Checkpoint Gate 1";
-	pixel_x = -25;
-	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
+/area/site53/llcz/entrance_checkpoint)
 "clO" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /area/site53/lowertrams/hub)
 "cme" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "cmh" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -22294,6 +22368,18 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/controlroom)
+"cor" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "cpO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22317,17 +22403,12 @@
 /turf/simulated/floor,
 /area/site53/uhcz/generalpurpose3)
 "cqc" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/obj/machinery/door/airlock/glass/security{
+	name = "Checkpoint holding cell";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/obj/structure/table/standard,
-/obj/item/boombox,
-/obj/item/paper{
-	info = "GC said to knock it off with the music, something about a strongly worded letter from the council, and an ass-chewing from the SD. Do try and keep it down when around the higher-ups. -Davis";
-	name = "hand-written note"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "cqF" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/gray,
@@ -22346,20 +22427,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"cqT" = (
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/llcz/checkequip)
 "crR" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/area/site53/lhcz/hczguardgear)
 "crW" = (
 /obj/effect/paint_stripe/red,
 /obj/structure/disposalpipe/segment{
@@ -22393,10 +22472,14 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aiccore)
 "cvG" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/floor_decal/corner/red/border,
+/obj/structure/sign/goldenplaque/security{
+	pixel_y = 30
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "cvQ" = (
@@ -22413,16 +22496,9 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp247observation)
 "cwc" = (
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "Heavy Containment Zone Commander";
-	send_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/guard/hcz,
 /turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/area/site53/lhcz/hczguardgear)
 "cwF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22495,6 +22571,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"cBj" = (
+/obj/structure/bed,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "cCy" = (
 /obj/item/device/flashlight{
 	on = 1
@@ -22513,21 +22593,46 @@
 /turf/simulated/floor/reinforced,
 /area/site53/reswing/robotics)
 "cDN" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "UHCZ Checkpoint Holding Cells";
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor{
+	name = "Booth";
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Booth Window 1";
+	name = "UHCZ Booth Window 1"
+	},
+/turf/simulated/floor,
 /area/site53/uhcz/securitypost)
 "cEb" = (
 /obj/structure/table/standard,
+/obj/item/stamp/cmo{
+	name = "HCZ Entry Checkpoint Stamp"
+	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Eastern Shutter Window";
+	name = "UHCZ Eastern Shutter Window";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
 /obj/machinery/light{
-	dir = 8
+	dir = 4
+	},
+/obj/item/device/radio/intercom/locked{
+	dir = 8;
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = 32;
+	channels = list(1)
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "cFl" = (
 /obj/structure/sign/scp/euclid_scp{
 	pixel_y = 32
@@ -22541,15 +22646,28 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"cFC" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Containment Cell 3";
+	name = "Humanoid Containment Cell 3";
+	begins_closed = 0
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "cFN" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light{
+/obj/structure/catwalk,
+/obj/machinery/light/spot{
 	dir = 4
 	},
 /turf/simulated/open,
@@ -22663,6 +22781,26 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"cNb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment South";
+	name = "Humanoid Containment South";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment North";
+	name = "Humanoid Containment North";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "cNi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22693,6 +22831,10 @@
 /obj/item/device/radio/phone,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"cRs" = (
+/obj/machinery/icecream_vat,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "cRR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22742,11 +22884,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
 "cTw" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
+/obj/structure/bed/chair/padded/black{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
 "cVc" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -22770,6 +22912,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"cWo" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
+"cWF" = (
+/obj/structure/filingcabinet/scp/keter,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "cXy" = (
 /obj/structure/sign/scp/euclid_scp{
 	pixel_x = -32
@@ -22820,8 +22977,29 @@
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
 "cYI" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id_tag = "ULCZ Checkpoint Flash";
+	name = "ULCZ Checkpoint Flash"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "LCZ Checkpoint Intercom";
+	pixel_y = -32;
+	channels = list(1)
+	},
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "cYP" = (
 /obj/effect/catwalk_plated/white,
@@ -22884,12 +23062,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
 "dcB" = (
-/obj/machinery/button/flasher{
-	id_tag = "HCZ Holding Cell 1";
-	name = "Flasher Holding Cell 1";
-	pixel_y = 25;
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "ddw" = (
@@ -22903,14 +23076,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp173)
 "ddz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/prepainted,
+/area/site53/llcz/entrance_checkpoint)
 "ddA" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -22941,6 +23109,19 @@
 /obj/item/boombox,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"dfj" = (
+/obj/item/clothing/gloves/thick/botany,
+/obj/item/material/hatchet,
+/obj/item/material/minihoe,
+/obj/item/clothing/mask/bandana/botany,
+/obj/item/clothing/under/rank/hydroponics,
+/obj/item/storage/backpack/hydroponics,
+/obj/structure/closet/secure_closet/hydroponics_torch,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "dgG" = (
 /obj/machinery/photocopier,
 /obj/machinery/alarm{
@@ -22988,6 +23169,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/uhcz/scp106containment)
+"dhn" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "dhQ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Chamber Airlock";
@@ -23077,20 +23264,17 @@
 "doD" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/titanium,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/hallways)
 "dpg" = (
 /turf/simulated/floor/carpet/brown,
 /area/site53/llcz/scp500{
 	requires_power = 0
 	})
 "dpC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "dqb" = (
 /obj/structure/table/standard,
@@ -23110,10 +23294,20 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
 "dsV" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "dsY" = (
 /obj/machinery/door/airlock/research{
 	name = "SCP-513 Observation";
@@ -23199,6 +23393,24 @@
 /obj/item/modular_computer/console/preset/aislot/research,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
+"dyC" = (
+/obj/structure/janitorialcart,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
+"dBg" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "dBn" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/glass/fifty,
@@ -23223,13 +23435,10 @@
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/escape)
 "dBT" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/skele_stand,
-/obj/item/clothing/head/hcz_hazmat{
-	pixel_y = 9
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/obj/structure/table/standard,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
 "dCs" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -23298,14 +23507,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
-"dFy" = (
-/obj/structure/sign/directions/ez{
-	dir = 8;
-	pixel_x = -30
-	},
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/uhcz/hallways)
 "dGG" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4;
@@ -23409,6 +23610,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/brownline)
+"dMS" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "dNM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -23451,6 +23658,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
+"dPU" = (
+/mob/living/carbon/human/scp_527,
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "dQS" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/wallframe_spawn/reinforced,
@@ -23465,31 +23676,17 @@
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/restaurantkitchenarea)
 "dRU" = (
-/obj/structure/table/standard,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/corner/red{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/button/flasher{
-	id_tag = "HCZCheckpointflash";
-	pixel_y = 32;
-	name = "HCZCheckpointflash"
-	},
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "UHCZ Booth Window 1";
-	name = "UHCZ Booth Window 1";
-	pixel_y = 9;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "UHCZ Checkpoint Outer Window 1";
-	name = "UHCZ Checkpoint Outer Window 1";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
 /obj/machinery/camera/network/hcz{
-	name = "HCZ Security Post"
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -23558,6 +23755,13 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
+"dZj" = (
+/obj/machinery/light,
+/obj/structure/hygiene/toilet{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/site53/ulcz/humanoidcontainment)
 "dZn" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -23581,17 +23785,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp113)
-"ebw" = (
-/obj/machinery/button/blast_door{
-	dir = 4;
-	id_tag = "ULCZ Checkpoint Booth Exit";
-	name = "ULCZ Checkpoint Booth Exit";
-	pixel_x = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/structure/flora/pottedplant/large,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
 "ebG" = (
 /obj/structure/table/rack,
 /obj/item/stack/material/aluminium/ten,
@@ -23632,6 +23825,11 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "eeH" = (
@@ -23682,6 +23880,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
+"ehq" = (
+/obj/structure/table/reinforced,
+/obj/item/beach_ball,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "ehP" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
@@ -23705,17 +23911,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
 "eiF" = (
-/obj/structure/table/standard,
-/obj/item/folder/red,
-/obj/item/folder/white,
-/obj/item/folder/yellow,
-/obj/item/folder/blue,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_x = -7
 	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/cheap,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "eiL" = (
 /obj/structure/table/rack,
 /obj/item/gun/energy/plasmastun,
@@ -23729,15 +23933,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
 "ekr" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/camera/network/entrance{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Maint Access";
+	name = "UHCZ Maint Access"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
+/turf/simulated/floor,
+/area/site53/lowertrams/hczmaint/south)
 "ele" = (
 /obj/machinery/door/airlock/highsecurity/bolted{
 	req_access = list("ACCESS_SCIENCE_LEVEL5","ACCESS_ADMIN_LEVEL4")
@@ -23760,6 +23967,18 @@
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
 /area/chapel)
+"enN" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "LCZ Checkpoint Intercom";
+	pixel_y = -32;
+	channels = list(1)
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
 "eon" = (
 /obj/item/stool/padded,
 /turf/simulated/floor/wood/walnut,
@@ -23771,28 +23990,50 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
-"epD" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+"epk" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "Humanoid Containment Intercom";
+	pixel_x = -26
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/boombox,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"epD" = (
+/obj/machinery/vending/security{
+	req_access = list()
+	},
+/obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "epS" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Eastern Checkpoint Access Door";
+	name = "UHCZ Eastern Checkpoint Access Door";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
+/area/site53/uhcz/securitypost)
+"eqf" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "eqH" = (
 /obj/machinery/door/airlock/science{
 	name = "Tranqilizer Storage";
@@ -23819,20 +24060,61 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
 "erI" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
-	dir = 4
+	dir = 4;
+	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/flasher{
+	id_tag = "ULCZ Checkpoint Flash";
+	name = "ULCZ Checkpoint Flash"
+	},
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "esS" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	begins_closed = 0;
-	id_tag = "UHCZ Checkpoint Outer Window 1";
-	name = "UHCZ Checkpoint Outer Window"
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
+"eto" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/civilian{
+	name = "Hub"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
+/area/site53/lowertrams/hub)
 "etJ" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/light/small/red{
@@ -23841,6 +24123,28 @@
 	},
 /turf/simulated/floor,
 /area/site53/surface/bunker)
+"euO" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "HCZ Checkpoint Intercom";
+	pixel_y = -32;
+	channels = list(1)
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
+"euW" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
+"evd" = (
+/obj/machinery/vending/hydroseeds/generic{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "evx" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
@@ -23870,10 +24174,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
-"ewJ" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
 "eyn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23888,10 +24188,13 @@
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
 "ezj" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/coatrack,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Shutter";
+	name = "UHCZ Eastern Shutter"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "ezt" = (
 /obj/structure/closet,
 /obj/item/device/radio,
@@ -23944,6 +24247,29 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/science/aicobservation)
+"eCZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
+/area/site53/lowertrams/brownline)
+"eEi" = (
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Shutter";
+	name = "UHCZ Eastern Shutter"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "eED" = (
 /obj/machinery/button/flasher{
 	dir = 1;
@@ -23980,13 +24306,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
-"eKg" = (
-/obj/machinery/door/airlock/security{
-	name = "Surplus Gear";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+"eJY" = (
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"eKg" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "HCZ Security Center";
+	send_access = list(203)
+	},
+/obj/structure/table/standard,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "eKA" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -24015,6 +24350,20 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/restaurantkitchenarea)
+"eLf" = (
+/obj/structure/table/woodentable,
+/obj/item/dice,
+/obj/item/dice,
+/obj/item/dice/d10,
+/obj/item/dice/d10,
+/obj/item/dice/d100,
+/obj/item/dice/d12,
+/obj/item/dice/d20,
+/obj/item/dice/d4,
+/obj/item/dice/d8,
+/obj/item/storage/pill_bottle/dice,
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "eMM" = (
 /obj/effect/floor_decal/corner/orange/mono,
 /obj/structure/cable{
@@ -24038,10 +24387,11 @@
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp096)
 "eOZ" = (
-/obj/structure/table/standard,
-/obj/item/deck/cards,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "ePk" = (
 /obj/machinery/light{
 	dir = 8
@@ -24086,6 +24436,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/ulcz/hallways)
+"eSG" = (
+/obj/structure/table/standard,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/paper,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "eUI" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -24117,9 +24477,6 @@
 "eVx" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/light,
-/obj/machinery/camera/network/entrance{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
 "eWo" = (
@@ -24128,6 +24485,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"eWp" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "eWL" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier{
@@ -24138,6 +24501,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
+"eXf" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "eXV" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 5
@@ -24145,6 +24512,20 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
+"eYt" = (
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Western Shutter";
+	name = "UHCZ Western Shutter"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "eYX" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -24168,6 +24549,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"fcp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/site53/ulcz/maintenance)
 "fcU" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/red/mono,
@@ -24311,12 +24700,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
 "fhQ" = (
-/obj/machinery/door/airlock/multi_tile/security{
-	name = "Heavy Containment Holding Cells";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "fiJ" = (
 /obj/item/modular_computer/console/preset/cardslot/command{
 	dir = 4
@@ -24404,6 +24790,15 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"fqs" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "fqw" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -24457,9 +24852,6 @@
 /turf/simulated/floor,
 /area/site53/ulcz/scp2427_3)
 "ftf" = (
-/obj/machinery/door/airlock/hatch/maintenance{
-	name = "ULCZ Maintenance"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24475,7 +24867,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
-/area/site53/lowertrams/brownline)
+/area/site53/ulcz/maintenance)
 "ftn" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/beakers,
@@ -24522,16 +24914,11 @@
 /turf/simulated/floor/reinforced,
 /area/site53/ulcz/hallways)
 "fva" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair{
+	dir = 4
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "fvB" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "Hallway"
@@ -24595,14 +24982,33 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"fwQ" = (
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "fwS" = (
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Eastern Gate";
-	name = "ULCZ Eastern Gate"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "fwU" = (
 /obj/machinery/door/blast/regular{
@@ -24685,24 +25091,26 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
+"fFm" = (
+/obj/structure/bookcase/manuals/engineering,
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "fFD" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/site53/uhcz/hallways)
+/area/site53/ulcz/scp2427_3)
 "fGE" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Checkpoint (RESTRICTED)";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/machinery/camera/network/entrance{
+	dir = 8
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "fGK" = (
 /obj/machinery/door/airlock/glass/civilian{
@@ -24732,6 +25140,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
+"fIB" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_x = -7
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"fJe" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/industrial/outline/orange,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "fKV" = (
 /obj/structure/bed/chair{
 	dir = 1;
@@ -24751,6 +25171,29 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"fME" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment Kitchen Access";
+	name = "Humanoid Containment Kitchen Access";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment Hydro Access";
+	name = "Humanoid Containment Hydro Access";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "fMY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24800,39 +25243,17 @@
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
 "fQz" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/obj/structure/closet/hydrant{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "fQK" = (
 /obj/structure/table/standard,
-/obj/item/device/radio/phone,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/photocopier{
+	pixel_y = 3
 	},
-/obj/machinery/door/blast/shutters{
-	begins_closed = 0;
-	id_tag = "UHCZ Booth Window 1";
-	name = "UHCZ Booth Window 1"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "fRi" = (
 /obj/structure/table/standard,
@@ -24909,6 +25330,10 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor/plating,
 /area/site53/ulcz/scp173)
+"fSH" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "fSL" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -24929,6 +25354,13 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"fTQ" = (
+/obj/machinery/light,
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "fUe" = (
 /obj/structure/table/reinforced,
 /obj/structure/flora/pottedplant/deskleaf,
@@ -25099,10 +25531,19 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
+"ggG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "ggM" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
 	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
@@ -25141,6 +25582,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"giK" = (
+/obj/structure/table/standard,
+/obj/machinery/reagent_temperature,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "giX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25153,13 +25600,18 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
 "gjb" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/crematorium{
+	dir = 1;
+	name = "HCZCrematorium";
+	id = "HCZCrematorium"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/machinery/light/small/red{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "gjy" = (
 /obj/machinery/camera/network/entrance{
 	c_tag = "Hub 2";
@@ -25246,11 +25698,20 @@
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
 "gmT" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/locked{
+	frequency = 10;
+	name = "HCZ Checkpoint Intercom";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "gmY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -25407,22 +25868,27 @@
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
 "gyj" = (
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "gyC" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Equipment Room"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
+/obj/item/clothing/head/helmet/scp/hczsecurityguard,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "gyL" = (
@@ -25476,6 +25942,28 @@
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
+"gCJ" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
+"gCY" = (
+/obj/structure/table/standard,
+/obj/item/storage/fancy/cigarettes/case,
+/obj/item/flame/lighter/random,
+/obj/structure/table/standard,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "gEl" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -25516,6 +26004,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp457containment)
+"gHs" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Central Observation Window";
+	name = "Humanoid Central Observation Window";
+	begins_closed = 0
+	},
+/turf/space,
+/area/site53/ulcz/humanoidcontainment)
 "gHD" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -25524,18 +26021,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "gHP" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small/red{
+	dir = 8
 	},
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Guard Office"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "gID" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -25544,6 +26035,21 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"gKy" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Southern Window";
+	name = "ULCZ Checkpoint Southern Window"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "gKT" = (
 /obj/effect/floor_decal/chapel,
 /obj/machinery/light,
@@ -25561,6 +26067,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"gNg" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/chemical_dispenser/bar_soft/full{
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "gNK" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -25615,9 +26130,23 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
 "gPT" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
+/obj/machinery/door/airlock/highsecurity{
+	name = "HCZ 096 Lockdown Control";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -25629,11 +26158,30 @@
 /obj/structure/hygiene/drain,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/lowertrams/hub)
+"gRd" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "gRy" = (
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
+"gRz" = (
+/obj/structure/closet/jcloset_torch,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "gSw" = (
 /obj/structure/table/standard,
 /obj/item/device/camera,
@@ -25701,11 +26249,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
@@ -25786,10 +26329,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "hah" = (
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/r_titanium,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/camera/network/entrance,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "hat" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
@@ -25847,6 +26395,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
+"hbx" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "hcC" = (
 /obj/machinery/camera/network/hcz{
 	dir = 4
@@ -25883,11 +26437,39 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "hgr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/paint_stripe/gray,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/wall/titanium,
+/area/site53/llcz/entrance_checkpoint)
+"hhj" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"hhA" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin";
+	pixel_y = 1
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
+"hiu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Eastern Observation Window";
+	name = "Humanoid Eastern Observation Window";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "hkp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -25938,6 +26520,15 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"hls" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "hmB" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-247 Staff Training";
@@ -25968,6 +26559,10 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp457containment)
+"hnN" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "hnU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -25982,17 +26577,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/primaryhallway)
 "hoG" = (
-/obj/machinery/door/airlock/multi_tile/security{
-	name = "Heavy Containment Equipment";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/commanderoffice)
+"hoI" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "hqI" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -26019,45 +26615,37 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "hsl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
 "hsY" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
@@ -26115,8 +26703,21 @@
 "hxk" = (
 /turf/unsimulated/mineral,
 /area/site53/surface/explorers/surrounding)
+"hxM" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Checkpoint Outer Window East";
+	name = "UHCZ Checkpoint Outer Window East"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "hyd" = (
-/obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -26128,8 +26729,16 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"hyr" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "hzp" = (
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
@@ -26139,6 +26748,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"hzA" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
 "hzL" = (
 /obj/structure/closet,
 /obj/item/device/tape/random,
@@ -26343,16 +26958,27 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp263)
 "hHF" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/paper_bin,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "hIO" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
 /area/site53/ulcz/generalpurpose)
+"hIZ" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "Humanoid Containment Kitchen Access";
+	name = "Humanoid Containment Kitchen Access"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "hJZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -26380,10 +27006,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/ulcz/scp173)
+"hLU" = (
+/obj/machinery/botany/extractor,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "hMa" = (
 /obj/item/storage/fancy/cigarettes,
 /turf/simulated/floor,
 /area/space)
+"hMF" = (
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "hMV" = (
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "comms_airlock";
@@ -26394,6 +27030,14 @@
 	temperature = 80
 	},
 /area/site53/upper_surface/serverfarminterior)
+"hNx" = (
+/obj/structure/fitness/weightlifter,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
+"hNz" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "hNN" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -26407,6 +27051,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
+"hPI" = (
+/obj/machinery/botany/editor,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "hQo" = (
 /obj/effect/paint_stripe/yellow,
 /obj/structure/disposalpipe/segment,
@@ -26498,12 +27146,8 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "hSN" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "hSQ" = (
@@ -26542,22 +27186,6 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
-"hTi" = (
-/obj/machinery/door/blast/regular{
-	id_tag = "UHCZ Checkpoint Gate 2";
-	name = "UHCZ Checkpoint Gate 2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor,
-/area/site53/uhcz/securitypost)
 "hTt" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-247 Observation";
@@ -26595,15 +27223,64 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
+"hUo" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"hUN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "hUS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Lockdown Upper";
+	name = "ULCZ Checkpoint Lockdown Upper"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "hVd" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
 /area/site53/science/aicobservation)
+"hVJ" = (
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "hWk" = (
 /obj/machinery/light{
 	dir = 4
@@ -26612,8 +27289,40 @@
 /area/site53/engineering/primaryhallway)
 "hWt" = (
 /obj/structure/table/standard,
-/obj/item/lipstick/random,
-/turf/simulated/floor/tiled,
+/obj/machinery/door/window/brigdoor{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Eastern Shutter Window";
+	name = "UHCZ Eastern Shutter Window"
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/site53/uhcz/securitypost)
+"hWS" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/obj/structure/table/standard,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/gun/launcher/grenade,
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/item/reagent_containers/spray/chemsprayer,
+/turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "hXN" = (
 /obj/machinery/camera/network/scp106{
@@ -26678,6 +27387,18 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
+"icg" = (
+/obj/structure/hygiene/sink{
+	dir = 4;
+	pixel_x = 10
+	},
+/obj/item/storage/mirror{
+	dir = 4;
+	pixel_x = 23;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/site53/ulcz/humanoidcontainment)
 "icl" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -26715,6 +27436,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
+"idc" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "idF" = (
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/white,
@@ -26725,6 +27453,18 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"ieo" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "Humanoid Containment Intercom";
+	pixel_x = -26
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "ify" = (
 /obj/machinery/vending/medical,
 /turf/simulated/floor/tiled/white,
@@ -26744,17 +27484,45 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"ihv" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
+"ihx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "LCZ Checkpoint Intercom";
+	pixel_y = -32;
+	channels = list(1)
+	},
+/turf/simulated/floor/tiled,
+/area/site53/lowertrams/brownline)
 "ihM" = (
-/obj/machinery/light/spot,
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/catwalk,
+/obj/machinery/light/spot,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"iik" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "iix" = (
 /obj/structure/closet/secure_closet/guard/breachautomatics,
 /obj/item/ammo_magazine/box/a556,
@@ -26776,41 +27544,93 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"ikz" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
-"ilx" = (
+"ijY" = (
 /obj/structure/cable/green{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
-"imN" = (
-/obj/structure/bed/chair,
-/obj/machinery/camera/network/lcz,
+/area/site53/lhcz/hczguardgear)
+"ikk" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
+"ikz" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"ilx" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
+"ilH" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
-"ing" = (
-/obj/effect/catwalk_plated/white,
+/area/site53/llcz/checkequip)
+"imN" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
+"ing" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Lockdown Upper";
+	name = "ULCZ Checkpoint Lockdown Upper"
+	},
+/obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
+"inT" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment Cell 3";
+	name = "Humanoid Containment Cell 3";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment Cell 2";
+	name = "Humanoid Containment Cell 2";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "ioc" = (
 /obj/machinery/light{
 	dir = 1
@@ -26847,13 +27667,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
-"ipQ" = (
-/obj/structure/closet/secure_closet/guard/hcz,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+"ipx" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Isocell 2";
+	name = "UHCZ Isocell 2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"ipQ" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "iqc" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -26926,9 +27753,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
 "ixi" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/r_titanium,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/airlock/security{
+	name = "Solitary Confinement";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Isocell 2";
+	name = "UHCZ Isocell 2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "ixs" = (
 /obj/machinery/holosign/surgery{
 	dir = 4;
@@ -26939,6 +27774,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
+"ixG" = (
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/open,
+/area/site53/uhcz/scp106containment)
+"iyl" = (
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "iyT" = (
 /obj/effect/floor_decal/industrial/fire,
 /obj/machinery/light/small,
@@ -26996,6 +27847,12 @@
 /obj/item/storage/box/matches,
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"iAX" = (
+/obj/structure/sign/scp/safe_scp{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "iBn" = (
 /obj/effect/floor_decal/industrial/hatch/orange,
 /turf/simulated/floor/reinforced,
@@ -27026,21 +27883,26 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/genstorage1)
 "iCg" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "ULCZ South Gate";
+	name = "ULCZ South Gate"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
-"iCG" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "HCZ Secure Armoury";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+"iCF" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "Humanoid Containment Intercom";
+	pixel_x = -26
 	},
-/obj/machinery/door/blast/regular/open{
-	begins_closed = 1;
-	icon_state = "pdoor0";
-	id_tag = "HCZ Secure Armoury";
-	name = "HCZ Secure Armoury"
+/obj/structure/table/woodentable,
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
+"iCG" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -27097,12 +27959,12 @@
 /area/site53/llcz/scp263)
 "iIU" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -27126,6 +27988,9 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
+"iJy" = (
+/turf/simulated/floor/tiled/freezer,
+/area/site53/ulcz/humanoidcontainment)
 "iJS" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/red/mono,
@@ -27156,6 +28021,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106containment)
+"iNh" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "0-1"
+	},
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "iNl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -27254,6 +28131,14 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"iRf" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/botanydisk,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "iRn" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -27288,27 +28173,31 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "iRt" = (
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Equipment Room"
-	},
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/black/full,
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"iRz" = (
 /obj/machinery/door/airlock/glass/security{
-	name = "Holding Cell 1";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+	name = "ULCZ Checkpoint Interior";
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Office Access N";
+	name = "ULCZ Checkpoint Office Access N"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
+"iRz" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Western Shutter Window";
+	name = "UHCZ Western Shutter Window";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -27316,11 +28205,33 @@
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/llcz/scp513)
+"iRY" = (
+/obj/machinery/honey_extractor,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "iTk" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
+"iUu" = (
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "iUJ" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/floor_decal/corner/red/mono,
@@ -27394,6 +28305,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
+"iXa" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/checkequip)
 "iXE" = (
 /obj/machinery/light{
 	dir = 4
@@ -27422,9 +28342,41 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"jaf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "SCP-151 Containment Chamber";
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"jaN" = (
+/obj/machinery/door/airlock/civilian{
+	name = "Restroom"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "jbo" = (
-/turf/simulated/wall/titanium,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/closet{
+	name = "D-Class Prep"
+	},
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "jbv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -27436,14 +28388,30 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
+"jdo" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "jdL" = (
-/obj/effect/floor_decal/corner/black/full,
-/obj/structure/table/standard,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
-/obj/item/hand_labeler,
+/obj/effect/landmark/start{
+	name = "HCZ Guard"
+	},
+/obj/structure/bed/chair/office/comfy,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
+"jee" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Eastern Observation Window";
+	name = "Humanoid Eastern Observation Window";
+	begins_closed = 0
+	},
+/turf/space,
+/area/site53/ulcz/humanoidcontainment)
 "jek" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
@@ -27468,22 +28436,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/lowertrams/restaurantkitchenarea)
 "jfF" = (
-/obj/structure/table/rack,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/item/clothing/gloves/tactical/scp,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled,
+/area/site53/lowertrams/brownline)
 "jgH" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 5
@@ -27522,6 +28477,15 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"jhG" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 8;
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = 32;
+	channels = list(1)
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "jkl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -27530,6 +28494,42 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
+"jkJ" = (
+/obj/structure/closet/secure_closet/freezer/kitchen{
+	req_access = list()
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"jkQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment Storage Access";
+	name = "Humanoid Containment Storage Access";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Containment Bar Access";
+	name = "Humanoid Containment Bar Access";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"jlN" = (
+/obj/structure/curtain/open/shower,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/site53/ulcz/humanoidcontainment)
 "jmg" = (
 /obj/machinery/r_n_d/server/core,
 /turf/simulated/floor/greengrid,
@@ -27648,6 +28648,14 @@
 	},
 /turf/simulated/floor/grass,
 /area/site53/science/aicobservation)
+"juH" = (
+/obj/structure/bookcase/manuals,
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "jvA" = (
 /obj/machinery/light/small,
 /obj/structure/table/steel,
@@ -27695,19 +28703,22 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "jxJ" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/spray/chemsprayer,
-/obj/item/reagent_containers/spray/chemsprayer,
-/obj/item/gun/launcher/grenade,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/structure/closet{
+	name = "Confiscated items"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
+"jxY" = (
+/obj/structure/bed/chair{
+	dir = 1;
+	pixel_y = 13
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "jye" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/button/blast_door{
@@ -27720,6 +28731,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"jzT" = (
+/obj/effect/paint_stripe/red,
+/obj/structure/sign/monkey_painting,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/humanoidcontainment)
 "jAF" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -27738,6 +28754,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"jBO" = (
+/obj/machinery/button/blast_door{
+	id_tag = "Humanoid Containment South";
+	name = "Humanoid Containment South";
+	pixel_y = 24
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "jBQ" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/bucket,
@@ -27797,17 +28826,15 @@
 "jEg" = (
 /turf/simulated/floor,
 /area/site53/surface/bunker)
-"jES" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/office)
 "jFe" = (
-/obj/structure/bed/chair{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/flasher{
-	id_tag = "HCZ Holding Cell 1";
-	pixel_y = 25
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -27832,14 +28859,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
 "jGl" = (
-/obj/machinery/vending/security{
-	req_access = list()
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
+/obj/effect/floor_decal/corner/red/border,
+/obj/structure/bed/chair/padded/black{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "jGW" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-012 Containment Chamber";
@@ -27896,11 +28921,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/generalpurpose3)
 "jKc" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/site53/ulcz/scp2427_3)
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "jKi" = (
 /obj/effect/paint_stripe/gray,
 /obj/structure/closet/hydrant{
@@ -27947,16 +28974,10 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "jOV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/office)
 "jPr" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/exoplanet/barren,
@@ -27979,31 +29000,29 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "jQI" = (
-/obj/structure/cable/green{
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/hub)
 "jQM" = (
-/obj/structure/table/standard,
+/obj/effect/floor_decal/scp/clear_north{
+	dir = 4
+	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/blast/shutters{
-	begins_closed = 0;
-	id_tag = "UHCZ Booth Window 1";
-	name = "UHCZ Booth Window 1"
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/site53/uhcz/securitypost)
+/turf/simulated/floor/reinforced,
+/area/site53/uhcz/scp106containment)
 "jQX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28087,16 +29106,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
 "jZA" = (
-/obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/obj/item/sticky_pad/random,
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/turf/simulated/floor/reinforced,
+/area/site53/uhcz/scp106containment)
 "kao" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/paper_bin,
@@ -28134,6 +29149,14 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
+"kbO" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/reagent_temperature/cooler,
+/obj/item/book/manual/barman_recipes,
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "kcw" = (
 /obj/machinery/light{
 	dir = 1
@@ -28148,10 +29171,14 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
 "kdH" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/item/stool,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Isocell 3";
+	name = "UHCZ Isocell 3"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "kdN" = (
 /obj/machinery/light{
 	dir = 4
@@ -28214,6 +29241,15 @@
 /obj/item/boombox,
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"khQ" = (
+/obj/structure/bed/chair/wood{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "khX" = (
 /obj/machinery/door/blast/shutters{
 	dir = 8;
@@ -28246,6 +29282,25 @@
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/uhcz/scp247containment)
+"kkD" = (
+/obj/structure/closet/secure_closet,
+/obj/item/storage/candle_box,
+/obj/item/storage/candle_box,
+/obj/item/flame/lighter/zippo/random,
+/obj/item/storage/candle_box/incense,
+/obj/item/stack/package_wrap,
+/obj/item/device/synthesized_instrument/synthesizer,
+/obj/item/folder/blue,
+/obj/item/folder/yellow,
+/obj/item/folder/nt,
+/obj/item/wrapping_paper,
+/obj/item/hand_labeler,
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "kkM" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 8
@@ -28260,6 +29315,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"kls" = (
+/obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
+"klC" = (
+/obj/item/device/radio/intercom/locked{
+	frequency = 10;
+	name = "HCZ Checkpoint Intercom";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "klJ" = (
 /obj/machinery/door/airlock/security{
 	name = "HCZ Sergeant Equipment";
@@ -28283,11 +29354,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
 "kmN" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/airlock/multi_tile/security{
+	name = "Heavy Containment Holding Cells";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "koq" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/spray/cleaner,
@@ -28303,6 +29378,13 @@
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
+"koI" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "koR" = (
 /obj/effect/floor_decal/industrial/fire/corner{
 	dir = 1
@@ -28311,12 +29393,12 @@
 /area/site53/ulcz/hallways)
 "koS" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /obj/machinery/camera/network/scp106{
 	dir = 4;
 	name = "SCP-106 Outdoor Observation Catwalk West"
@@ -28370,16 +29452,15 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
-"krW" = (
-/obj/structure/bed/chair{
-	dir = 4
+"krP" = (
+/obj/structure/bed/chair/armchair/beige{
+	dir = 1
 	},
-/obj/machinery/camera/network/hcz{
-	dir = 4;
-	name = "HCZ Holding Cell 1"
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "ksL" = (
 /obj/structure/table/standard,
 /obj/machinery/button/femur_breaker{
@@ -28458,10 +29539,16 @@
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
 "kys" = (
-/obj/effect/floor_decal/corner/red/border,
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/floor_decal/corner/red{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "kyw" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -28476,6 +29563,10 @@
 /obj/structure/closet/secure_closet/hydroponics_torch,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lowertrams/restaurantkitchenarea)
+"kAB" = (
+/obj/machinery/computer/arcade/battle,
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "kAL" = (
 /obj/machinery/light{
 	dir = 4
@@ -28532,6 +29623,10 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/surface/bunker)
+"kEI" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/space,
+/area/site53/ulcz/humanoidcontainment)
 "kEU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28567,11 +29662,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
 "kFS" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/random,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
+	},
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "kGi" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -28641,9 +29741,9 @@
 	pixel_y = 28
 	},
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
@@ -28737,7 +29837,6 @@
 "kSE" = (
 /obj/machinery/vending/snack,
 /obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/camera/network/entrance,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
 "kUj" = (
@@ -28747,7 +29846,29 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
 "kVb" = (
-/turf/unsimulated/mineral,
+/obj/structure/table/standard,
+/obj/machinery/computer/guestpass{
+	pixel_y = 28
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ Checkpoint Office Access S";
+	name = "ULCZ Checkpoint Office Access S";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ Checkpoint Office Access N";
+	name = "ULCZ Checkpoint Office Access N";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "LCZ Checkpoint Intercom";
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "kVA" = (
 /obj/structure/bed/chair,
@@ -28769,11 +29890,25 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
+"kWi" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "laQ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
@@ -28782,8 +29917,19 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
+"lbi" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "lbn" = (
 /obj/effect/paint_stripe/red,
 /obj/effect/paint_stripe/red,
@@ -28815,10 +29961,21 @@
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
 "lcy" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/item/stool/padded,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Checkpoint Gate 2";
+	name = "UHCZ Checkpoint Gate 2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
+/area/site53/uhcz/securitypost)
 "ldd" = (
 /obj/effect/floor_decal/corner/green/border{
 	dir = 4
@@ -28842,6 +29999,22 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"lfb" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "Humanoid Airlock Window";
+	name = "Humanoid Airlock Window";
+	pixel_x = -25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "lfB" = (
 /obj/structure/table/standard,
 /obj/item/device/megaphone,
@@ -28860,25 +30033,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/controlroom)
+"lga" = (
+/obj/structure/bed/chair/armchair/beige,
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "lgn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "HCZ Secure Armoury";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/machinery/door/blast/regular{
-	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
-	name = "UHCZ Secure Maintenance Tunnel Lockdown"
-	},
-/turf/simulated/floor,
-/area/site53/lowertrams/hczmaint/east)
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "lgp" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 8
@@ -28922,6 +30086,9 @@
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
+"ljb" = (
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "ljc" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 8
@@ -28938,16 +30105,12 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "lkI" = (
-/obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "lmp" = (
 /obj/structure/table/rack,
@@ -28999,10 +30162,14 @@
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
 "ltH" = (
-/obj/structure/table/standard,
-/obj/item/storage/wallet/random,
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Checkpoint Access";
+	name = "UHCZ Checkpoint Access";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "luf" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -29022,6 +30189,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
+"lus" = (
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
 "luD" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
@@ -29076,6 +30249,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"lxI" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Humanoid Containment Unit"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Lockdown";
+	name = "Humanoid Lockdown";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/uhcz/hallways)
 "lxL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -29098,16 +30287,11 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/lowertrams/redline)
 "lzu" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "lzE" = (
 /obj/structure/cable{
@@ -29194,26 +30378,23 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/escape)
-"lFb" = (
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
-	},
-/obj/structure/table/rack,
-/obj/effect/floor_decal/corner/red/mono,
+"lEX" = (
+/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
+"lFb" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
+	},
+/obj/structure/filingcabinet,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "lFx" = (
 /obj/effect/paint_stripe/yellow,
 /obj/machinery/button/blast_door{
@@ -29243,6 +30424,14 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/surface/bunker)
+"lHe" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "lHu" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/combat,
@@ -29279,13 +30468,21 @@
 /turf/simulated/floor/plating,
 /area/site53/engineering/atmos)
 "lKF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id_tag = "ULCZ Checkpoint Flash";
+	name = "ULCZ Checkpoint Flash"
+	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/railing/mapped,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "lLr" = (
 /obj/structure/cable/green{
@@ -29325,23 +30522,29 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "lMj" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
 	dir = 4
 	},
-/obj/machinery/light{
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/sign/bluecross_2{
-	pixel_y = 38
+/obj/structure/window/reinforced{
+	dir = 0
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Eastern Shutter Window (Side)";
+	name = "UHCZ Eastern Shutter Window (Side)"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "lMF" = (
 /obj/effect/catwalk_plated/dark,
 /obj/effect/floor_decal/industrial/warning{
@@ -29409,6 +30612,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"lOO" = (
+/obj/structure/table/woodentable,
+/obj/item/paper,
+/obj/item/pen,
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "lPe" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -29442,7 +30651,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/surface/explorers/surrounding)
 "lPE" = (
-/obj/effect/paint_stripe/red,
+/obj/structure/closet/secure_closet/guard/hcz,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "lQa" = (
@@ -29480,6 +30692,11 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
+"lRm" = (
+/obj/machinery/microwave,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "lSJ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29512,16 +30729,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aiccore)
 "lTO" = (
-/obj/structure/table/standard,
-/obj/machinery/photocopier{
-	pixel_y = 3
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "lUd" = (
 /obj/structure/closet/wardrobe/suit,
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"lUD" = (
+/obj/structure/table/standard,
+/obj/item/clothing/gloves/thick/botany,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "lVz" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
@@ -29529,19 +30752,19 @@
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp096)
 "lWh" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/table/standard,
+/obj/item/boombox,
+/obj/item/device/megaphone,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "lWq" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /obj/machinery/camera/network/scp106{
 	dir = 1;
 	name = "SCP-106 Outdoor Observation Catwalk South"
@@ -29579,6 +30802,14 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/llcz/entrance_checkpoint)
+"lZE" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/site53/ulcz/maintenance)
 "maA" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/warning,
@@ -29605,6 +30836,13 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
+"mcz" = (
+/obj/machinery/vending/wallmed1{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "mdA" = (
 /obj/machinery/computer/cryopod/robot{
 	pixel_y = 31
@@ -29635,29 +30873,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/xenobiology)
 "mfw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/black/full,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/table/standard,
+/obj/item/storage/box/donut,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "mfE" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/pistol/usp45,
-/obj/item/gun/projectile/pistol/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/box/a45,
-/obj/item/ammo_magazine/box/a45,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/black/full,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/lowertrams/hczmaint/south)
 "mfJ" = (
 /obj/structure/closet,
 /obj/machinery/light{
@@ -29685,6 +30908,14 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"mfY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/site53/ulcz/hallways)
 "mhh" = (
 /obj/machinery/light{
 	dir = 1
@@ -29693,12 +30924,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
 "mhP" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
-	},
+/obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "mhU" = (
 /obj/item/modular_computer/console/preset/aislot/sysadmin,
 /turf/simulated/floor/tiled/techmaint,
@@ -29748,6 +30976,13 @@
 "mjK" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose)
+"mjN" = (
+/obj/structure/bookcase/manuals/xenoarchaeology,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "mkF" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -29756,6 +30991,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"mkS" = (
+/obj/structure/table/standard,
+/obj/item/storage/mre/random,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "mlt" = (
 /obj/machinery/r_n_d/server,
 /obj/machinery/camera/motion{
@@ -29765,10 +31005,24 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
+"mmw" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "Humanoid Containment Hydro Access";
+	name = "Humanoid Containment Hydro Access"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "mmM" = (
-/obj/machinery/camera/network/hcz,
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/hallways)
+/area/site53/uhcz/securitypost)
 "mmX" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1;
@@ -29792,6 +31046,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"mov" = (
+/obj/structure/closet,
+/obj/item/clothing/suit/chef,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/suit/chef/classic,
+/obj/item/book/manual/chef_recipes,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
 "moM" = (
 /obj/machinery/camera/network/lcz{
 	dir = 1
@@ -29799,12 +31065,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "moW" = (
-/obj/machinery/light{
-	dir = 4
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 9
 	},
-/obj/effect/floor_decal/corner/black/full,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/commanderoffice)
 "mpo" = (
 /obj/structure/closet/l3closet/general,
 /turf/simulated/floor/tiled/white,
@@ -29860,6 +31126,12 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/surface/explorers/surrounding)
+"mrs" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "mrP" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -29882,24 +31154,43 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/engineering/bathrooms)
+"muh" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "muz" = (
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/security{
+	name = "Armoury (Non Lethal)";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/brownline)
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "muQ" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -30001,12 +31292,12 @@
 /area/site53/ulcz/scp2427_3)
 "mxN" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /obj/machinery/camera/network/scp106{
 	dir = 4;
 	name = "SCP-106 Upper Observation Catwalk"
@@ -30038,6 +31329,9 @@
 	icon_state = "0-2"
 	},
 /obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
 "mzz" = (
@@ -30051,11 +31345,9 @@
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
 "mBg" = (
+/obj/structure/table/rack,
 /obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -30066,36 +31358,27 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/scp2427_3)
-"mBr" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/glass/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
 "mBw" = (
 /obj/structure/table/standard,
-/obj/machinery/button/blast_door{
-	dir = 3;
-	id_tag = "ULCZ Internal Windows";
-	name = "ULCZ Internal Windows";
-	pixel_x = -6;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Booth Window 1";
+	name = "UHCZ Booth Window 1"
 	},
-/obj/machinery/button/blast_door{
-	dir = 3;
-	id_tag = "ULCZ External Windows";
-	name = "ULCZ External Windows";
-	pixel_x = 4;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/stamp/cmo{
+	name = "HCZ Entry Checkpoint Stamp"
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/paper/sec_ctp,
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "mCP" = (
 /obj/structure/closet,
 /obj/item/device/toner,
@@ -30119,30 +31402,35 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
 "mDU" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/light{
+/turf/simulated/floor/reinforced,
+/area/site53/uhcz/scp106containment)
+"mEc" = (
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"mEc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "ULCZ Checkpoint Southern Window";
+	name = "ULCZ Checkpoint Southern Window"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/hallways)
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "mEC" = (
 /obj/item/modular_computer/console/preset/cardslot/command_sec{
 	dir = 4
@@ -30152,6 +31440,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/surface/bunker)
+"mEO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/site53/ulcz/hallways)
 "mFR" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "ULCZ Maintenance";
@@ -30210,6 +31505,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
+"mLp" = (
+/obj/structure/table/marble,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "mLD" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 8
@@ -30227,15 +31528,16 @@
 	requires_power = 0
 	})
 "mNl" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/bed/chair/office/dark{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4;
-	icon_state = "warning"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
+/area/site53/llcz/entrance_checkpoint)
 "mNs" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 4
@@ -30348,12 +31650,12 @@
 /area/site53/ulcz/hallways)
 "mSX" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "mTN" = (
@@ -30397,14 +31699,16 @@
 /turf/simulated/floor/reinforced,
 /area/space)
 "mVs" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
+/obj/machinery/camera/network/hcz{
+	dir = 4
 	},
-/obj/effect/landmark/start{
-	name = "HCZ Junior Guard"
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = -26
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "mVy" = (
 /obj/machinery/implantchair{
 	desc = "A machine that was once, long ago, used to implant Foundation Employees with Mind Control Chips. Decommissioned shortly after use due to ethical concerns."
@@ -30426,18 +31730,35 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "mXc" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/shutters{
-	id_tag = "ULCZ Internal Windows";
-	name = "ULCZ Internal Windows"
-	},
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
+	id_tag = "ULCZ Checkpoint Lockdown Upper";
+	name = "ULCZ Checkpoint Lockdown Upper"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
+"mXl" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "mXo" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -30466,21 +31787,29 @@
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
-"nan" = (
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "UHCZ Checkpoint Control Room 2";
-	name = "UHCZ Checkpoint Control Room 2";
-	pixel_y = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+"mYx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/stamp/cmo{
-	name = "HCZ Entry Checkpoint Stamp"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"mZS" = (
+/obj/structure/bed/roller/ironingboard,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
+"nan" = (
+/obj/structure/table/standard,
+/obj/item/storage/wallet/random,
+/obj/item/lipstick/random,
+/turf/simulated/floor/tiled,
 /area/site53/uhcz/securitypost)
 "naq" = (
 /obj/machinery/camera/motion{
@@ -30489,12 +31818,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"nbD" = (
+/obj/machinery/seed_extractor,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "nbE" = (
-/obj/effect/floor_decal/corner/black/full,
-/obj/structure/closet,
-/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
-/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
-/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/table/standard,
+/obj/item/deck/cards,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "nbP" = (
@@ -30510,6 +31843,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
+"ndr" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "ndt" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -30531,8 +31871,20 @@
 /area/site53/ulcz/hallways)
 "neg" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"nem" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "nfV" = (
 /obj/effect/floor_decal/chapel{
 	dir = 8
@@ -30578,6 +31930,13 @@
 /obj/structure/stairs/east,
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"niD" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "niH" = (
 /obj/machinery/light{
 	dir = 1
@@ -30586,12 +31945,12 @@
 /area/site53/uhcz/scp247observation)
 "niQ" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "njj" = (
@@ -30721,6 +32080,9 @@
 	},
 /turf/simulated/floor/grass,
 /area/site53/science/aicobservation)
+"nsU" = (
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "ntc" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "SCP-513"
@@ -30736,16 +32098,11 @@
 /turf/simulated/floor,
 /area/site53/llcz/scp513)
 "ntR" = (
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "UHCZ Checkpoint Control Room";
-	name = "UHCZ Checkpoint Control Room";
-	pixel_y = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/structure/table/standard,
-/obj/machinery/photocopier{
-	pixel_y = 3
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Checkpoint Outer Window West";
+	name = "UHCZ Checkpoint Outer Window West"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -30824,6 +32181,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
+"nyh" = (
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/hallways)
 "nyL" = (
 /obj/effect/paint_stripe/gray,
 /obj/structure/noticeboard,
@@ -30847,6 +32209,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
+"nBh" = (
+/obj/machinery/vending/coffee,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "nBD" = (
 /obj/machinery/light{
 	dir = 4
@@ -30939,6 +32305,24 @@
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/llcz/entrance_checkpoint)
+"nGd" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Eastern Shutter Window (Side)";
+	name = "UHCZ Eastern Shutter Window (Side)";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "UHCZ Maint Access";
+	name = "UHCZ Maint Access";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "nGT" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor,
@@ -31001,6 +32385,15 @@
 	temperature = 80
 	},
 /area/site53/upper_surface/serverfarminterior)
+"nJn" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "nJN" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/camera/network/hcz,
@@ -31008,12 +32401,12 @@
 /area/site53/uhcz/hallways)
 "nJV" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /obj/machinery/camera/network/scp106{
 	name = "SCP-106 Outdoor Observation Catwalk South"
 	},
@@ -31067,9 +32460,22 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"nMW" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/obj/machinery/door/airlock/glass/civilian{
+	name = "SCP 527 Dorm (Mr Fish)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "nNb" = (
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
+"nNn" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
 "nNp" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -31093,6 +32499,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"nOq" = (
+/obj/structure/closet/wardrobe/suit,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "nOA" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -31108,30 +32518,44 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
-"nQR" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/mono,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
+"nQM" = (
+/obj/machinery/cooker/fryer,
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
-/area/site53/lhcz/hczguardgear)
-"nRo" = (
-/obj/structure/lattice,
-/obj/structure/catwalk,
+/area/site53/ulcz/humanoidcontainment)
+"nQR" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
+"nRf" = (
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/open,
-/area/site53/uhcz/scp106containment)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"nRz" = (
+/obj/structure/table/standard,
+/obj/item/tray,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
+"nRA" = (
+/obj/machinery/camera/network/lcz{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "nTc" = (
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/monotile,
@@ -31155,26 +32579,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/maintenance)
 "nTU" = (
-/obj/machinery/door/airlock/glass/research{
-	name = "Office"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/office)
-"nUg" = (
-/obj/machinery/door/airlock/security{
-	name = "Heavy Containment Zone Gate Security Post";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/ulcz/hallways)
 "nUn" = (
 /obj/machinery/light{
 	dir = 1
@@ -31215,18 +32624,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "nWH" = (
-/obj/structure/table/rack,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "nWT" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
@@ -31247,6 +32652,22 @@
 /obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
+"oau" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "oaH" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/plating,
@@ -31277,28 +32698,25 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "ocR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "ocX" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/hallways)
+/area/site53/uhcz/securitypost)
 "odC" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "oee" = (
 /obj/structure/lattice,
@@ -31363,10 +32781,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
 "okj" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/border,
-/obj/item/device/radio/phone,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner/red/diagonal,
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/lhcz/hczguardgear)
 "okr" = (
 /obj/structure/table/rack,
@@ -31418,6 +32837,12 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/lowertrams/escape)
+"oni" = (
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "onl" = (
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
@@ -31449,6 +32874,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"ooD" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/hub)
 "ooJ" = (
 /obj/machinery/vending/cola,
 /obj/effect/floor_decal/corner/red/mono,
@@ -31541,6 +32980,30 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
+"otv" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 0
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Airlock Window";
+	name = "Humanoid Airlock Window"
+	},
+/turf/simulated/floor/plating,
+/area/site53/ulcz/humanoidcontainment)
 "otI" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31554,6 +33017,19 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/lowertrams/restaurantkitchenarea)
+"ouf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/site53/ulcz/maintenance)
 "ove" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -31624,23 +33100,23 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "oAS" = (
-/obj/structure/closet/secure_closet/guard/breachautomatics,
-/obj/item/ammo_magazine/box/a556,
-/obj/item/ammo_magazine/box/a556,
-/obj/item/ammo_magazine/box/a556,
-/obj/item/ammo_magazine/box/a556,
-/obj/machinery/button/blast_door{
-	id_tag = "HCZ Secure Armoury";
-	name = "HCZ Secure Armoury";
-	pixel_y = 22;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
 	},
-/obj/effect/floor_decal/corner/red/mono,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "oBp" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 9
@@ -31654,6 +33130,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"oBE" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "oBG" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/structure/bed/chair,
@@ -31683,6 +33166,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/restaurantkitchenarea)
+"oFR" = (
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "oGS" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 1
@@ -31710,12 +33197,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
 "oHH" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 6
+/obj/structure/lattice,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/obj/structure/catwalk,
+/turf/simulated/open,
+/area/site53/uhcz/scp106containment)
 "oHL" = (
 /obj/machinery/button/blast_door{
 	dir = 1;
@@ -31731,19 +33221,27 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aiccore)
 "oIp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard,
+/obj/item/device/radio/phone,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Booth Window 1";
+	name = "UHCZ Booth Window 1"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/door/airlock/multi_tile/security{
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/obj/item/device/radio/intercom/locked{
 	dir = 4;
-	name = "Heavy Containment Security Point";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = -26
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "oJB" = (
 /obj/machinery/camera/network/entrance{
 	c_tag = "Hub 1";
@@ -31850,16 +33348,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
 "oQu" = (
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Eastern Shutter";
+	name = "UHCZ Eastern Shutter"
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "UHCZ Lockdown";
-	name = "UHCZ Lockdown"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -31882,13 +33380,24 @@
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/site53/engineering/sleeproom)
-"oVt" = (
-/obj/structure/closet/secure_closet/guard/hcz,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
+"oUj" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled,
+/area/site53/uhcz/securitypost)
+"oVt" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "HCZ Checkpoint Western Office";
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Western Checkpoint Access Door";
+	name = "UHCZ Western Checkpoint Access Door"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "oVw" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -31927,6 +33436,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"oWN" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Western Observation Window";
+	name = "Humanoid Western Observation Window";
+	begins_closed = 0
+	},
+/turf/space,
+/area/site53/ulcz/humanoidcontainment)
 "oWT" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -31961,6 +33479,19 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
+"oZI" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/chemical_dispenser/bar_alc/full{
+	pixel_y = 7
+	},
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "pak" = (
 /obj/machinery/light,
 /obj/structure/table/rack,
@@ -31989,17 +33520,22 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp457containment)
 "paF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/window/reinforced{
+	dir = 0
 	},
-/turf/simulated/floor,
-/area/site53/lowertrams/hczmaint/south)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Eastern Shutter Window (Side)";
+	name = "UHCZ Eastern Shutter Window (Side)"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "pbZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -32020,11 +33556,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
-"pcU" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
 "pdr" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/corner/red/mono,
@@ -32069,16 +33600,25 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "phw" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Western Checkpoint Access Door";
+	name = "UHCZ Western Checkpoint Access Door";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "pid" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/camera/network/lcz{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "pih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -32117,13 +33657,16 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
 "pku" = (
-/obj/machinery/papershredder,
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Guard Office"
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
 	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/table/standard,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "pkC" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -32155,6 +33698,33 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/science/aicobservation)
+"pox" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
+"pqx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/turf/simulated/floor/tiled,
+/area/site53/lowertrams/brownline)
 "prb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32235,19 +33805,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
 "pyn" = (
-/obj/structure/closet{
-	name = "D-Class Prep"
-	},
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/machinery/camera/network/lcz,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "pze" = (
 /obj/machinery/camera/autoname{
@@ -32276,12 +33836,25 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
+"pAo" = (
+/obj/structure/lattice,
+/obj/structure/cable{
+	d1 = 32;
+	icon_state = "32-1"
+	},
+/turf/simulated/open,
+/area/site53/ulcz/maintenance)
 "pBu" = (
 /obj/effect/floor_decal/corner/green/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"pCp" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "pCH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32357,16 +33930,33 @@
 /area/site53/llcz/scp500{
 	requires_power = 0
 	})
+"pFH" = (
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_x = -7
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "pFN" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
+"pFP" = (
+/obj/machinery/computer/arcade/battle,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "pFU" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/maintenance)
+/area/site53/llcz/checkequip)
 "pHf" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/bin{
@@ -32386,16 +33976,13 @@
 /area/site53/lowertrams/hub)
 "pIF" = (
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -32408,6 +33995,15 @@
 "pKU" = (
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp106containment)
+"pLN" = (
+/obj/effect/paint_stripe/red,
+/obj/machinery/button/crematorium{
+	id_tag = "HCZCrematorium";
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"));
+	name = "HCZCrematorium"
+	},
+/turf/simulated/wall/titanium,
+/area/site53/uhcz/securitypost)
 "pMp" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -32432,9 +34028,14 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "pNO" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor,
-/area/site53/ulcz/office)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "pNQ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -32451,16 +34052,21 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/lhcz/hczguardgear)
+"pOU" = (
+/obj/structure/closet/cabinet,
+/obj/item/storage/mre/random,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/shoes/orange,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "pPg" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/structure/bed/chair/office/dark{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -32506,6 +34112,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"pTX" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/checkequip)
 "pUs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -32542,8 +34157,12 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
 "pXS" = (
-/obj/item/modular_computer/console/preset/security,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/brown/mono,
+/obj/structure/railing/mapped,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled,
 /area/site53/llcz/entrance_checkpoint)
 "pXT" = (
 /obj/structure/closet/toolcloset,
@@ -32587,12 +34206,12 @@
 /area/site53/llcz/scp263research)
 "qbz" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/catwalk,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -32694,20 +34313,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
 "qhP" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/shutters{
-	id_tag = "ULCZ Internal Windows";
-	name = "ULCZ Internal Windows"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "qig" = (
 /turf/simulated/floor/tiled/steel_grid,
@@ -32765,8 +34376,27 @@
 /turf/simulated/floor/reinforced,
 /area/site53/reswing/robotics)
 "qkl" = (
-/turf/simulated/floor/tiled,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Western Shutter Window (side)";
+	name = "UHCZ Western Shutter Window (side)"
+	},
+/turf/simulated/floor,
+/area/site53/uhcz/securitypost)
 "qkX" = (
 /obj/machinery/door/airlock/highsecurity/bolted{
 	req_access = list("ACCESS_SCIENCE_LEVEL5","ACCESS_ADMIN_LEVEL4")
@@ -32798,10 +34428,21 @@
 /obj/item/ammo_magazine/scp/p90_mag,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
+"qnc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/brown/mono,
+/turf/simulated/floor/tiled,
+/area/site53/lowertrams/brownline)
 "qnO" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "qoe" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32818,6 +34459,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/upper_surface/serverfarmtunnel)
+"qow" = (
+/obj/structure/closet/crate/hydroponics/prespawned,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "qpB" = (
 /obj/effect/floor_decal/carpet/green,
 /obj/effect/floor_decal/carpet/green{
@@ -32833,11 +34478,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose)
 "qqQ" = (
-/obj/structure/table/standard,
-/obj/machinery/camera/network/lcz{
-	dir = 1
+/obj/machinery/light{
+	dir = 1;
+	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "qro" = (
 /obj/effect/floor_decal/industrial/fire{
@@ -32846,6 +34491,10 @@
 /obj/structure/flora/pottedplant/flower,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
+"qrC" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "qrM" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/cable{
@@ -32867,24 +34516,24 @@
 /turf/simulated/floor,
 /area/site53/engineering/primaryhallway)
 "qtP" = (
-/obj/structure/closet/secure_closet/guard/hcz,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"quy" = (
-/obj/machinery/camera/network/hcz{
-	name = "HCZ Security Post"
-	},
 /obj/effect/floor_decal/corner/blue/border{
-	dir = 1
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "Heavy Containment Zone Commander";
+	send_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
+"quy" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "qvi" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 1
@@ -32894,6 +34543,9 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
+"qvG" = (
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
 "qxk" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/monotile,
@@ -32902,6 +34554,17 @@
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/scp513)
+"qyR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Western Observation Window";
+	name = "Humanoid Western Observation Window";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "qzl" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable{
@@ -32958,6 +34621,10 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
+"qEa" = (
+/obj/machinery/cooker/grill,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
 "qEd" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -33006,12 +34673,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
 "qJk" = (
-/obj/machinery/vending/security{
-	req_access = list()
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Isocell 1";
+	name = "UHCZ Isocell 1"
 	},
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "qJB" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
@@ -33054,6 +34723,13 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"qKS" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "qLk" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Communication Engineers";
@@ -33087,6 +34763,10 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"qMp" = (
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "qOz" = (
 /obj/effect/floor_decal/corner/green/border{
 	dir = 5
@@ -33096,6 +34776,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"qOA" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "Humanoid Containment Intercom";
+	pixel_y = -32;
+	channels = list(1)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "qPI" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
@@ -33103,13 +34792,24 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uhcz/scp247containment)
+"qPJ" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "qPN" = (
-/obj/effect/catwalk_plated/white,
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
-	id_tag = "ULCZ Western Gate";
-	name = "ULCZ Western Gate"
+	id_tag = "ULCZ Checkpoint Lockdown Upper";
+	name = "ULCZ Checkpoint Lockdown Upper"
 	},
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "qQb" = (
@@ -33162,17 +34862,9 @@
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/brownline)
 "qUS" = (
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/vending/fitness,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "qVh" = (
 /obj/effect/floor_decal/corner/yellow/border{
 	dir = 8
@@ -33189,6 +34881,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "qWj" = (
@@ -33345,19 +35038,19 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "rcM" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/shutters{
-	id_tag = "ULCZ External Windows";
-	name = "ULCZ External Windows"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "rcN" = (
 /obj/machinery/door/airlock/maintenance{
@@ -33378,27 +35071,20 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "ren" = (
+/obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "reE" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/r_titanium,
-/area/site53/uhcz/commanderoffice)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "reW" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/area/site53/lhcz/hczguardgear)
 "rfa" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -33435,9 +35121,29 @@
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp096)
 "riw" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 0
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	dir = 4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	dir = 8
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Western Shutter Window";
+	name = "UHCZ Western Shutter Window"
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
 "riD" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -33475,6 +35181,9 @@
 	name = "Containment Chamber";
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp106containment)
 "rmo" = (
@@ -33495,6 +35204,11 @@
 /obj/machinery/light/small,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint)
+"rmS" = (
+/obj/structure/table/standard,
+/obj/machinery/cooker/candy,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "rnc" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/structure/window/reinforced{
@@ -33532,6 +35246,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"rpF" = (
+/obj/machinery/vending/games,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "rpY" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/flashlight/maglight,
@@ -33772,10 +35490,35 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"rDY" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "Humanoid Lockdown";
+	name = "Humanoid Lockdown";
+	pixel_x = -25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "rEG" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"rFw" = (
+/obj/machinery/light,
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/uhcz/hallways)
 "rFI" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donut,
@@ -33793,6 +35536,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"rHr" = (
+/obj/structure/bookcase/manuals/research_and_development,
+/obj/structure/sign/scp/euclid_scp{
+	pixel_y = 32
+	},
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "rHu" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/blast/regular/open{
@@ -33843,6 +35593,15 @@
 	temperature = 80
 	},
 /area/site53/upper_surface/serverfarminterior)
+"rKp" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "rLz" = (
 /obj/machinery/papershredder,
 /obj/machinery/camera/network/entrance{
@@ -33904,6 +35663,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aiccore)
+"rPm" = (
+/obj/machinery/chem_master/condimaster,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
+"rPv" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "rPD" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -33914,11 +35685,22 @@
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "rPG" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/machinery/power/apc/hyper{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "0-1"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "rPM" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -33935,6 +35717,12 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"rSk" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "rSP" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
@@ -33969,17 +35757,17 @@
 /area/site53/uhcz/scp247observation)
 "rXl" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "rXP" = (
@@ -33991,6 +35779,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"rYx" = (
+/obj/structure/hygiene/sink/kitchen{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "rYU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/table/standard,
@@ -34014,27 +35809,19 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/surface/bunker)
+"sac" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "Humanoid Containment Intercom";
+	pixel_y = -32;
+	channels = list(1)
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "sak" = (
 /obj/structure/bed/chair/pew/left/mahogany,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"saA" = (
-/obj/structure/table/rack,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/item/material/knife/combat,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
 "saK" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -34062,18 +35849,40 @@
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
 "sbE" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	name = "Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/machinery/door/blast/shutters{
-	id_tag = "ULCZ External Windows";
-	name = "ULCZ External Windows"
-	},
-/obj/machinery/door/blast/regular{
 	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
+	id_tag = "ULCZ Checkpoint Northern Window";
+	name = "ULCZ Checkpoint Northern Window"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/site53/llcz/entrance_checkpoint)
+"sbY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "scg" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/structure/bed/chair{
@@ -34099,7 +35908,7 @@
 	dir = 1;
 	name = "intercom (SCP-173)"
 	},
-/turf/simulated/wall/prepainted,
+/turf/simulated/wall/titanium,
 /area/site53/ulcz/scp173)
 "sdl" = (
 /turf/simulated/floor/plating,
@@ -34131,12 +35940,13 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/scp343entrance)
 "sek" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Checkpoint holding cell";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/structure/closet/secure_closet/guard/hcz,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "sez" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -34175,15 +35985,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
 "shV" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/airlock/security{
+	name = "Solitary Confinement";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Isocell 1";
+	name = "UHCZ Isocell 1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "sie" = (
 /obj/structure/table/standard,
 /obj/machinery/reagent_temperature,
@@ -34199,6 +36011,19 @@
 	},
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/south)
+"siB" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "SCP 527 Dorm (Mr Fish)";
+	name = "SCP 527 Dorm (Mr Fish)";
+	begins_closed = 0
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "siU" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 6
@@ -34250,10 +36075,16 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
 "slq" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/donut,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/door/airlock/security{
+	name = "Solitary Confinement";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Isocell 3";
+	name = "UHCZ Isocell 3"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/securitypost)
 "slu" = (
 /obj/structure/table/reinforced,
@@ -34273,6 +36104,21 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"snm" = (
+/obj/machinery/door/airlock/security{
+	name = "UHCZ Checkpoint";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Checkpoint Access";
+	name = "UHCZ Checkpoint Access"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "soj" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -34286,6 +36132,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"spT" = (
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/obj/structure/cable,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "sqv" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -34353,6 +36208,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
 "str" = (
@@ -34378,12 +36234,17 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "suu" = (
-/obj/effect/floor_decal/corner/red/bordercorner,
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
+/obj/machinery/door/airlock/glass/security{
+	name = "UHCZ Checkpoint";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Checkpoint Control Room";
+	name = "UHCZ Checkpoint Control Room"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "suv" = (
 /obj/structure/flora/pottedplant,
 /obj/machinery/light{
@@ -34395,12 +36256,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/breakroom)
 "suY" = (
-/obj/structure/closet/secure_closet/guard/zone_commander,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 10
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "sva" = (
 /obj/machinery/door/airlock/civilian{
 	name = "Evacuation Bunker Living Compartment"
@@ -34441,6 +36302,22 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
+"sxX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"szC" = (
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "HCZ Secure Armoury";
+	name = "HCZ Secure Armoury";
+	pixel_x = -25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
 "szK" = (
 /obj/structure/bed/chair/padded/black,
 /turf/simulated/floor/tiled/dark,
@@ -34561,14 +36438,17 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
 "sHS" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "HCZ Security Center";
-	send_access = list(203)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
 	},
-/obj/structure/table/standard,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/bed/chair/padded/black{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "sIW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34621,6 +36501,13 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
+"sPg" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/reagent_dispensers/water_cooler{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "sPh" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/steel_grid,
@@ -34761,6 +36648,10 @@
 /obj/item/storage/slide_projector,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"sYr" = (
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
 "sYT" = (
 /obj/effect/paint_stripe/gray,
 /obj/structure/sign/directions/ez{
@@ -34788,6 +36679,19 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"sZn" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Containment Cell 2";
+	name = "Humanoid Containment Cell 2";
+	begins_closed = 0
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "tar" = (
 /obj/structure/mopbucket,
 /obj/structure/catwalk,
@@ -34816,17 +36720,17 @@
 /area/site53/reswing/robotics)
 "tcK" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "tcL" = (
@@ -34869,21 +36773,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
-"tfe" = (
-/obj/machinery/camera/network/hcz{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
 "tgo" = (
-/obj/structure/sign/goldenplaque/security{
-	pixel_y = 30
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "UHCZ Isocell 3";
+	name = "UHCZ Isocell 3";
+	pixel_x = -25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/effect/floor_decal/corner/red/border{
-	dir = 1
+	dir = 10
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "tia" = (
 /obj/structure/cable/cyan{
 	icon_state = "4-8"
@@ -34941,6 +36846,9 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/machinery/camera/network/hcz{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "tjw" = (
@@ -34952,6 +36860,17 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aiccore)
+"tjF" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "Humanoid Containment Storage Access";
+	name = "Humanoid Containment Storage Access"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "tjW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -35007,24 +36926,14 @@
 /turf/simulated/floor/plating,
 /area/site53/upper_surface/serverfarmcontrol)
 "tpZ" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "tqR" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -35184,13 +37093,17 @@
 /turf/simulated/floor,
 /area/site53/surface/bunker)
 "tzd" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/door/airlock/glass/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "tzl" = (
 /obj/effect/floor_decal/carpet/orange{
 	dir = 4
@@ -35210,8 +37123,34 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "tzE" = (
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Checkpoint Control Room 2";
+	name = "UHCZ Checkpoint Control Room 2";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Western Lockdown";
+	name = "UHCZ Western Lockdown";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "tzW" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/exoplanet/grass,
@@ -35250,14 +37189,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
 "tGq" = (
-/obj/effect/floor_decal/corner/red/diagonal,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
 /obj/machinery/light,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/hczguardgear)
 "tHs" = (
 /obj/structure/table/standard,
@@ -35271,6 +37211,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"tII" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "Security Booth";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "tIS" = (
 /obj/item/folder/yellow,
 /obj/item/folder/red,
@@ -35278,6 +37225,13 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"tJn" = (
+/obj/structure/bookcase/manuals/medical,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "tJR" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
@@ -35306,6 +37260,13 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
+"tMx" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "tML" = (
 /obj/machinery/door/unpowered/simple/wood,
 /obj/structure/cable/green{
@@ -35331,6 +37292,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"tNu" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "tOm" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 4
@@ -35370,26 +37340,44 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
-"tRU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
+"tQF" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/obj/structure/sign/warning{
-	name = "\improper SECURITY EMERGENCIES ONLY";
-	pixel_x = 6;
-	pixel_y = 29
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
 	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
+"tRU" = (
+/obj/structure/table/standard,
+/obj/item/stamp/cmo{
+	name = "HCZ Entry Checkpoint Stamp"
 	},
-/obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Western Shutter Window (side)";
+	name = "UHCZ Western Shutter Window (side)";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "HCZ Checkpoint Intercom";
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"tSr" = (
+/obj/machinery/vending/wallmed1{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "tSX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -35416,11 +37404,31 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
 /area/site53/llcz/scp513)
+"tWa" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/simulated/floor/lino,
+/area/site53/ulcz/humanoidcontainment)
 "tWi" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
+"tWM" = (
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Western Lockdown";
+	name = "UHCZ Western Lockdown";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "tXn" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -35432,12 +37440,29 @@
 /obj/item/paper/scp/safe/scp2398,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp2398)
+"tXU" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	network = list("Heavy Containment Zone Network");
+	name = "SCP-049 Observation 2"
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "tYx" = (
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
+"tZi" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "uaR" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
@@ -35454,16 +37479,9 @@
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
 "ubf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "ubt" = (
 /obj/machinery/light{
 	dir = 1
@@ -35471,13 +37489,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
 "uce" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/space,
+/area/site53/uhcz/hallways)
 "ucY" = (
 /obj/structure/bed/chair/office/light{
 	dir = 8
@@ -35511,6 +37524,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
+"ues" = (
+/obj/structure/bed/chair/wood{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "ugr" = (
 /obj/machinery/light,
 /obj/machinery/disposal/deliveryChute{
@@ -35539,19 +37558,22 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/breakroom)
+"uhy" = (
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "uhK" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "uhL" = (
@@ -35573,7 +37595,6 @@
 /area/site53/llcz/scp513)
 "uiA" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -35585,18 +37606,24 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/structure/catwalk,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "ujf" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
 "ujC" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
@@ -35612,14 +37639,12 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "ujD" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/highsecurity{
+	name = "SCP-106";
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL4"))
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/scp106containment)
 "uku" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -35659,18 +37684,10 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "ulD" = (
-/obj/structure/table/standard,
-/obj/machinery/button/blast_door{
-	id_tag = "UHCZ Lockdown";
-	name = "UHCZ Lockdown";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "UHCZ Western Lockdown";
+	name = "UHCZ Western Lockdown"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -35722,6 +37739,10 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/scp2427_3)
+"urC" = (
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/humanoidcontainment)
 "urL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35755,6 +37776,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp247observation)
+"usK" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "usU" = (
 /obj/structure/table/reinforced,
 /obj/structure/flora/pottedplant/deskfern,
@@ -35848,14 +37880,11 @@
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
 "uDy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "uDT" = (
 /obj/structure/lattice,
 /obj/structure/catwalk,
@@ -35894,6 +37923,11 @@
 /obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/engineering/controlroom)
+"uGE" = (
+/obj/structure/table/reinforced,
+/obj/item/newspaper,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "uGF" = (
 /obj/machinery/light{
 	dir = 1
@@ -35902,11 +37936,10 @@
 /turf/simulated/floor/plating,
 /area/site53/engineering/primaryhallway)
 "uGR" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/machinery/camera/network/hcz{
-	dir = 1
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -35995,9 +38028,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor,
+/area/site53/uhcz/hallways)
 "uKs" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -36020,15 +38052,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/site53/uhcz/scp247observation)
 "uLN" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/revolver/rhino,
-/obj/item/gun/projectile/revolver/rhino,
-/obj/effect/floor_decal/corner/black/full,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/door/airlock/glass/security{
+	name = "Corridor";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/lhcz/hczguardgear)
 "uNq" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -36117,6 +38145,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"uTp" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "UHCZ Checkpoint Outer Window West";
+	name = "UHCZ Checkpoint Outer Window West"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "uTI" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -36153,14 +38195,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"uVf" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Guard Office"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
 "uVm" = (
 /obj/structure/table/standard,
 /obj/item/device/camera,
@@ -36193,19 +38227,32 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
 "uXa" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	id_tag = "UHCZ Western Lockdown";
+	name = "UHCZ Western Lockdown";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Western Shutter";
+	name = "UHCZ Western Shutter";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Checkpoint Gate 1";
+	name = "UHCZ Checkpoint Gate 1";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
+"uXd" = (
+/obj/structure/fitness/punchingbag,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "uXk" = (
 /obj/effect/floor_decal/corner/green/border{
 	dir = 5
@@ -36289,15 +38336,22 @@
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/xenobiology)
+"vdC" = (
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "vea" = (
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/effect/paint_stripe/gray,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/railing/mapped{
-	dir = 4
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "veT" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -36341,45 +38395,22 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
-"viG" = (
-/obj/structure/table/standard,
-/obj/machinery/door/window/brigdoor{
-	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/machinery/door/window/brigdoor/northright{
-	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/machinery/door/blast/shutters{
-	id_tag = "ULCZ Internal Windows";
-	name = "ULCZ Internal Windows"
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown";
-	name = "ULCZ Checkpoint Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
-"viK" = (
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "HCZ Secure Armoury";
-	name = "HCZ Secure Armoury";
-	pixel_y = -22;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/light{
+"viC" = (
+/obj/structure/bed/chair{
 	dir = 4
 	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
+"viG" = (
+/obj/effect/floor_decal/corner/black/full,
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
+"viK" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "vjP" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
@@ -36393,12 +38424,10 @@
 /area/site53/llcz/scp012)
 "vkJ" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "vlk" = (
@@ -36420,25 +38449,32 @@
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
+"vlN" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Containment South";
+	name = "Humanoid Containment South"
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
+"vmh" = (
+/obj/machinery/vending/boozeomat{
+	req_access = list()
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "vmr" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/beakers,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/xenobiology)
 "vmG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/unsimulated/mineral,
 /area/site53/ulcz/maintenance)
 "vnm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -36501,8 +38537,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/lowertrams/restaurantkitchenarea)
 "vqG" = (
-/obj/effect/landmark/start{
-	name = "HCZ Guard"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -36638,6 +38679,12 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
+"vwK" = (
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "vxd" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -36646,6 +38693,14 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/xenobiology)
+"vxS" = (
+/obj/structure/table/reinforced,
+/obj/item/newspaper,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "vyb" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1;
@@ -36659,6 +38714,10 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/uhcz/scp247observation)
+"vzD" = (
+/obj/machinery/biogenerator,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "vAq" = (
 /obj/machinery/power/apc{
 	dir = 8
@@ -36681,6 +38740,15 @@
 /obj/structure/closet/crate/bin,
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"vBn" = (
+/obj/machinery/light,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "vBB" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36696,6 +38764,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/generalpurpose3)
+"vCX" = (
+/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "vDw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -36709,16 +38786,23 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
 "vDN" = (
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Equipment Room"
-	},
-/obj/structure/sign/warning/nosmoking_1{
-	pixel_x = 8;
-	pixel_y = -26
-	},
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/paper_bin,
 /turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/commanderoffice)
+"vEp" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "Humanoid Containment North";
+	name = "Humanoid Containment North"
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "vEz" = (
 /obj/machinery/door/window/brigdoor/northleft{
 	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
@@ -36773,11 +38857,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
-"vIP" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
 "vJF" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Evacuation Bunker"
@@ -36806,6 +38885,15 @@
 /obj/item/storage/toolbox/electrical,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"vKQ" = (
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/chemical_dispenser/bar_coffee/full{
+	pixel_y = 7
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "vKY" = (
 /obj/effect/floor_decal/corner/green/mono,
 /obj/structure/table/standard,
@@ -36831,15 +38919,32 @@
 /turf/simulated/floor/plating,
 /area/site53/ulcz/generalpurpose)
 "vLm" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ Checkpoint Northern Window";
+	name = "ULCZ Checkpoint Northern Window";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ Checkpoint Southern Window";
+	name = "ULCZ Checkpoint Southern Window";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "ULCZ Checkpoint Central Window";
+	name = "ULCZ Checkpoint Central Window";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "vNb" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/light{
@@ -36860,6 +38965,23 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics)
+"vNN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "SCP 527 Dorm (Mr Fish)";
+	name = "SCP 527 Dorm (Mr Fish)";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "Humanoid Central Observation Window";
+	name = "Humanoid Central Observation Window";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "vNQ" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/light{
@@ -36954,24 +39076,32 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
 "vVj" = (
-/obj/effect/floor_decal/corner/red/border{
+/obj/structure/table/standard,
+/obj/item/device/radio/phone,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
-"vVl" = (
-/obj/structure/bed/chair{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/window/reinforced{
+	dir = 0
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "UHCZ Western Shutter Window";
+	name = "UHCZ Western Shutter Window"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uhcz/securitypost)
+"vVl" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "vVK" = (
 /obj/structure/flora/pottedplant/floorleaf,
@@ -37113,6 +39243,18 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
+"wfV" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/floor,
+/area/site53/ulcz/humanoidcontainment)
 "wgK" = (
 /obj/machinery/light{
 	dir = 8
@@ -37177,11 +39319,18 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "wjM" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "HCZ 096 Lockdown Control";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4;
+	icon_state = "warning"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "wkb" = (
@@ -37190,13 +39339,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
 "wkv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "wmf" = (
 /obj/effect/floor_decal/corner/yellow/half{
@@ -37312,6 +39458,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"wut" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "wuI" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -37470,13 +39624,17 @@
 /turf/simulated/floor,
 /area/site53/uhcz/securitypost)
 "wDE" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/item/stool,
-/obj/machinery/camera/network/hcz{
-	dir = 1;
-	name = "HCZ Guard Office"
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/hczguardgear)
 "wDU" = (
 /obj/effect/catwalk_plated,
@@ -37507,14 +39665,22 @@
 /turf/simulated/floor/plating,
 /area/site53/upper_surface/serverfarmtunnel)
 "wFp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/gun/projectile/pistol/mk9,
+/obj/item/gun/projectile/pistol/mk9,
 /turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/area/site53/lhcz/hczguardgear)
 "wFy" = (
 /obj/machinery/door/airlock/freezer,
 /turf/simulated/floor/tiled/monotile,
@@ -37548,24 +39714,31 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
 /area/site53/uhcz/scp106observ)
-"wGM" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/gun/projectile/pistol/mk9,
-/obj/item/gun/projectile/pistol/mk9,
-/obj/effect/floor_decal/corner/red/mono,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+"wHv" = (
+/obj/structure/table/reinforced,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "wIt" = (
 /obj/effect/landmark/test/space_turf,
 /turf/simulated/floor,
@@ -37603,6 +39776,17 @@
 /obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/scp012)
+"wKN" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "Humanoid Containment Bar Access";
+	name = "Humanoid Containment Bar Access"
+	},
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "wLC" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
@@ -37612,6 +39796,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
+"wLQ" = (
+/obj/structure/table/standard,
+/obj/item/deck/cards,
+/obj/item/boombox,
+/turf/simulated/floor/wood/walnut,
+/area/site53/ulcz/humanoidcontainment)
 "wMy" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -37625,6 +39815,11 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
 /area/site53/uhcz/scp106observ)
+"wNk" = (
+/obj/machinery/cooker/cereal,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
 "wNz" = (
 /obj/structure/table/standard,
 /obj/machinery/reagent_temperature/cooler,
@@ -37710,6 +39905,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"wRH" = (
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/humanoidcontainment)
 "wRV" = (
 /obj/structure/bed/chair/office{
 	dir = 1
@@ -37769,6 +39968,10 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/scp066)
+"wUY" = (
+/obj/structure/bed/chair/wood,
+/turf/simulated/floor/wood,
+/area/site53/ulcz/humanoidcontainment)
 "wVj" = (
 /obj/machinery/light{
 	dir = 8
@@ -37786,14 +39989,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "wVr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/glass/research{
+	name = "Office"
 	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
 "wVK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37809,15 +40012,14 @@
 /turf/simulated/floor/plating,
 /area/site53/engineering/primaryhallway)
 "wVL" = (
-/obj/machinery/power/apc/hyper{
-	dir = 1
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4;
+	icon_state = "bordercolor"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
 	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
@@ -37847,6 +40049,29 @@
 /obj/item/storage/box/frags,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
+"wZG" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/food/condiment/small/peppermill,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/humanoidcontainment)
+"wZP" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/item/device/radio/intercom/locked{
+	frequency = 10;
+	name = "HCZ Checkpoint Intercom";
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
 "wZX" = (
 /obj/effect/paint_stripe/gray,
 /obj/structure/sign/directions/ez{
@@ -37895,6 +40120,13 @@
 /obj/item/storage/pill_bottle/amnesticsb,
 /obj/item/storage/pill_bottle/amnesticsh,
 /obj/item/storage/pill_bottle/amnesticsi,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "HCZ Secure Armoury";
+	name = "HCZ Secure Armoury";
+	pixel_x = -25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lhcz/hczguardgear)
 "xcu" = (
@@ -37932,10 +40164,27 @@
 /area/site53/uhcz/hallways)
 "xfJ" = (
 /obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Eastern Shutter";
+	name = "UHCZ Eastern Shutter";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Checkpoint Gate 2";
+	name = "UHCZ Checkpoint Gate 2";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "UHCZ Eastern Lockdown";
+	name = "UHCZ Eastern Lockdown";
+	pixel_x = 24
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/lhcz/hczguardgear)
+/area/site53/uhcz/securitypost)
 "xfS" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/telescreen/preset/generic{
@@ -38050,47 +40299,46 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
 "xoD" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
 "xpf" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/door/airlock/highsecurity,
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/lowertrams/redline)
 "xpD" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
-"xpZ" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/suit/armor/pcarrier/scp/tactical,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/item/clothing/head/helmet/scp/hczsecurityguard,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
+"xpX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
+"xpZ" = (
+/obj/machinery/light,
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "xqN" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/item/storage/candle_box,
@@ -38148,11 +40396,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"xrI" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/maintenance)
 "xrQ" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -38216,6 +40459,9 @@
 "xvH" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/structure/flora/pottedplant/floorleaf,
+/obj/machinery/camera/network/entrance{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
 "xww" = (
@@ -38253,12 +40499,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
 "xyH" = (
-/obj/effect/floor_decal/corner/red/diagonal,
-/obj/machinery/door/airlock/security{
-	name = "Armoury (Non Lethal)";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/paint_stripe/red,
+/obj/structure/reagent_dispensers/peppertank,
+/turf/simulated/wall/titanium,
 /area/site53/lhcz/hczguardgear)
 "xyT" = (
 /obj/structure/bed/chair{
@@ -38288,12 +40531,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
-"xBJ" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/maintenance)
+"xCn" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "xCR" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -38376,13 +40620,13 @@
 /area/site53/llcz/dclass/armory)
 "xFg" = (
 /obj/structure/lattice,
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
+/obj/structure/catwalk,
+/obj/machinery/light/spot,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
 "xFL" = (
@@ -38404,20 +40648,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
-"xHb" = (
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "UHCZ Secure Maintenance Tunnel Lockdown";
-	name = "UHCZ Secure Maintenance Tunnel Lockdown";
-	pixel_x = 24;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+"xHF" = (
+/obj/structure/sign/scp/euclid_scp{
+	pixel_y = 32
 	},
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/steel_grid,
+/area/site53/ulcz/humanoidcontainment)
 "xHJ" = (
 /obj/structure/table/rack,
 /obj/item/storage/toolbox/electrical,
@@ -38488,6 +40724,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"xPT" = (
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/obj/machinery/door/airlock/glass/civilian{
+	name = "Humanoid Containment Cell"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/ulcz/humanoidcontainment)
 "xQv" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-263 Test Chamber";
@@ -38520,6 +40765,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
+"xRv" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "xSs" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a57,
@@ -38547,20 +40800,19 @@
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp457containment)
 "xSS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/industrial/warning,
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "LCZ Checkpoint Intercom";
+	pixel_y = -32;
+	channels = list(1)
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "xTl" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "xTy" = (
 /obj/effect/floor_decal/corner/orange/mono,
 /obj/structure/cable{
@@ -38610,20 +40862,26 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
 "xVn" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/vending/security{
+	req_access = list()
 	},
-/obj/effect/floor_decal/corner/black/full,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "xVz" = (
-/obj/effect/floor_decal/corner/red/border,
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "xWw" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp263)
@@ -38656,14 +40914,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "xZB" = (
-/obj/effect/floor_decal/corner/red/border,
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "HCZ Security Center";
-	send_access = list(203)
+/obj/structure/bed/chair/office/comfy,
+/obj/effect/landmark/start{
+	name = "HCZ Zone Commander"
 	},
-/turf/unsimulated/mineral,
-/area/site53/lhcz/hczguardgear)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/commanderoffice)
 "xZE" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -38690,20 +40946,48 @@
 /turf/simulated/floor,
 /area/site53/surface/bunker)
 "yaT" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/table/rack,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/obj/item/material/knife/combat,
+/turf/simulated/floor/tiled/dark,
+/area/site53/lhcz/hczguardgear)
+"ybq" = (
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Checkpoint Control Room";
+	name = "UHCZ Checkpoint Control Room";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Checkpoint Outer Window West";
+	name = "UHCZ Checkpoint Outer Window West";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "UHCZ Checkpoint Outer Window East";
+	name = "UHCZ Checkpoint Outer Window East";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/hallways)
-"ybq" = (
-/obj/structure/bed/chair/office/comfy{
-	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "HCZ Zone Commander"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/area/site53/uhcz/securitypost)
 "ybV" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -38717,19 +41001,18 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "ycD" = (
-/obj/machinery/papershredder,
+/obj/structure/bed/chair{
+	dir = 8;
+	pixel_x = -7
+	},
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/power/apc/hyper{
-	dir = 4
-	},
 /obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uhcz/securitypost)
 "ydq" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -38739,10 +41022,26 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
 "yew" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/dark,
-/area/site53/uhcz/commanderoffice)
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "ULCZ North Gate";
+	name = "ULCZ North Gate"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "yhJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/window/brigdoor/northleft{
@@ -43292,11 +45591,11 @@ nVn
 aTJ
 azA
 asA
-lbS
-asA
+aVD
+aTJ
 aVB
-asA
-asA
+aTJ
+aTJ
 asA
 azA
 azA
@@ -43549,11 +45848,11 @@ aVo
 aTJ
 azA
 azA
-asA
-aGM
-aFe
-aGM
-asA
+aTJ
+aMS
+pTX
+aMS
+aTJ
 azA
 azA
 azA
@@ -43797,7 +46096,7 @@ aMS
 aDI
 aTJ
 aTI
-aMS
+aTq
 aUv
 fwG
 aMS
@@ -43806,11 +46105,11 @@ aVu
 aTJ
 azA
 azA
-asA
-apj
-aFe
-aGM
-asA
+aTJ
+lbi
+pTX
+aMS
+aTJ
 azA
 azA
 azA
@@ -44054,20 +46353,20 @@ aVD
 aTJ
 aTJ
 aTZ
-aMS
-aMS
+xRv
+ilH
 aMS
 aMS
 aMS
 aTq
 aVD
-asA
-asA
-lbS
-aGM
-aFe
-aGM
-asA
+aTJ
+aTJ
+aVD
+aMS
+pTX
+aMS
+aTJ
 azA
 azA
 azA
@@ -44312,19 +46611,19 @@ aTM
 aMS
 aMS
 aMS
-aMS
+aTq
 aMS
 aMS
 aMS
 aTq
 aTJ
-aGM
-aXf
-aGM
-aGM
-aFe
-aGM
-asA
+aMS
+wVj
+aMS
+aMS
+pTX
+aMS
+aTJ
 aVS
 aVS
 aVS
@@ -44575,13 +46874,13 @@ aMS
 aMS
 aVy
 aVz
-afp
-afp
-afp
-afp
+iXa
+iXa
+iXa
+iXa
 aNG
-moM
-asA
+nRA
+aTJ
 xZp
 aIR
 aJt
@@ -44826,19 +47125,19 @@ aTM
 aMS
 aMS
 aMS
-aMS
+aTq
 aMS
 aMS
 aMS
 aVr
 aTJ
-aGM
+aMS
 bko
-aGM
-aGM
-aKq
+aMS
+aMS
+cqT
 bko
-asA
+aTJ
 aIo
 aGM
 aGM
@@ -45076,26 +47375,26 @@ azA
 azA
 azA
 aTJ
-aoN
-aMS
+aTJ
+aNb
 aTJ
 aTJ
 aTJ
 aTL
 aMS
-aMS
+aTq
 aMS
 aMS
 aMS
 akH
 aTJ
-asA
-asA
-asA
-asA
+aTJ
+aTJ
+aTJ
+aTJ
 bkw
-asA
-asA
+aTJ
+aTJ
 aIo
 aGM
 aGM
@@ -45333,25 +47632,25 @@ azA
 azA
 azA
 aTJ
-aTJ
-aNb
-aVD
-aTJ
+avx
+aMS
+hhA
+spT
 aVD
 aTP
 aMS
-aMS
+aTq
 jnd
 gci
 jnd
 aVq
 aTJ
-bkm
-bkp
+bWR
+aMS
 bkr
 bku
-bkp
-xrI
+aMS
+aTJ
 aVS
 aGM
 aGM
@@ -45590,25 +47889,25 @@ azA
 azA
 azA
 aTJ
-avx
-aMS
 aoN
+aNO
+nJn
 aTy
 aTJ
 aUg
 aMS
-aMS
+aTq
 jnd
 gci
 jnd
 aVq
 aTJ
-bkm
-bkp
+bWR
+aMS
 bkr
 pFU
-bkp
-xrI
+aMS
+aTJ
 aVS
 aVS
 aVS
@@ -45847,25 +48146,25 @@ azA
 azA
 azA
 aTJ
-aMS
+aoN
 aNO
 aNO
-aNO
+vCX
 aTE
 aMS
 aMS
-aMS
+aTq
 jnd
 gci
 jnd
 aVq
 aTJ
-bkm
-bkp
+bWR
+aMS
 bkr
-bkp
-bkp
-xrI
+aMS
+aMS
+aTJ
 aVS
 aVS
 aVS
@@ -46104,25 +48403,25 @@ azA
 azA
 azA
 aTJ
-aMS
+aoN
 aNO
 aNO
-aNO
-aTE
-aMS
-aMS
-aMS
+nJn
+jaN
+dMS
+dMS
+oni
 xxz
 gci
 wVp
 aVq
 aTJ
 bkn
-bkp
+aMS
 bks
-bkp
-bkx
-xrI
+aMS
+bko
+aTJ
 aVS
 aHO
 aIt
@@ -46361,7 +48660,7 @@ azA
 azA
 azA
 aTJ
-aDI
+aoN
 aPV
 aMS
 aNs
@@ -46374,12 +48673,12 @@ aTJ
 aTJ
 aVD
 aVD
-xrI
-xrI
-xrI
-xrI
-xrI
-xBJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aVD
 aVS
 aIj
 aIu
@@ -46632,16 +48931,16 @@ goj
 aTJ
 azA
 azA
-aFE
-aFE
-aFE
-aFE
-aFE
+aVS
+aVS
+aVS
+aVS
+aVS
 aVS
 aVS
 aVS
 ahW
-aFE
+aVS
 aVS
 aHJ
 qCZ
@@ -46889,14 +49188,14 @@ aVk
 aTJ
 azA
 azA
-aFE
+aVS
 agR
 ahy
 ahH
 bha
 bha
 bha
-aig
+bha
 aiB
 aiD
 aVS
@@ -47146,16 +49445,16 @@ bTG
 aTJ
 azA
 azA
-aFE
+aVS
 ahd
-adC
+ahd
 ahK
 bhb
 bhb
 bhb
 bhc
 aBV
-aFE
+aVS
 aVS
 aVS
 aKh
@@ -47403,9 +49702,9 @@ aMS
 aTJ
 azA
 azA
-aFE
+aVS
 bgm
-adC
+ahd
 aMA
 aeP
 aeP
@@ -47660,10 +49959,10 @@ rzX
 aTJ
 azA
 azA
-aFE
+aVS
 ahn
 ahD
-agm
+aMA
 aeP
 aHU
 aIv
@@ -47915,12 +50214,12 @@ aTJ
 aTJ
 aTJ
 aVD
-aFE
-aFE
-aFE
+bgX
+bgX
+aVS
 ahw
-acP
-agm
+mfY
+aMA
 aeP
 ahf
 aIw
@@ -48172,10 +50471,10 @@ azA
 azA
 azA
 azA
-aFE
-agy
-agQ
-ahx
+bgX
+agh
+bgV
+mEO
 ahx
 agz
 aeP
@@ -48429,8 +50728,8 @@ azA
 azA
 azA
 azA
-aFE
-agm
+bgX
+aiq
 aeP
 aeP
 aeP
@@ -48686,8 +50985,8 @@ azA
 azA
 azA
 azA
-aFE
-agm
+bgX
+aiq
 aeP
 aHk
 aHr
@@ -48938,13 +51237,13 @@ azA
 azA
 azA
 azA
-aFE
-aFE
-aFE
-aFE
-aFE
-aFE
-agm
+bgX
+bgX
+bgX
+bgX
+bgX
+bgX
+aiq
 aeP
 aHl
 aHs
@@ -49195,13 +51494,13 @@ azA
 azA
 azA
 azA
-aFE
+bgX
 agh
 agQ
+agQ
+agQ
+agQ
 vmG
-agQ
-agQ
-agz
 aeP
 aHm
 aHs
@@ -49452,11 +51751,11 @@ azA
 azA
 azA
 azA
-aFE
-agm
-aFE
-aFE
-aFE
+bgX
+aiq
+bgX
+bgX
+bgX
 aeP
 aeP
 aeP
@@ -49709,9 +52008,9 @@ azA
 azA
 azA
 azA
-aFE
-agm
-aFE
+bgX
+aiq
+bgX
 azA
 azA
 aeP
@@ -49966,9 +52265,9 @@ azA
 azA
 azA
 azA
-aFE
-agn
-aFE
+bgX
+aiq
+bgX
 azA
 azA
 aeP
@@ -50223,9 +52522,9 @@ azA
 azA
 azA
 azA
-aFE
-agm
-aFE
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -50480,9 +52779,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -50737,9 +53036,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -50994,9 +53293,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -51251,9 +53550,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -51508,9 +53807,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -51765,9 +54064,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -52022,9 +54321,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -52279,9 +54578,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
@@ -52536,9 +54835,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 bkq
 bkq
@@ -52793,9 +55092,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 bkq
 hkC
@@ -53050,9 +55349,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 bkq
 mRy
@@ -53307,9 +55606,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 bkq
 mRy
@@ -53564,9 +55863,9 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 bkq
 tyX
@@ -53821,10 +56120,10 @@ azA
 azA
 azA
 azA
-ahm
-agn
-ahm
-ahm
+bgX
+aiq
+bgX
+bgX
 bkq
 mRy
 cVc
@@ -53863,20 +56162,20 @@ azA
 azA
 azA
 azA
-aMd
-aMd
-aMd
+aMB
+aMB
+aMB
 aLA
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
 azA
 azA
 azA
@@ -54078,10 +56377,10 @@ azA
 azA
 azA
 azA
-ahm
-agm
 bgX
-ahm
+aiq
+bgX
+bgX
 bkq
 mRy
 pPO
@@ -54120,7 +56419,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 aJH
 aKG
 aKw
@@ -54129,11 +56428,11 @@ aTj
 aJM
 aKQ
 aLf
-aMd
+aMB
 aKO
 aKO
 uWH
-aMd
+aMB
 azA
 azA
 azA
@@ -54335,10 +56634,10 @@ azA
 azA
 azA
 azA
-ahm
+bgX
 aiq
-ahm
-ahm
+bgX
+bgX
 bkq
 nIS
 uBV
@@ -54377,7 +56676,7 @@ azA
 azA
 azA
 azA
-aPh
+amm
 aJI
 aJM
 aKx
@@ -54386,17 +56685,17 @@ aWh
 aSv
 aKR
 aLB
-aMd
+aMB
 ajw
 aJM
 sqS
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
 azA
 azA
 azA
@@ -54592,9 +56891,9 @@ azA
 azA
 azA
 azA
-ahm
+bgX
 aiq
-ahm
+bgX
 azA
 bkq
 bkq
@@ -54612,7 +56911,7 @@ azA
 aVS
 aGM
 qKl
-cIC
+aGM
 aVS
 azA
 azA
@@ -54634,7 +56933,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 aMq
 aKJ
 aMq
@@ -54643,7 +56942,7 @@ aMy
 aJM
 aKS
 aLB
-aMd
+aMB
 ajw
 aJM
 aEx
@@ -54653,7 +56952,7 @@ aJM
 aLZ
 aJM
 aJM
-aMd
+aMB
 azA
 azA
 azA
@@ -54849,9 +57148,9 @@ azA
 azA
 azA
 azA
-ahm
+bgX
 aiq
-ahm
+bgX
 azA
 azA
 azA
@@ -54891,7 +57190,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 aTs
 aJM
 aJT
@@ -54900,17 +57199,17 @@ aMy
 aJM
 aKS
 aLi
-aMd
-aMd
+aMB
+aMB
 ddw
-aMd
+aMB
 amm
 aLC
 aJM
 aJM
 aJM
 aMh
-aMd
+aMB
 azA
 azA
 azA
@@ -55106,23 +57405,23 @@ azA
 azA
 azA
 azA
-ahm
-bgV
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aeS
+aeS
+aeS
+aeS
+nyL
+aeS
+aeS
+aeS
+pVB
 aVS
 aGM
 qKl
@@ -55148,7 +57447,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 aJM
 aJM
 aJU
@@ -55167,7 +57466,7 @@ aJM
 aJM
 aJM
 aJM
-aMd
+aMB
 azA
 azA
 azA
@@ -55363,23 +57662,23 @@ azA
 azA
 azA
 azA
-ahm
-bgW
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aeS
+aeS
+aLd
+mNs
+rFI
+rZd
+tIS
+wTN
+aLd
+aLd
 aVS
 qHF
 qKl
@@ -55405,7 +57704,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 aTW
 aJM
 msC
@@ -55424,7 +57723,7 @@ aJM
 aMa
 aJM
 aJM
-aMd
+aMB
 azA
 azA
 azA
@@ -55620,23 +57919,23 @@ azA
 azA
 azA
 azA
-ahm
-bgV
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
-azA
 aeS
-aeS
-aeS
-aeS
-nyL
-aeS
-aeS
-aeS
-pVB
+xYA
+aLd
+aLd
+aLd
+aLd
+aLd
+aLd
+aLd
+rZd
 aVS
 aGM
 qKl
@@ -55662,7 +57961,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 bgz
 aJM
 aJM
@@ -55681,7 +57980,7 @@ aJM
 aJM
 aJM
 aJM
-aMd
+aMB
 azA
 azA
 azA
@@ -55877,23 +58176,23 @@ azA
 azA
 azA
 azA
-ahm
+bgX
 aiq
-ahm
+bgX
 azA
 azA
 azA
 azA
 aeS
-aeS
+btZ
 aLd
-mNs
-rFI
-rZd
-tIS
-wTN
+aLb
+aLJ
+aLb
+brU
 aLd
 aLd
+aPH
 pkC
 aGM
 aWF
@@ -55919,7 +58218,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 aJM
 aJM
 aJU
@@ -55928,17 +58227,17 @@ aMy
 aJM
 aKS
 aLk
-aMd
-aMd
+aMB
+aMB
 aMy
-aMd
+aMB
 amm
 aLH
 aJM
 aJM
 aJM
 aMh
-aMd
+aMB
 azA
 azA
 azA
@@ -56134,23 +58433,23 @@ azA
 azA
 azA
 azA
-ahm
+bgX
 aiq
-ahm
+bgX
 azA
 azA
 azA
 azA
 aeS
-xYA
+btZ
 aLd
 aLd
+eeH
+aLd
+eeH
 aLd
 aLd
-aLd
-aLd
-aLd
-rZd
+jYH
 pkC
 aGM
 aLv
@@ -56176,7 +58475,7 @@ azA
 azA
 azA
 azA
-aMd
+aMB
 aJL
 aJM
 aJZ
@@ -56185,7 +58484,7 @@ aMy
 aLh
 iNl
 aLh
-aMd
+aMB
 izM
 iqI
 aKB
@@ -56195,7 +58494,7 @@ aJM
 aMc
 aJM
 aLB
-aMd
+aMB
 azA
 azA
 azA
@@ -56391,29 +58690,39 @@ azA
 azA
 azA
 azA
-ahm
+bgX
 aiq
-ahm
-ahm
+bgX
+bgX
 azA
 azA
 azA
 aeS
-btZ
-aLd
-aLb
-aLJ
-aLb
-brU
+aKZ
 aLd
 aLd
-aPH
+aLd
+aLd
+aLd
+aLd
+aLd
+aPe
 pkC
 aGM
 jVk
 aGM
 aVS
 azA
+agU
+agU
+agU
+agU
+agU
+agU
+agU
+agU
+agU
+agU
 azA
 azA
 azA
@@ -56423,17 +58732,7 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-aMd
+aMB
 aJM
 aJM
 aKD
@@ -56447,12 +58746,12 @@ aJM
 aJM
 aJU
 scy
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
 azA
 azA
 azA
@@ -56648,29 +58947,39 @@ azA
 azA
 azA
 azA
-ahm
-agm
 bgX
-ahm
+aiq
+bgX
+bgX
 azA
 azA
 azA
 aeS
-btZ
+jFN
+aMj
+aLz
+aLx
+aLz
+fRi
 aLd
 aLd
-eeH
-aLd
-eeH
-aLd
-aLd
-jYH
+aPB
 pkC
 pSE
 jVk
 pSE
 aVS
 azA
+agU
+jbo
+aVb
+aVb
+aEE
+biQ
+xTl
+aVb
+wkv
+agU
 azA
 azA
 azA
@@ -56680,30 +58989,20 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-aMd
+aMB
 aJS
 aKL
-aMd
-aMd
-aMd
+aMB
+aMB
+aMB
 aJM
 aKT
 aMh
-aMd
+aMB
 aTs
 aJZ
 aXC
-aMd
+aMB
 azA
 azA
 azA
@@ -56905,30 +59204,39 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
-ahm
+bgX
+aiq
+bgX
+bgX
 azA
 azA
 azA
 aeS
-aKZ
+mij
 aLd
 aLd
+eeH
+aLd
+oJR
 aLd
 aLd
-aLd
-aLd
-aPe
-aeS
+aPI
 aVS
 aVS
 tjj
 aVS
 aVS
-aVS
-aVS
+azA
+agU
+jxJ
+aVb
+aVb
+aVb
+aVb
+cqc
+aVb
+gyj
+agU
 azA
 azA
 azA
@@ -56938,29 +59246,20 @@ azA
 azA
 azA
 azA
+aMB
+aMB
+aMB
+aMB
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-aMd
-aMd
-aMd
-aMd
-azA
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
-aMd
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
+aMB
 azA
 azA
 azA
@@ -57162,39 +59461,39 @@ azA
 azA
 azA
 azA
-ahm
-agn
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
 aeS
-jFN
-aMj
-aLz
-aLx
-aLz
-fRi
+eeH
 aLd
-aPB
-jES
+aLd
+aLd
+aLd
+rka
+iql
+iql
+iql
+wVr
+cjx
+hyd
 aGM
-aGM
-jLw
-aGM
-aGM
-moM
 aVS
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+agU
+biQ
+aVb
+aVb
+aFD
+biQ
+xTl
+aVb
+wkv
+agU
 azA
 azA
 azA
@@ -57419,39 +59718,39 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
 aeS
-mij
+aKY
+aLd
+aLb
+brU
+aLb
+brU
 aLd
 aLd
-eeH
 aLd
-oJR
-aLd
-aPI
-pNO
+aMd
 aGM
-aKq
-jLw
-aKq
-aGM
+aPh
 aGM
 aVS
 azA
 agU
+cme
+aVb
+aVb
+lWh
 agU
 agU
 agU
 agU
-azA
-azA
-azA
+agU
 azA
 azA
 azA
@@ -57676,39 +59975,39 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
 aeS
+aeS
+aLd
+wSy
 eeH
 aLd
+eeH
+wSy
 aLd
-aLd
-aLd
-rka
-iql
-iql
-nTU
-aVK
-kQL
-hyd
-aKq
-aKq
-aEt
+dIs
+aMd
+aGM
+aPh
+cIC
 aVS
 azA
+agU
+iTk
+aMH
+aVb
+pyn
 agU
 iYX
 nFS
 lYV
 agU
-azA
-azA
-azA
 azA
 azA
 azA
@@ -57933,39 +60232,39 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
+azA
 azA
 azA
 azA
 azA
 aeS
-aKY
-aLd
-aLb
-brU
-aLb
-brU
-aLd
-aMi
-pNO
-aWJ
-aKq
-xTl
-aKq
-aGM
-bhg
+aeS
+jKi
+bhP
+bhP
+bhP
+bhP
+bhP
+jOV
+nyh
+nTU
+xpX
+enN
 aVS
 azA
 agU
+clC
+qhP
+aVb
+aVb
+fYk
 eQq
 eQq
 kFd
 agU
-azA
-azA
-azA
 azA
 azA
 azA
@@ -58190,39 +60489,39 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
-aeS
-aeS
-aLd
-wSy
-eeH
-aLd
-eeH
-wSy
-dIs
-pNO
-aWJ
-aGM
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+cqF
+aGZ
 ing
 hUS
 ddz
-aGM
-aVS
 azA
+agU
+agU
+bia
+agU
+agU
 agU
 woN
 eQq
 whL
 agU
-azA
-azA
-azA
 azA
 azA
 azA
@@ -58447,39 +60746,39 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
 azA
 azA
 azA
 azA
 azA
-aeS
-aeS
-jKi
-agU
-agU
-agU
-agU
-agU
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 cqF
-aVi
-mXc
+aGZ
 mXc
 qPN
-bhB
 biy
-agU
+biy
+bjv
 kVb
+qhP
+vLm
 agU
 agU
-fYk
 agU
 agU
-azA
-azA
-azA
+agU
+agU
 azA
 azA
 azA
@@ -58704,9 +61003,15 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58716,26 +61021,20 @@ azA
 azA
 azA
 agU
-aMV
-odC
-aaJ
-eiF
-ebw
-jQI
 lkI
 bgK
-aDO
-dpC
-ewJ
+bjp
+aVb
+aVb
+iRt
+aVb
+qhP
+aVb
+aVY
+aVb
+bVr
+wkv
 agU
-agU
-agU
-odC
-aDO
-odC
-agU
-azA
-azA
 azA
 azA
 azA
@@ -58961,9 +61260,15 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58973,26 +61278,20 @@ azA
 azA
 azA
 agU
-aMV
-aDO
-aDO
-aDO
-tzd
-gjb
-azx
-viG
-vea
-dpC
-aDO
+biK
+qhP
+aVb
+aVb
+aVb
 sbE
 aDR
 odC
-aDO
-aDO
-vVl
+aVb
+mEc
+aVb
+aVb
+wkv
 agU
-azA
-azA
 azA
 azA
 azA
@@ -59218,9 +61517,15 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59230,26 +61535,20 @@ azA
 azA
 azA
 agU
-pyn
-aDO
-agU
-pXS
-wkv
-mBw
 bgF
-bgK
-aDO
-dpC
-aDO
-sbE
-aDR
-aDO
-aDO
-aDO
-vVl
+qhP
+aVb
+aVb
+aVb
+bhB
+blg
+mNl
+aGA
+gKy
+aVb
+aVb
+wkv
 agU
-azA
-azA
 azA
 azA
 azA
@@ -59475,9 +61774,15 @@ azA
 azA
 azA
 azA
-ahm
-agm
-ahm
+bgX
+aiq
+bgX
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59487,26 +61792,20 @@ azA
 azA
 azA
 agU
-kFS
-blf
-aMH
-aaH
-jQI
-aDO
 azx
-viG
-gyj
-dpC
-aDO
+qhP
+aVb
+aVb
+aEE
 fwS
 bhf
+bis
 aDO
-aDO
-aDO
-qqQ
 agU
-azA
-azA
+qqQ
+aVb
+aEA
+agU
 azA
 azA
 azA
@@ -59732,9 +62031,15 @@ azA
 azA
 azA
 azA
-ahm
-agn
-ahm
+bgX
+aiq
+bgX
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59744,26 +62049,20 @@ azA
 azA
 azA
 agU
-agU
-agU
-agU
-aMU
-jQI
-aDO
-bgD
-qhP
-aDO
-dpC
-aDO
+bgF
+rKp
+jxY
+aVb
+xSS
 fwS
 erI
-aDO
-aDO
-aDO
-vVl
+aao
+aEq
 agU
-azA
-azA
+gmT
+aVb
+pid
+agU
 azA
 azA
 azA
@@ -60000,27 +62299,27 @@ ahm
 ahm
 azA
 azA
+azA
+azA
+azA
+azA
+azA
+azA
 agU
-aDR
-aDO
-sek
-tzd
-gjb
-aDO
-aDO
+qqQ
 bgI
-aDO
 dpC
-aDO
-sbE
-aDR
+dpC
+suY
+yew
+bip
 bpz
-aDO
+bYK
 iCg
 vVl
+biD
+aVb
 agU
-azA
-azA
 azA
 azA
 azA
@@ -60257,27 +62556,27 @@ nTF
 ahm
 azA
 azA
+azA
+azA
+azA
+azA
+azA
+azA
 agU
-imN
-blf
-riw
-ycD
-lTO
-aVw
+bgF
+bgW
+jxY
 aVb
-mXc
-blf
-uDy
-xSS
+sPg
 rcM
 lKF
 ren
 cYI
 hgr
 blf
+tpZ
+fQz
 agU
-azA
-azA
 azA
 azA
 azA
@@ -60508,33 +62807,33 @@ acP
 ahm
 ahm
 ahm
-abI
-abI
+aFE
+aFE
 ftf
-abI
-abI
-abI
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-fGE
-agU
-agU
-agU
-aCb
-aCb
-agU
-agU
-agU
+aFE
 azA
 azA
+azA
+azA
+azA
+azA
+azA
+azA
+agU
+agU
+agU
+agU
+agU
+agU
+aXK
+agU
+aCb
+agU
+cqF
+bkh
+bkh
+bkh
+agU
 azA
 azA
 azA
@@ -60765,33 +63064,33 @@ acP
 ahm
 azA
 azA
-abI
-akO
-muz
-adx
-xvH
-aZt
-acp
-acp
-aaA
-acp
-acp
-aZt
-adx
-adx
-adx
-xvH
-adx
-epS
-adx
-adx
-aOU
-aOU
-adx
-abI
+azA
+aFE
+ftf
+aFE
 azA
 azA
 azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+acs
+agU
+bYK
+agU
+agU
+bYK
+bYK
+bYK
+agU
 azA
 azA
 azA
@@ -61023,32 +63322,32 @@ ahm
 azA
 azA
 abI
-adx
-acB
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-adx
 abI
-azA
-azA
-azA
+bhK
+abI
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aig
+aXK
+agU
+aCb
+agU
+agU
+bkh
+bkh
+bkh
+agU
 azA
 azA
 azA
@@ -61281,31 +63580,31 @@ azA
 azA
 abI
 adx
-acB
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-aOU
-adx
-abI
-azA
-azA
-azA
+pqx
+qnc
+eCZ
+qnc
+qnc
+qnc
+eCZ
+qnc
+qnc
+qnc
+eCZ
+qnc
+qnc
+qnc
+eCZ
+ihx
+vea
+agU
+wZP
+aVW
+pXS
+bhO
+bhO
+bhO
+agU
 azA
 azA
 azA
@@ -61540,29 +63839,29 @@ abI
 adx
 acB
 aOU
-akO
-azF
-adx
-adx
-adx
-adx
-adx
-adx
-adx
-adx
-adx
-xvH
-ekr
-adx
-adx
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+jfF
 bkh
-adx
-adx
-adx
-abI
-azA
-azA
-azA
+bkh
+ujf
+aXT
+aXT
+aXT
+aXT
+aXT
+agU
 azA
 azA
 azA
@@ -61797,29 +64096,29 @@ abI
 acu
 acB
 aOU
-eVx
-shr
-aiw
-aiw
-aiw
-aiw
-aiw
-aiw
-aiw
-aiw
-aiw
-aiw
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-abI
-azA
-azA
-azA
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+jfF
+bkh
+bkh
+ujf
+aXT
+aXT
+aXT
+aXT
+pox
+agU
 azA
 azA
 azA
@@ -62054,29 +64353,29 @@ abI
 adx
 acB
 aOU
-adx
-aiw
-acs
-aXt
-aXK
-aXJ
-aXO
-aXJ
-aXN
-aXN
-aoG
-aXJ
-abI
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+aOU
+jfF
+bkh
+bkh
+ujf
+aXT
+aXT
+aXT
+aXT
+aXT
+agU
 azA
 azA
 azA
@@ -62311,29 +64610,29 @@ hFp
 adx
 acB
 aOU
+akO
+azF
 adx
-aiw
-aoG
-aXJ
-aXL
-aXt
-aXP
-aXR
-aXt
-aXt
-aXQ
-aXT
-abI
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+adx
+adx
+adx
+adx
+adx
+adx
+adx
+adx
+adx
+adx
+xvH
+agU
+agU
+fGE
+agn
+bjT
+agn
+bjT
+agn
+agU
 azA
 azA
 azA
@@ -62568,29 +64867,29 @@ abI
 bMS
 acB
 aOU
-adP
+eVx
+shr
 aiw
-aBI
-aXK
-aXM
-aXN
-aoG
-aBI
-aXN
-aoG
-aXN
-aoG
-abI
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aiw
+aiw
+aiw
+aiw
+aiw
+aiw
+aiw
+aiw
+aiw
+aiw
+aiw
+agU
+agU
+agU
+agU
+agU
+agU
+agU
+agU
+agU
 azA
 azA
 azA
@@ -62837,9 +65136,9 @@ eEQ
 aXQ
 aXt
 aXQ
+eEQ
+aXQ
 abI
-azA
-azA
 azA
 azA
 azA
@@ -63095,8 +65394,8 @@ abI
 abI
 abI
 orD
-azA
-azA
+abI
+orD
 azA
 azA
 azA
@@ -64875,8 +67174,8 @@ azA
 aFE
 gmw
 laQ
-adC
-adC
+fcp
+lZE
 abI
 acL
 acB
@@ -65131,8 +67430,8 @@ azA
 azA
 aFE
 acx
-acP
-adC
+ouf
+pAo
 xfd
 abI
 acN
@@ -66936,7 +69235,7 @@ aej
 agj
 aag
 mFY
-mFY
+ooD
 aag
 gqv
 gqv
@@ -67193,7 +69492,7 @@ aen
 abE
 aaf
 ahe
-ahe
+jQI
 aaf
 aae
 aae
@@ -67450,7 +69749,7 @@ aen
 abE
 aaf
 ahe
-ahe
+jQI
 aaf
 aae
 aae
@@ -67707,7 +70006,7 @@ aen
 abE
 aaf
 ahe
-ahe
+jQI
 aaf
 aae
 aae
@@ -67964,7 +70263,7 @@ aen
 agk
 abO
 aak
-aak
+bTJ
 apQ
 abX
 oJB
@@ -68221,7 +70520,7 @@ aen
 aPG
 aac
 aKP
-aKP
+eto
 aac
 aac
 aac
@@ -68478,7 +70777,7 @@ aeo
 uXT
 aac
 aaf
-aaf
+qdk
 aZu
 fOI
 aac
@@ -68735,7 +71034,7 @@ hCY
 agp
 aac
 bBS
-aaf
+qdk
 aqO
 ayS
 aac
@@ -68992,7 +71291,7 @@ aer
 aai
 aKP
 aaf
-aaf
+qdk
 aae
 abL
 aac
@@ -69249,7 +71548,7 @@ aer
 aai
 aKP
 aaf
-aaf
+qdk
 aae
 abL
 aac
@@ -72590,7 +74889,7 @@ bdp
 abx
 sCI
 dmR
-lTp
+bWT
 abW
 abY
 azA
@@ -73104,7 +75403,7 @@ mNN
 abx
 txd
 cLI
-adU
+xpf
 tWi
 abY
 azA
@@ -73361,7 +75660,7 @@ lOF
 abx
 sCI
 cLI
-adU
+xpf
 abW
 abY
 azA
@@ -73375,8 +75674,8 @@ aPK
 aPK
 aPK
 aPK
+aPK
 aOQ
-aPM
 aPM
 agE
 aLN
@@ -73616,9 +75915,9 @@ xyT
 rBZ
 acW
 abx
-sCI
-cLI
-adU
+mXl
+oau
+dBg
 abW
 abY
 azA
@@ -73631,8 +75930,8 @@ azA
 azA
 azA
 azA
+azA
 aPK
-anC
 anC
 aph
 aPJ
@@ -73875,7 +76174,7 @@ aLT
 abY
 myM
 acE
-adU
+xpf
 abW
 abY
 azA
@@ -73888,8 +76187,8 @@ azA
 azA
 azA
 azA
+azA
 aqR
-anD
 aeN
 aeN
 aeN
@@ -74131,8 +76430,8 @@ ahR
 ahR
 abY
 kSE
-cLI
-adU
+lTp
+xpf
 abW
 abY
 azA
@@ -74145,8 +76444,8 @@ azA
 azA
 azA
 azA
+azA
 aqR
-anD
 aeD
 amB
 amB
@@ -74388,8 +76687,8 @@ aMb
 smh
 abY
 eir
-cLI
-adU
+lTp
+xpf
 abW
 abY
 azA
@@ -74402,8 +76701,8 @@ azA
 azA
 azA
 azA
-aYw
-anD
+azA
+aqR
 aeD
 aeL
 aeL
@@ -74645,22 +76944,22 @@ khX
 aav
 abY
 omv
-cLI
-adU
+lTp
+xpf
 bDX
 abY
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+ass
+ass
+ass
+ass
+ass
+ass
 azA
 aqR
-anD
 aeD
 aUl
 aUl
@@ -74902,22 +77201,22 @@ nhM
 aav
 abY
 ooJ
-cLI
-adU
+lTp
+xpf
 abW
 abY
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+tRU
+phw
+ass
+aEC
+aga
+ass
 azA
 aqR
-anD
 aeN
 aeN
 aoz
@@ -75159,47 +77458,47 @@ aId
 aId
 adN
 bTH
-cLI
-adU
+lTp
+xpf
 abW
 abY
-aec
-ass
-ass
-ass
-ass
-ass
-ass
-ass
 azA
+azA
+azA
+ass
+uXa
+aEC
+oVt
+aEC
+aEC
+ass
 azA
 aoy
-anD
-anD
-anD
-anD
-aow
-anD
-anD
-anD
-aow
-anD
-anD
-anD
-aow
-anD
-anD
-anD
-aow
-anD
-anD
-anD
-aow
-anD
-anD
-anD
-anD
-anD
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
+aoy
 aoy
 azA
 abU
@@ -75416,48 +77715,48 @@ aCq
 aCq
 aoq
 qrM
-cLI
-adU
-adU
-adU
-adU
-aga
-bjh
-aga
+lTp
+xpf
+abW
+abY
+azA
+azA
+azA
+ass
+iRz
+viK
+qkl
 aEC
 aEC
-aEC
 ass
 ass
-ass
-ass
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
-aoy
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 abU
 ada
@@ -75673,20 +77972,20 @@ aId
 aId
 adN
 kKf
-gVe
-aFR
-aFR
-aFR
-aFR
-aGB
-aFS
-aGB
-aGB
-aFp
+lTp
+xpf
+euO
+ass
+ass
+ass
+ass
+ass
+vVj
+riw
+ass
+klC
 aEC
-bjh
-bqI
-clC
+krd
 ass
 ass
 ass
@@ -75695,26 +77994,26 @@ ass
 ass
 ass
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+ass
 azA
 abU
 ada
@@ -75929,49 +78228,49 @@ azA
 azA
 azA
 abY
-ylD
-efe
-adU
-kAL
-adU
-adU
+hah
+gVe
+cor
+aFR
+aDD
+aFS
+aDD
+aFS
+aDD
+aGB
+aGB
+eYt
+aGB
+aGB
+aFp
 aEC
-bjh
 aEC
-aEC
-aFr
-aEC
-bjh
-aEC
-aEC
-krd
+bhL
+fva
+bhV
 ass
-jFe
-krW
+aEC
+aEC
 ass
 sjI
 eAb
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+viG
+agy
+ass
+viG
+agy
+ass
+viG
+agy
+ass
+ipQ
+nWH
+ipQ
+ocR
+uGR
+ocR
+ass
 azA
 abU
 ada
@@ -76185,50 +78484,50 @@ azA
 azA
 azA
 azA
-abY
-abY
-abY
-abY
-abY
-abY
 aec
+abW
+adU
+adU
+adU
 ulD
-ass
-ass
-mNl
-hat
-aGs
+aEC
+ulD
+aEC
+ulD
+aEC
+aEC
 bjh
-biV
-bit
-biX
+aEC
+aEC
+aFr
+aEC
+aEC
+aEC
+aEC
+vwK
+snm
+hbx
+fTQ
 ass
 fyn
 aEC
 ass
-fyn
-aEC
+bhE
+kFS
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+bhE
+kFS
+ass
+bhE
+kFS
+ass
+qnO
+aaJ
+bhZ
+aaJ
+bhZ
+hUo
+ass
 azA
 abU
 ada
@@ -76442,50 +78741,50 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+abY
+ylD
+efe
+kAL
+adU
+ulD
+ocX
+ulD
+ocX
+ulD
+aEC
+ocX
+bjh
+aEC
+biX
+hat
+biX
+jhG
+biV
+bit
+dRU
 ass
+ltH
+ikz
 ass
-ass
-ass
-ass
-wDw
-ass
-ass
-esS
-bQJ
-esS
-ass
-wnA
-iRz
-ass
-wnA
 qiu
+wnA
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+viG
+ilx
+ass
+viG
+ilx
+ass
+viG
+ilx
+ass
+aEC
+aEC
+bhU
+bhU
+bhU
+eKg
+ass
 azA
 abU
 ada
@@ -76699,50 +78998,50 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aec
+aec
+aec
+aec
+bjf
 ass
-ioc
-acl
-biS
-fQK
-oMg
-aEC
+ass
+ass
+ass
+ass
+tWM
+ass
+ass
+ass
+ass
+wDw
+ass
+ass
 ntR
+bQJ
+uTp
 ass
-dcB
 aEC
-bnp
+ikz
+aEC
 aEC
 eED
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+shV
+qJk
+ass
+ixi
+ipx
+ass
+slq
+kdH
+ass
+ass
+bhT
+bhU
+bhU
+bhU
+dcB
+ass
 azA
 abU
 ada
@@ -76959,47 +79258,47 @@ azA
 azA
 azA
 azA
+aec
+aec
+aec
 azA
 azA
 azA
-azA
-azA
-azA
-aPk
-kry
-ocR
-xcu
-biM
-biI
-bIZ
-aEC
-cDN
-aEC
-aEC
-bIZ
-aEC
-biH
+ass
+ass
 ass
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+ioc
+acl
+biS
+oIp
+oMg
+aEC
+ybq
+ass
+aEC
+wut
+hbx
+hbx
+hbx
+kmN
+qPJ
+hls
+aXJ
+aFU
+pNO
+biM
+hls
+hls
+tgo
+kmN
+hbx
+oUj
+ihv
+cTw
+bjo
+ass
 azA
 abU
 ada
@@ -77222,41 +79521,41 @@ azA
 azA
 azA
 azA
+azA
+azA
+azA
+azA
+aPk
+kry
+bIZ
+xcu
+cDN
+aEF
+fhQ
+ikz
+suu
+aEC
+aEC
+fhQ
+aEC
+aEC
+aEC
+nQR
+aaA
+bjw
+rPG
+imN
+bjm
+bjm
+aaA
+eOZ
+aEC
+aEC
+bhU
+bjt
+dBT
+mkS
 ass
-ioc
-aGW
-bTo
-jQM
-dRU
-aEC
-nan
-ass
-pul
-aEC
-aEC
-aEC
-slq
-ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
 azA
 abU
 ada
@@ -77479,41 +79778,41 @@ azA
 azA
 azA
 azA
+azA
+azA
+azA
+azA
 ass
+ioc
+aGW
+bTo
+mBw
+bie
+aEC
+tzE
 ass
-hTi
-ass
-ass
-esS
-hDv
-esS
-ass
-uoM
+fQK
 aEC
 aEC
 aEC
-deH
+mfw
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+ass
+aEl
+ass
+ass
+ass
+biY
+mhP
+ass
+ass
+aXO
+lus
+hzA
+bii
+aBX
+ass
 azA
 abU
 ada
@@ -77723,13 +80022,12 @@ bIm
 kxP
 aKM
 aKM
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
+bIm
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -77737,40 +80035,41 @@ azA
 azA
 azA
 ass
-aGA
-rqW
-aGA
-bjh
-fLX
-qEN
-pPg
 ass
-bkg
-gHD
-twT
-rdx
-lfB
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+ass
+ass
+ass
+lcy
+ass
+ass
+bhR
+hDv
+hxM
+ass
+pul
+aEC
+aEC
+aEC
+xpZ
+ass
+gHP
+xcu
+xcu
+xcu
+aow
+ass
+uDy
+aFU
+dsV
+ass
+aXR
+bjt
+bhU
+cTw
+bjo
+ass
 azA
 abU
 ada
@@ -77980,54 +80279,54 @@ bIm
 vww
 aKM
 aKM
-aBo
-aBA
-aBA
-gpO
-aBA
-aBA
+bIm
 aBo
 aBo
 aBo
 aBo
 aBo
 aBo
-aBo
-aBo
+azA
+azA
+azA
+azA
+azA
+ass
+adP
+aMi
+rPv
+aga
+ezj
+pPg
+rqW
+pPg
+mVs
+fLX
+qEN
+kys
+ass
+uoM
 aEC
-uAj
-aGB
-oQu
-aGB
-pIF
-aaI
+aEC
+aEC
+deH
 ass
+aVi
+xcu
+xcu
+xcu
+esS
 ass
+afl
+reE
+jGl
 ass
+qUS
+bjt
+bhU
+nan
+gCY
 ass
-ass
-ass
-ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
 azA
 abU
 ada
@@ -78237,54 +80536,54 @@ bIm
 rkv
 aKM
 aKM
+bIm
+aBA
+aBA
+gpO
+aBA
+aBA
 aBo
-xXC
-ajR
-ajR
-ajR
-aBT
 aBo
-aBU
-yaT
-bik
-yaT
-bik
-yaT
-bik
-aEC
-aEC
-tfe
 ass
 ass
+ass
+ass
+ass
+ass
+aEC
+jFe
+aGB
+oQu
+aGB
+pIF
+aEC
+aEC
+aEC
+aEC
+vBn
+ass
+bkg
+gHD
+twT
+rdx
+lfB
+ass
+bij
+xcu
+xcu
+xcu
+gjb
+ass
+afl
+reE
+biz
+ass
+ubf
+bjt
+bhU
+bii
 aBX
 ass
-ass
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
 azA
 abU
 ada
@@ -78492,56 +80791,56 @@ aVs
 aVs
 urr
 rkv
-obI
-fSL
-fFD
-iqc
-iqc
-ggM
+aKM
+aKM
+bIm
+xXC
 ajR
 ajR
-xpf
-aBU
-aBU
+ajR
+aBA
+rFw
+aBo
+aga
 bik
-aBU
+aga
 bik
-aBU
+aga
 bik
 aEC
-aEC
-krd
+aFr
+vwK
+eEi
+hbx
+hbx
+hbx
+hbx
+ycD
+pFH
+eiF
 ass
-dII
-paF
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-bhu
-wio
-atV
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+ass
+ass
+ass
+ass
+ass
+ass
+iik
+iik
+iik
+pLN
+ass
+oAS
+bjm
+sHS
+ass
+mmM
+ikz
+aEC
+ocX
+gHD
+ass
 azA
 abU
 abU
@@ -78749,56 +81048,56 @@ lMF
 lMF
 bIm
 rkv
-jKc
-aKM
-aBo
-xKh
-ajR
-qJM
-ajR
-aBT
-aBo
-mmM
-ocX
-bik
-ocX
-bik
-ocX
-bik
-aGs
-aGs
-aGs
+obI
+fSL
+fFD
+iqc
+iqc
+ggM
+iqc
+iqc
+iqc
+aYw
+hbx
+bPM
+hbx
+bPM
+hbx
+bPM
+hbx
+mYx
+eJY
 ass
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-adI
-atV
+lMj
+paF
+aEM
+ass
+ass
+ass
+ass
+ass
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+ass
+ass
+ass
+ass
+ass
+gID
+gID
+gID
+gID
+gID
+gID
+aCE
+uLN
+gID
+gID
+gID
 azA
 azA
 azA
@@ -79008,23 +81307,27 @@ bIm
 jNc
 xEi
 jJj
-aBo
-aBA
-fEW
+bIm
+xKh
+ajR
 qJM
-fEW
+ajR
 aBA
+aBT
 aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-wnA
-wjM
-wnA
+bjD
+bik
+ocX
+bik
+ocX
+bik
+aEC
+aFr
+aEC
+hWt
+viK
+aEC
+epS
 ass
 azA
 azA
@@ -79041,21 +81344,17 @@ azA
 azA
 azA
 azA
-atV
-adI
-atV
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+aTF
+bdl
+bdj
+gID
+lzu
+bjk
+rrU
+epD
+xVn
+gID
 azA
 azA
 azA
@@ -79265,56 +81564,56 @@ bIm
 rcy
 aKM
 aKM
+bIm
+aBA
+fEW
+qJM
+fEW
+aBA
 aBo
 aBo
-aBo
-kJB
-aBo
-aBo
-aBo
-azA
-azA
-azA
-azA
-azA
-azA
 ass
-keu
-gPT
-bzi
+ass
+ass
+ass
+ass
+ass
+aGs
+wjM
+aGs
+bqI
+aEC
+xfJ
+nGd
 ass
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+mfE
+mfE
+mfE
 atV
-adI
+atV
+atV
+atV
+atV
+atV
+atV
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+gkD
+bdl
+bdl
+aEH
+rrU
+bjk
+rrU
+rrU
+aaE
+gID
+gID
+gID
 azA
 aSK
 aSK
@@ -79523,12 +81822,12 @@ rcy
 aKM
 aKM
 bIm
-azA
 aBo
-qJM
 aBo
-azA
-azA
+kJB
+aBo
+aBo
+aBo
 azA
 azA
 azA
@@ -79536,42 +81835,42 @@ azA
 azA
 azA
 ass
-uBK
-aEC
-uGR
+fqs
+gPT
+fqs
+ass
+cEb
+ass
+ass
 ass
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-atV
-adI
+mfE
+bjr
+ekr
+ciN
+ciN
+ciN
+ciN
+ciN
+bhu
+wio
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+dxl
+bdl
+pOk
+gID
+acp
+quy
+iCG
+rrU
+rrU
+gWM
+lPE
+gID
 azA
 aSK
 aSM
@@ -79782,53 +82081,53 @@ aKM
 bIm
 azA
 aBo
-bQR
+qJM
 aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
+uce
+uce
+uce
+uce
+aFT
+aFT
+aFT
 azA
 ass
-uBK
-aEC
-bYZ
+keu
+xVz
+bzi
 ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
+aDB
+mfE
+atV
+atV
+atV
+atV
+atV
 atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+dxl
+bdl
+bdl
+gID
+bju
+rrU
+bjk
+rrU
+rrU
+gWM
+cwc
+gID
 azA
 aSK
 aSM
@@ -80039,31 +82338,31 @@ bIm
 bIm
 azA
 aBo
-eoN
-akt
-akt
-akt
-akt
-akt
-akt
-rPD
+bQR
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
 aBo
 azA
 ass
-nCF
-xzQ
-tjn
-ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+uBK
+uAj
+bYZ
+aVQ
+ciN
+ekr
+ciN
+ekr
+ciN
+ekr
+ciN
+ekr
+bkb
+mfE
 azA
 azA
 azA
@@ -80073,19 +82372,19 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+kqN
+okj
+vNQ
+gID
+aVK
+nem
+bjk
+rrU
+rrU
+gWM
+cwc
+gID
 azA
 aSK
 aSM
@@ -80260,7 +82559,7 @@ aiF
 aPx
 aiF
 aJi
-bjH
+aPx
 aPx
 aPx
 aPx
@@ -80295,32 +82594,32 @@ azA
 azA
 azA
 azA
-hDy
 aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-rwu
+eoN
+akt
+akt
+akt
+akt
+akt
+akt
+rPD
 aBo
 azA
 ass
+nCF
+xzQ
+tjn
 ass
-ass
-ass
-ass
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
+mfE
 azA
 azA
 azA
@@ -80330,19 +82629,19 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rrA
+rrA
+rrA
+rrA
+rrA
+mGa
+mGa
+bjk
+rrU
+rrU
+gWM
+aaH
+gID
 azA
 aSK
 aSM
@@ -80517,14 +82816,7 @@ agY
 aPx
 agY
 aKu
-heG
 aPx
-azA
-azA
-azA
-azA
-azA
-azA
 azA
 azA
 azA
@@ -80562,12 +82854,19 @@ azA
 aBo
 qJM
 aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+rwu
+aBo
 azA
-azA
-azA
-azA
-azA
-azA
+ass
+ass
+ass
+ass
+ass
 azA
 azA
 azA
@@ -80587,19 +82886,19 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rrA
+moW
+qtP
+bjl
+hoG
+xoD
+mGa
+bjk
+rrU
+rrU
+gWM
+sek
+gID
 azA
 aSK
 aSM
@@ -80774,7 +83073,6 @@ aSy
 aPx
 aSy
 heG
-heG
 aPx
 azA
 azA
@@ -80810,8 +83108,9 @@ azA
 azA
 azA
 azA
-azA
-azA
+aBo
+qJM
+aBo
 azA
 azA
 azA
@@ -80844,19 +83143,19 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rrA
+aMU
+xZB
+mGf
+fUI
+bVj
+mGa
+bjk
+rrU
+rrU
+gWM
+cwc
+gID
 azA
 aSK
 aSM
@@ -81031,44 +83330,44 @@ heG
 aPx
 heG
 bjZ
-heG
 aPx
 azA
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+tQF
+aBo
 azA
 azA
 azA
@@ -81101,19 +83400,19 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rrA
+bhW
+lTO
+peA
+fUI
+bVj
+mGa
+ijY
+crR
+crR
+qjN
+yaT
+xyH
 azA
 aSK
 aTc
@@ -81289,43 +83588,43 @@ aPx
 aPx
 aPx
 aPx
-aPx
+azA
+urC
+jlN
+dZj
+urC
+cWF
+ljb
+tWa
+sbY
+urC
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aBo
+jKc
+ajR
+ajR
+ajR
+ajR
+jKc
+ajR
+ajR
+ajR
+ajR
+jKc
+rDY
+akt
+akt
+akt
+gRd
+akt
+akt
+kWi
+aBo
 azA
 azA
 azA
@@ -81358,19 +83657,19 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rrA
+aZt
+taB
+vDN
+fUI
+bjy
+rrA
+cvG
+rrU
+rrU
+bjk
+aDG
+xyH
 azA
 azA
 azA
@@ -81547,42 +83846,42 @@ azA
 azA
 azA
 azA
+urC
+icg
+iJy
+xPT
+ljb
+dPU
+aXV
+mLp
+urC
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+lxI
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
 azA
 azA
 azA
@@ -81615,19 +83914,19 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rrA
+lFb
+aXL
+wVL
+wVL
+bhg
+tzd
+vqG
+crR
+biw
+reW
+mBg
+xyH
 azA
 azA
 azA
@@ -81804,6 +84103,15 @@ azA
 azA
 azA
 azA
+urC
+urC
+urC
+urC
+bTK
+ljb
+ljb
+ljb
+urC
 azA
 azA
 azA
@@ -81821,18 +84129,9 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aBo
+cWo
+aBo
 azA
 azA
 azA
@@ -81872,22 +84171,22 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rrA
+rrA
+rrA
+rrA
+rrA
+rrA
+rrA
+rrU
+rrU
+gID
+muz
+gID
+gID
+gID
+gID
+gID
 hxk
 aSJ
 hxk
@@ -82061,37 +84360,37 @@ azA
 azA
 azA
 azA
+urC
+uGE
+eXf
+urC
+kEI
+kEI
+kEI
+ikk
+urC
+azA
+urC
+urC
+jzT
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aBo
+lxI
+aBo
+urC
+urC
 azA
 azA
 azA
@@ -82129,22 +84428,22 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+lHu
+rrU
+hHF
+rrU
+rrU
+bjn
+rrU
+rrU
+gID
+lgn
+xbL
+biq
+pku
+hWS
+gID
 hxk
 aSJ
 hxk
@@ -82318,37 +84617,37 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+cBj
+hyr
+urC
+hoI
+oFR
+mZS
+hyr
+urC
+urC
+urC
+mjN
+lga
+iCF
+krP
+vdC
+kEI
+ehq
+mcz
+hyr
+eqf
+dyC
+urC
+urC
+urC
+urC
+urC
+nRf
+tSr
+nsU
+urC
 azA
 azA
 azA
@@ -82386,22 +84685,22 @@ atV
 bjI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+oLR
+jdL
+hSN
+rrU
+rrU
+bjn
+rrU
+rrU
+gID
+lgn
+yce
+rrU
+rrU
+tGq
+gID
 hxk
 aSJ
 hxk
@@ -82575,37 +84874,37 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+pOU
+hUN
+ikk
+hUN
+hyr
+hyr
+hUN
+nMW
+hUN
+siB
+iyl
+iyl
+iyl
+iyl
+iyl
+kEI
+hnN
+hyr
+hyr
+hyr
+euW
+urC
+usK
+ieo
+usK
+urC
+jBO
+hhj
+iNh
+urC
 azA
 azA
 aBo
@@ -82643,22 +84942,22 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+rrU
+rrU
+rrU
+rrU
+rrU
+klJ
+rrU
+yce
+gID
+biI
+gID
+wDE
+wDE
+aVw
+gID
 hxk
 aSJ
 hxk
@@ -82832,37 +85131,37 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+blb
+urC
+rHr
+iyl
+iyl
+iyl
+iyl
+kEI
+rpF
+hyr
+uXd
+hyr
+gRz
+urC
+tXU
+buA
+buA
+urC
+iAX
+nsU
+nsU
+urC
 azA
 azA
 aBo
@@ -82900,22 +85199,22 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+oLR
+rrU
+hHF
+rrU
+tKB
+gID
+gID
+gID
+gID
+biI
+gID
+gID
+gID
+gID
+gID
 hxk
 aSJ
 hxk
@@ -83099,27 +85398,27 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+fFm
+iyl
+wUY
+wUY
+iyl
+kEI
+nBh
+hyr
+hNx
+hyr
+hyr
+vEp
+qMp
+qMp
+qMp
+vlN
+nsU
+nsU
+urC
+urC
 azA
 azA
 aBo
@@ -83157,22 +85456,22 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+aDK
+jdL
+hSN
+szK
+nbE
+gID
+wFp
+iix
+iix
+rrU
+szC
+abV
+rIu
+bhA
+gID
 hxk
 aSJ
 hxk
@@ -83346,36 +85645,36 @@ azA
 azA
 azA
 azA
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+juH
+iyl
+eLf
+lOO
+ues
+kEI
+kkD
+hyr
+hNx
+hyr
+qOA
+urC
+lHe
+lHe
+lHe
+urC
+xHF
+nsU
+urC
 azA
 azA
 azA
@@ -83414,22 +85713,22 @@ atV
 adI
 atV
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+gID
+gID
+gID
+gID
+gID
+gID
+qmG
+rrU
+rrU
+rrU
+rrU
+rrU
+rrU
+gyC
+gID
 hxk
 aTa
 hxk
@@ -83603,36 +85902,36 @@ azA
 azA
 azA
 azA
+urC
+jlN
+dZj
+urC
+cWF
+ljb
+tWa
+sbY
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+tJn
+iyl
+iUu
+khQ
+iyl
+tjF
+hUN
+hyr
+hyr
+hyr
+niD
+urC
+wfV
+qMp
+gCJ
+urC
+fJe
+nsU
+urC
 azA
 azA
 azA
@@ -83677,16 +85976,16 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+qmG
+aXP
+wZn
+rrU
+rrU
+rCr
+biA
+fDv
+gID
 hxk
 hxk
 hxk
@@ -83860,36 +86159,36 @@ azA
 azA
 azA
 azA
+urC
+icg
+iJy
+xPT
+ljb
+ljb
+aXV
+mLp
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+kEI
+kEI
+kEI
+kEI
+wKN
+urC
+oWN
+oWN
+oWN
+oWN
+oWN
+urC
+urC
+otv
+urC
+urC
+jdo
+nsU
+urC
 azA
 azA
 azA
@@ -83934,16 +86233,16 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gID
+gID
+gID
+gID
+gID
+gID
+gID
+gID
+gID
+gID
 azA
 azA
 azA
@@ -84117,36 +86416,36 @@ azA
 azA
 azA
 azA
+urC
+urC
+urC
+urC
+bTK
+ljb
+ljb
+ljb
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+brK
+gNg
+tMx
+tNu
+hMF
+gHs
+jkQ
+eWp
+qyR
+pCp
+ndr
+urC
+lfb
+fIB
+epk
+urC
+fJe
+nsU
+urC
 azA
 azA
 azA
@@ -84184,58 +86483,58 @@ azA
 atV
 adI
 atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -84374,36 +86673,36 @@ azA
 azA
 azA
 azA
+urC
+vxS
+eXf
+urC
+kEI
+kEI
+kEI
+ikk
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+vKQ
+hMF
+kbO
+dhn
+hMF
+gHs
+rSk
+nsU
+nsU
+nsU
+sac
+urC
+cNb
+nsU
+mrs
+urC
+nsU
+nsU
+urC
 azA
 azA
 azA
@@ -84439,59 +86738,59 @@ mXo
 azA
 azA
 atV
-bjJ
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-bhu
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-ciN
-bhu
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bhu
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bkc
-bhu
-wio
+adI
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
 atV
 azA
 azA
@@ -84631,36 +86930,36 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+cBj
+hyr
+urC
+hoI
+oFR
+mZS
+hyr
+urC
+urC
+urC
+oZI
+hMF
+vmh
+dhn
+hMF
+gHs
+vNN
+nsU
+mrs
+nsU
+nsU
+tII
+nsU
+nsU
+nsU
+tII
+nsU
+nsU
+urC
 azA
 azA
 azA
@@ -84696,59 +86995,59 @@ mXo
 azA
 azA
 atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-atV
-agr
+bjJ
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+bhu
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+ciN
+bhu
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bhu
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bkc
+bhu
+wio
 atV
 azA
 azA
@@ -84888,36 +87187,36 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+pOU
+hyr
+ikk
+hUN
+hyr
+hyr
+hUN
+xPT
+hUN
+sZn
+hMF
+hMF
+hMF
+hMF
+hMF
+gHs
+inT
+nsU
+koI
+nsU
+nsU
+urC
+xCn
+nsU
+jaf
+urC
+nsU
+nsU
+urC
 azA
 azA
 azA
@@ -84952,58 +87251,58 @@ kgM
 mXo
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
+atV
 atV
 agr
 atV
@@ -85145,36 +87444,36 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+kAB
+hMF
+tZi
+tZi
+hMF
+gHs
+bWr
+nsU
+nsU
+nsU
+nsU
+urC
+urC
+tII
+urC
+urC
+nsU
+nsU
+urC
 azA
 azA
 azA
@@ -85412,26 +87711,26 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+pFP
+qrC
+wLQ
+eSG
+hMF
+gHs
+fME
+viC
+hiu
+pCp
+xCn
+urC
+sxX
+nsU
+sxX
+tII
+nsU
+sxX
+urC
 azA
 azA
 azA
@@ -85659,36 +87958,36 @@ azA
 azA
 azA
 azA
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+kEI
+kEI
+kEI
+kEI
+mmw
+urC
+jee
+jee
+jee
+jee
+jee
+urC
+urC
+tII
+urC
+urC
+urC
+urC
+urC
 azA
 azA
 azA
@@ -85916,36 +88215,36 @@ azA
 azA
 azA
 azA
+urC
+jlN
+dZj
+urC
+cWF
+ljb
+tWa
+sbY
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+evd
+bHN
+lUD
+qKS
+hyr
+hIZ
+ggG
+qvG
+rYx
+nNn
+idc
+urC
+wHv
+nsU
+nsU
+nsU
+nsU
+nsU
+urC
 azA
 azA
 azA
@@ -86173,36 +88472,36 @@ azA
 azA
 azA
 azA
+urC
+icg
+iJy
+xPT
+ljb
+ljb
+aXV
+mLp
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+hyr
+hyr
+hyr
+hyr
+hyr
+kEI
+sYr
+uhy
+qvG
+uhy
+bIx
+urC
+muh
+fwQ
+hVJ
+nOq
+jkJ
+dfj
+urC
 azA
 azA
 azA
@@ -86430,36 +88729,36 @@ azA
 azA
 azA
 azA
+urC
+urC
+urC
+urC
+bTK
+ljb
+ljb
+ljb
+urC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+kls
+fSH
+fSH
+hyr
+qow
+kEI
+wRH
+qvG
+giK
+qvG
+nNn
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
 azA
 azA
 azA
@@ -86687,30 +88986,30 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+vxS
+eXf
+urC
+kEI
+kEI
+kEI
+ikk
+urC
+urC
+urC
+fSH
+fSH
+fSH
+hyr
+iRf
+kEI
+qEa
+uhy
+qvG
+uhy
+hNz
+lRm
+urC
 azA
 azA
 azA
@@ -86944,30 +89243,30 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+urC
+cBj
+hyr
+ikk
+hyr
+hyr
+hyr
+hyr
+xPT
+hUN
+cFC
+hyr
+hyr
+hyr
+hyr
+iRY
+kEI
+nQM
+qvG
+uhy
+qvG
+uhy
+rPm
+urC
 azA
 azA
 azA
@@ -87201,41 +89500,41 @@ azA
 azA
 azA
 azA
+urC
+pOU
+hUN
+urC
+oBE
+oFR
+mZS
+hUN
+urC
+urC
+urC
+lEX
+nbD
+hPI
+hLU
+vzD
+kEI
+wZG
+rmS
+wNk
+cRs
+mov
+nRz
+urC
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+kPM
+kPM
+kPM
+kPM
+kPM
 kPM
 uIb
 iKX
@@ -87458,41 +89757,41 @@ azA
 azA
 azA
 azA
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+azA
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
+urC
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+kPM
+bnp
+aEK
+aXM
+kPM
 kPM
 wOn
 gWI
@@ -87745,11 +90044,11 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
+kPM
+aEK
+aEK
+jQM
+kPM
 kPM
 mPf
 kaH
@@ -88004,8 +90303,8 @@ kPM
 kPM
 kPM
 kPM
-kPM
-kPM
+ujD
+bib
 kPM
 kPM
 jHA
@@ -88519,7 +90818,7 @@ uDT
 uDT
 uDT
 uDT
-nRo
+ixG
 uDT
 uDT
 uDT
@@ -88776,7 +91075,7 @@ oCm
 oCm
 oCm
 dUf
-nRo
+ixG
 bwI
 oCm
 oCm
@@ -89543,15 +91842,15 @@ vse
 ceF
 nVI
 xCX
-nRo
+oHH
 kPM
+bji
 pKU
-pKU
-pKU
+aXN
 pKU
 pKU
 kPM
-nRo
+oHH
 riD
 nVI
 kPM
@@ -89800,15 +92099,15 @@ ahS
 aBs
 hlc
 xCX
-nRo
+oHH
 kPM
-pKU
-pKU
-pKU
+jZA
+aaI
+mDU
 pKU
 pKU
 kPM
-nRo
+oHH
 riD
 nVI
 kPM
@@ -90057,7 +92356,7 @@ ksL
 ceF
 nVI
 xCX
-nRo
+oHH
 kPM
 pKU
 pKU
@@ -90065,7 +92364,7 @@ pKU
 pKU
 pKU
 kPM
-nRo
+oHH
 riD
 nVI
 kPM
@@ -90571,7 +92870,7 @@ edu
 ceF
 nVI
 xCX
-nRo
+oHH
 kPM
 pKU
 pKU
@@ -90579,7 +92878,7 @@ pKU
 pKU
 pKU
 kPM
-nRo
+oHH
 riD
 kPM
 aYC
@@ -90828,7 +93127,7 @@ ahS
 aBs
 hlc
 xCX
-nRo
+oHH
 kPM
 hXN
 pKU
@@ -90836,7 +93135,7 @@ sRV
 pKU
 pKU
 kPM
-nRo
+oHH
 riD
 kPM
 ajR
@@ -91085,7 +93384,7 @@ hfi
 ceF
 nVI
 xCX
-nRo
+oHH
 kPM
 pKU
 pKU
@@ -91093,7 +93392,7 @@ pKU
 pKU
 pKU
 kPM
-nRo
+oHH
 riD
 kPM
 nJN
@@ -93682,12 +95981,12 @@ azA
 aBo
 aEz
 aBo
-aBo
-aBo
-aBo
-aBo
-aBo
-aBo
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -93936,14 +96235,14 @@ azA
 azA
 azA
 azA
-dFy
-aDz
-aBU
-aBU
-aBU
-aBU
-aBU
-aBU
+aBo
+ajT
+aBo
+aBo
+aBo
+aBo
+aBo
+aBo
 aBo
 azA
 azA
@@ -94195,11 +96494,11 @@ azA
 azA
 aBo
 aDA
-aDG
-aDG
-aDG
-mEc
-aDG
+akt
+akt
+akt
+akt
+akt
 oAN
 aBo
 azA
@@ -94455,10 +96754,10 @@ aBo
 aBo
 aBo
 aBo
-gID
-phw
-oIp
-bYK
+aBo
+aBo
+ajT
+hDy
 azA
 azA
 azA
@@ -94703,19 +97002,19 @@ azA
 azA
 azA
 azA
-gID
-gID
-gID
-gID
-gID
-dsV
-cEb
-dsV
-xfJ
-gID
-phw
-bis
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+uTI
+aBo
 azA
 azA
 azA
@@ -94960,19 +97259,19 @@ azA
 azA
 azA
 azA
-gID
-dsV
-xfJ
-dsV
-cEb
-ujf
-bjr
-aEM
-aEK
-gID
-hHF
-tGq
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+hDy
+ajT
+aBo
 azA
 azA
 azA
@@ -95217,19 +97516,19 @@ azA
 azA
 azA
 azA
-gID
-ujf
-bjr
-aEM
-bjr
-qkl
-qkl
-qkl
-tzE
-gID
-phw
-hSN
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+ajT
+aBo
 azA
 azA
 azA
@@ -95474,19 +97773,19 @@ azA
 azA
 azA
 azA
-gID
-afl
-aGZ
-qkl
-qkl
-qkl
-qkl
-qkl
-sHS
-gID
-phw
-gHP
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+ajT
+aBo
 azA
 azA
 azA
@@ -95697,7 +97996,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -95731,19 +98030,19 @@ azA
 azA
 azA
 azA
-gID
-aEl
-aFD
-jOV
-jOV
-jOV
-jOV
-aVQ
-aEF
-nUg
-gyC
-uXa
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+ajT
+aBo
 azA
 azA
 azA
@@ -95954,7 +98253,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -95988,19 +98287,19 @@ aki
 azA
 azA
 azA
-gID
-lzu
-qkl
-hWt
-bjr
-bjr
-ltH
-qkl
-pku
-gID
-phw
-hSN
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+ajT
+aBo
 azA
 azA
 azA
@@ -96211,7 +98510,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -96245,21 +98544,21 @@ aki
 azA
 azA
 azA
-gID
-xfJ
-qkl
-aEM
-aEM
-aEM
-aEM
-qkl
-aDK
-gID
-hHF
-tGq
-gID
-gID
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+uTI
+aBo
+azA
+azA
 azA
 azA
 azA
@@ -96468,7 +98767,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -96502,20 +98801,20 @@ aki
 azA
 azA
 azA
-gID
-aDK
-tzE
-bhI
-tzE
-tzE
-bhI
-tzE
-aVY
-gID
-phw
-bis
-phw
-phw
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+ajT
+aBo
+aBo
 doD
 atV
 atV
@@ -96725,7 +99024,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -96759,19 +99058,19 @@ aki
 azA
 azA
 azA
-gID
-gID
-bhO
-gID
-aEA
-aEA
-gID
-gID
-gID
-gID
-ezj
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
 aEL
-bjD
+uKm
 uKm
 bzh
 bhu
@@ -96982,7 +99281,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -97016,20 +99315,20 @@ aki
 azA
 azA
 azA
-gID
-bhL
-tzE
-bhU
-bhW
-bhX
-biQ
-gID
-gID
-gID
-lPE
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
 bjd
-phw
-uVf
+aBo
+aBo
 doD
 atV
 atV
@@ -97239,7 +99538,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -97273,21 +99572,21 @@ aki
 azA
 azA
 azA
-gID
-aEq
-tzE
-tzE
-bhW
-bie
-biQ
-gID
-aTF
-bdj
-gID
-fQz
-phw
-phw
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjz
+aBo
+azA
+azA
 azA
 azA
 azA
@@ -97496,7 +99795,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -97530,21 +99829,21 @@ aki
 azA
 azA
 azA
-gID
-aEE
-tzE
-tzE
-bhW
-bii
-biQ
-gID
-gkD
-bdl
-aEH
-bjf
-phw
-phw
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+hDy
+bjd
+aBo
+azA
+azA
 azA
 azA
 azA
@@ -97753,7 +100052,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -97787,21 +100086,21 @@ aki
 azA
 azA
 azA
-gID
-aFT
-tzE
-bhI
-bhZ
-tzE
-tzE
-gID
-dxl
-pOk
-gID
-lMj
-phw
-pcU
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
+azA
+azA
 azA
 azA
 azA
@@ -98010,7 +100309,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -98044,21 +100343,6 @@ aki
 azA
 azA
 azA
-gID
-gID
-gID
-gID
-gID
-gID
-gID
-gID
-bdl
-bdl
-gID
-bjf
-phw
-phw
-gID
 azA
 azA
 azA
@@ -98069,13 +100353,28 @@ azA
 azA
 azA
 azA
-ixi
-ixi
-ixi
-ixi
-ixi
-ixi
-hah
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -98267,7 +100566,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -98303,19 +100602,17 @@ azA
 azA
 azA
 azA
-gID
-bhV
-bia
-bij
-bji
-gID
-kqN
-vNQ
-gID
-bjt
-phw
-phw
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
 azA
 azA
 azA
@@ -98326,13 +100623,15 @@ azA
 azA
 azA
 azA
-ixi
-tpZ
-qmG
-mfw
-aDD
-nbE
-ixi
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -98524,7 +100823,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -98560,36 +100859,36 @@ azA
 azA
 azA
 azA
-gID
-bid
-bhQ
-rrU
-bjl
-gID
-gID
-gID
-gID
-bju
-kdH
-kdH
-gID
-ixi
-ixi
-ixi
-ixi
-ixi
 azA
 azA
 azA
 azA
 azA
-ixi
-abV
-aDD
-aDD
-aDD
-iRt
-ixi
+azA
+azA
+azA
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -98781,7 +101080,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -98817,36 +101116,36 @@ azA
 azA
 azA
 azA
-gID
-bhK
-bib
-biU
-bjm
-gID
-phw
-phw
-iTk
-bjf
-lcy
-kdH
-gID
-oVt
-mVs
-bij
-jGl
-ixi
-ixi
-ixi
-ixi
-ixi
-ixi
-ixi
-bhA
-aDD
-wZn
-aDD
-fDv
-ixi
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -99038,7 +101337,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -99074,36 +101373,36 @@ azA
 azA
 azA
 azA
-gID
-gID
-bjn
-biY
-bjn
-gID
-phw
-bip
-kmN
-bjf
-lcy
-kdH
-gID
-qtP
-gWM
-rrU
-qJk
-gID
-lFb
-rrU
-rrU
-rrU
-nWH
-ixi
-rIu
-aao
-jdL
-aDD
-rCr
-ixi
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -99295,7 +101594,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -99328,39 +101627,39 @@ baN
 aki
 azA
 azA
-gID
-gID
-gID
-gID
-gID
-bhR
-bjk
-bjo
-gID
-hHF
-biq
-vIP
-bjf
-lcy
-wDE
-gID
-ipQ
-gWM
-rrU
-aaE
-gID
-shV
-rrU
-rrU
-rrU
-vDN
-ixi
-xVn
-aDD
-aDD
-aDD
-mfE
-ixi
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -99552,7 +101851,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -99585,39 +101884,39 @@ baO
 aki
 azA
 azA
-gID
-aDB
-aFU
-bhE
-gID
-bid
-rrU
-bjv
-gID
-phw
-phw
-biw
-bjf
-biK
-kdH
-gID
-ipQ
-gWM
-rrU
-suu
-xyH
-rrU
-rrU
-rrU
-rrU
-rrU
-iCG
-aDD
-aDD
-aDD
-aDD
-uLN
-ixi
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -99809,7 +102108,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -99842,39 +102141,39 @@ bcQ
 aki
 azA
 azA
-gID
-aDD
-aDD
-aDD
-bhP
-biz
-rrU
-bjp
-gID
-gID
-gID
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
 bjz
-gID
-gID
-gID
-ipQ
-gWM
-rrU
-xVz
-gID
-nQR
-cme
-jxJ
-xbL
-viK
-ixi
-oAS
-iix
-moW
-aDD
-wGM
-ixi
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -100066,7 +102365,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -100099,39 +102398,39 @@ baO
 aki
 azA
 azA
-gID
-gID
-gID
-gID
-gID
-bhS
-qnO
-bjw
-gID
-mBg
-biA
-biA
-bjB
-gID
-jbo
-gID
-qtP
-gWM
-rrU
-kys
-rrA
-rrA
-rrA
-rrA
-rrA
-rrA
-reE
-ixi
-ixi
-ixi
-ixi
-ixi
-ixi
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -100323,7 +102622,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -100356,33 +102655,33 @@ baO
 aki
 azA
 azA
-gID
-aDB
-aFU
-bhE
-gID
-bhT
-rrU
-bjy
-fhQ
-cTw
-rrU
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
 biC
 bjC
-gID
-gID
-gID
-tgo
-rrU
-rrU
-xZB
-rrA
-wVL
-reW
-jZA
-cwc
-suY
-rrA
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -100580,7 +102879,7 @@ azA
 azA
 azA
 bjY
-bVr
+afU
 bjY
 azA
 azA
@@ -100613,33 +102912,33 @@ baO
 aki
 azA
 azA
-gID
-aDD
-aDD
-aDD
-bhP
-biz
-rrU
-bjE
-rrU
-bib
-bib
-biD
-bjT
-hoG
-ubf
-ubf
-fva
-qjN
-szK
-okj
-mGa
-gmT
-taB
-mGf
-fUI
-bVj
-rrA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -100870,33 +103169,33 @@ baP
 aki
 azA
 azA
-gID
-gID
-gID
-gID
-gID
-bhK
-bib
-blg
-gID
-gID
-gID
-aVW
-bjE
-rrU
-lWh
-rrU
-rrU
-wVr
-rrU
-cvG
-mGa
-gmT
-taB
-peA
-ybq
-dBT
-rrA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjz
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -101131,29 +103430,29 @@ azA
 azA
 azA
 azA
-gID
-gID
-gID
-gID
-gID
 azA
-gID
-tRU
-xHb
-gID
-cqc
-rrU
-rrU
-uce
-qjN
-bjw
-rrA
-quy
-wFp
-xoD
-fUI
-yew
-rrA
+azA
+azA
+azA
+azA
+azA
+aBo
+bjd
+aBo
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -101395,22 +103694,22 @@ azA
 azA
 azA
 bjY
-lgn
+afU
 bjY
-gID
-mDU
-bib
-biU
-bib
-vVj
-qUS
-mBr
-crR
-ilx
-ujD
-ikz
-oHH
-rrA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -101654,20 +103953,20 @@ bjY
 bjY
 afU
 bjY
-gID
-gID
-bjn
-klJ
-bjn
-gID
-eKg
-rrA
-rrA
-rrA
-rrA
-rrA
-rrA
-rrA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -101886,10 +104185,10 @@ aCC
 aCC
 aCC
 aCC
-aCE
-aCE
-aCE
-aCE
+aCC
+aCC
+aCC
+aCC
 aCC
 aCC
 aCC
@@ -101903,25 +104202,25 @@ aCC
 aCC
 aCC
 aCC
-aCE
-aCE
-aCE
-aCE
+aCC
+aCC
+aCC
+aCC
 aCC
 aCu
 aCO
 bjY
-lHu
-rPG
-rrU
-rrU
-pid
-gID
-epD
-biA
-biA
-xpZ
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -102168,17 +104467,17 @@ bjY
 bjY
 bjY
 bjY
-oLR
-vqG
-rrU
-rrU
-tKB
-gID
-jfF
-saA
-vLm
-mhP
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -102424,18 +104723,18 @@ azA
 azA
 azA
 azA
-gID
-oLR
-vqG
-rrU
-szK
-eOZ
-gID
-gID
-gID
-gID
-gID
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -102681,13 +104980,13 @@ azA
 azA
 azA
 azA
-gID
-rrU
-rrU
-rrU
-yce
-bhQ
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -102938,13 +105237,13 @@ azA
 azA
 azA
 azA
-gID
-gID
-gID
-gID
-gID
-gID
-gID
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -23969,11 +23969,6 @@
 /obj/structure/table/reinforced,
 /obj/item/device/radio,
 /obj/item/device/radio,
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "Humanoid Containment Intercom";
-	pixel_x = -26
-	},
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/boombox,

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -23641,7 +23641,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
 "dPU" = (
-/mob/living/carbon/human/scp_527,
+/obj/effect/landmark{
+	name = "scp527"
+	},
 /turf/simulated/floor/lino,
 /area/site53/ulcz/humanoidcontainment)
 "dQS" = (

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -23640,12 +23640,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
-"dPU" = (
-/obj/effect/landmark{
-	name = "scp527"
-	},
-/turf/simulated/floor/lino,
-/area/site53/ulcz/humanoidcontainment)
 "dQS" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/wallframe_spawn/reinforced,
@@ -83687,7 +83681,7 @@ icg
 iJy
 xPT
 ljb
-dPU
+ljb
 aXV
 mLp
 urC

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -22025,12 +22025,6 @@
 	id_tag = "HCZCheckpointflash";
 	name = "HCZCheckpointflash"
 	},
-/obj/item/device/radio/intercom/locked{
-	dir = 8;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = 32;
-	channels = list(1)
-	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bTG" = (
@@ -22625,12 +22619,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/device/radio/intercom/locked{
-	dir = 8;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = 32;
-	channels = list(1)
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "cFl" = (
@@ -22993,12 +22981,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "LCZ Checkpoint Intercom";
-	pixel_y = -32;
-	channels = list(1)
-	},
 /turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "cYP" = (
@@ -23967,18 +23949,6 @@
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
 /area/chapel)
-"enN" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 4
-	},
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "LCZ Checkpoint Intercom";
-	pixel_y = -32;
-	channels = list(1)
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
 "eon" = (
 /obj/item/stool/padded,
 /turf/simulated/floor/wood/walnut,
@@ -24123,15 +24093,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/surface/bunker)
-"euO" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "HCZ Checkpoint Intercom";
-	pixel_y = -32;
-	channels = list(1)
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/lowertrams/redline)
 "euW" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/techmaint,
@@ -25704,11 +25665,6 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
-	},
-/obj/item/device/radio/intercom/locked{
-	frequency = 10;
-	name = "HCZ Checkpoint Intercom";
-	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -27458,11 +27414,6 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "Humanoid Containment Intercom";
-	pixel_x = -26
-	},
 /turf/simulated/floor,
 /area/site53/ulcz/humanoidcontainment)
 "ify" = (
@@ -27490,21 +27441,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/securitypost)
-"ihx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/brown/mono,
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "LCZ Checkpoint Intercom";
-	pixel_y = -32;
-	channels = list(1)
-	},
-/turf/simulated/floor/tiled,
-/area/site53/lowertrams/brownline)
 "ihM" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -27892,12 +27828,8 @@
 /turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "iCF" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "Humanoid Containment Intercom";
-	pixel_x = -26
-	},
 /obj/structure/table/woodentable,
+/obj/item/device/radio,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
 "iCG" = (
@@ -28477,15 +28409,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"jhG" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 8;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = 32;
-	channels = list(1)
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
 "jkl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29323,14 +29246,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
-"klC" = (
-/obj/item/device/radio/intercom/locked{
-	frequency = 10;
-	name = "HCZ Checkpoint Intercom";
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
 "klJ" = (
 /obj/machinery/door/airlock/security{
 	name = "HCZ Sergeant Equipment";
@@ -29862,11 +29777,6 @@
 	name = "ULCZ Checkpoint Office Access N";
 	pixel_y = 9;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "LCZ Checkpoint Intercom";
-	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -31702,11 +31612,6 @@
 /obj/machinery/camera/network/hcz{
 	dir = 4
 	},
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = -26
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "mVy" = (
@@ -33232,11 +33137,6 @@
 	dir = 1
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = -26
-	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "oJB" = (
@@ -34773,15 +34673,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
-"qOA" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "Humanoid Containment Intercom";
-	pixel_y = -32;
-	channels = list(1)
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/site53/ulcz/humanoidcontainment)
 "qPI" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
@@ -35507,15 +35398,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
-"rFw" = (
-/obj/machinery/light,
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = -26
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/site53/uhcz/hallways)
 "rFI" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donut,
@@ -35664,14 +35546,6 @@
 /obj/machinery/chem_master/condimaster,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/humanoidcontainment)
-"rPv" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = -26
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uhcz/securitypost)
 "rPD" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -35806,15 +35680,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/surface/bunker)
-"sac" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "Humanoid Containment Intercom";
-	pixel_y = -32;
-	channels = list(1)
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/site53/ulcz/humanoidcontainment)
 "sak" = (
 /obj/structure/bed/chair/pew/left/mahogany,
 /turf/simulated/floor/tiled/dark,
@@ -37360,11 +37225,6 @@
 	name = "UHCZ Western Shutter Window (side)";
 	pixel_y = 25;
 	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "HCZ Checkpoint Intercom";
-	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -40057,18 +39917,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/humanoidcontainment)
-"wZP" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
-/obj/item/device/radio/intercom/locked{
-	frequency = 10;
-	name = "HCZ Checkpoint Intercom";
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled,
-/area/site53/llcz/entrance_checkpoint)
 "wZX" = (
 /obj/effect/paint_stripe/gray,
 /obj/structure/sign/directions/ez{
@@ -40798,12 +40646,6 @@
 /area/site53/uhcz/scp457containment)
 "xSS" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "LCZ Checkpoint Intercom";
-	pixel_y = -32;
-	channels = list(1)
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "xTl" = (
@@ -60249,7 +60091,7 @@ jOV
 nyh
 nTU
 xpX
-enN
+nTU
 aVS
 azA
 agU
@@ -63592,10 +63434,10 @@ qnc
 qnc
 qnc
 eCZ
-ihx
+qnc
 vea
 agU
-wZP
+bhO
 aVW
 pXS
 bhO
@@ -77971,7 +77813,7 @@ adN
 kKf
 lTp
 xpf
-euO
+adU
 ass
 ass
 ass
@@ -77980,7 +77822,7 @@ ass
 vVj
 riw
 ass
-klC
+aEC
 aEC
 krd
 ass
@@ -78755,7 +78597,7 @@ aEC
 biX
 hat
 biX
-jhG
+aEC
 biV
 bit
 dRU
@@ -80291,7 +80133,7 @@ azA
 ass
 adP
 aMi
-rPv
+aEC
 aga
 ezj
 pPg
@@ -80796,7 +80638,7 @@ ajR
 ajR
 ajR
 aBA
-rFw
+aBT
 aBo
 aga
 bik
@@ -85663,7 +85505,7 @@ kkD
 hyr
 hNx
 hyr
-qOA
+hyr
 urC
 lHe
 lHe
@@ -86691,7 +86533,7 @@ rSk
 nsU
 nsU
 nsU
-sac
+nsU
 urC
 cNb
 nsU

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -32462,9 +32462,6 @@
 /area/site53/ulcz/hallways)
 "nMW" = (
 /obj/machinery/door/airlock/glass/civilian{
-	name = "Humanoid Containment Cell"
-	},
-/obj/machinery/door/airlock/glass/civilian{
 	name = "SCP 527 Dorm (Mr Fish)"
 	},
 /turf/simulated/floor/tiled/techmaint,

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -1188,8 +1188,8 @@
 /obj/structure/closet/secure_closet/engineering_electrical{
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "cD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -1441,12 +1441,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 1;
-	dir = 4;
-	id_tag = "LCZ Upper Maintenance Hatch";
-	name = "LCZ Upper Maintenance Hatch"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/zonecommanderoffice)
@@ -1831,13 +1825,8 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
 "eb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "ec" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/titanium,
@@ -1978,15 +1967,11 @@
 "et" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "eu" = (
 /obj/structure/closet/secure_closet/medical2{
 	req_access = list("ACCESS_MEDICAL_LEVEL3")
@@ -2353,13 +2338,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/equipmentroom)
 "fp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "fq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2396,15 +2379,12 @@
 /area/site53/uez/equipmentroom)
 "ft" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "fu" = (
 /obj/structure/table/woodentable/walnut,
 /obj/structure/bookcase/manuals/medical{
@@ -2666,22 +2646,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/hall)
 "gf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 1;
+/obj/machinery/light/small{
 	dir = 4;
-	id_tag = "LCZ Upper Maintenance Hatch";
-	name = "LCZ Upper Maintenance Hatch"
+	pixel_y = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "gg" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/boombox,
@@ -2707,11 +2677,6 @@
 "gl" = (
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
@@ -2740,17 +2705,12 @@
 /area/site53/maintenance/surfacewest)
 "gp" = (
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "gq" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
@@ -4284,12 +4244,6 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "LCZ Upper Maintenance Hatch";
-	name = "LCZ Upper Maintenance Hatch";
-	pixel_y = 34;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/zonecommanderoffice)
 "kn" = (
@@ -5292,8 +5246,8 @@
 /obj/structure/closet/secure_closet/engineering_welding{
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "mW" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
@@ -7930,9 +7884,11 @@
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
 "xF" = (
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
-/area/site53/maintenance/surfacewest)
+/obj/machinery/power/smes/buildable/preset/ds90/substation_full{
+	RCon_tag = "Self-Destruct Substation"
+	},
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "xK" = (
 /obj/machinery/button/alternate/door/bolts{
 	id_tag = "ezcell3";
@@ -8217,8 +8173,8 @@
 	dir = 1;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "zx" = (
 /obj/machinery/organ_printer/robot/mapped,
 /obj/machinery/light{
@@ -8916,19 +8872,15 @@
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/restaurantkitchenarea)
 "Er" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 1;
-	dir = 4;
-	id_tag = "LCZ Upper Maintenance Hatch";
-	name = "LCZ Upper Maintenance Hatch"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "Es" = (
 /obj/machinery/door/airlock/glass/security{
 	id_tag = "ezcell3";
@@ -9843,18 +9795,15 @@
 /area/site53/medical/isolation)
 "Ls" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 1;
-	dir = 4;
-	id_tag = "LCZ Upper Maintenance Hatch";
-	name = "LCZ Upper Maintenance Hatch"
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "Lv" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
@@ -10305,19 +10254,14 @@
 /turf/simulated/floor/tiled,
 /area/site53/uez/armory)
 "PM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Self-Destruct Bypass"
 	},
-/obj/machinery/button/blast_door{
-	id_tag = "LCZ Upper Maintenance Hatch";
-	name = "LCZ Upper Maintenance Hatch";
-	pixel_y = 34;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "PR" = (
 /obj/structure/bed/chair/padded,
 /turf/simulated/floor/tiled/techfloor,
@@ -11055,8 +10999,8 @@
 	dir = 1;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/maintenance/surfacewest)
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "Vu" = (
 /obj/effect/paint_stripe/white,
 /obj/structure/table/glass,
@@ -11454,6 +11398,14 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
+"YF" = (
+/obj/structure/lattice,
+/obj/structure/cable{
+	d1 = 32;
+	icon_state = "32-1"
+	},
+/turf/simulated/open,
+/area/site53/zonecommanderoffice)
 "YH" = (
 /obj/structure/morgue,
 /obj/machinery/light{
@@ -11581,6 +11533,17 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
+"Zx" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/site53/zonecommanderoffice)
 "Zy" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
@@ -18154,13 +18117,13 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-tb
-Gg
-Vr
+ty
 xF
+PM
+gp
+Ls
+YF
+ty
 aQ
 aQ
 aQ
@@ -18411,13 +18374,13 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-tb
-Gg
+ty
+Er
+ft
+Zx
+et
 cC
-xF
+ty
 aQ
 aQ
 aQ
@@ -18668,13 +18631,13 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-tb
-Gg
+ty
+fp
+eb
+eb
+eb
 mU
-xF
+ty
 aQ
 aQ
 aQ
@@ -18925,20 +18888,20 @@ dA
 dA
 dA
 dA
-dA
-dA
-dA
-tb
-Gg
+ty
+eb
+eb
+eb
+eb
 zw
-xF
-xF
-xF
-xF
-xF
-xF
-xF
-xF
+ty
+ty
+ty
+ty
+ty
+ty
+ty
+ty
 ty
 ty
 ty
@@ -19182,25 +19145,25 @@ dA
 dA
 dA
 dA
+ty
+eb
+gf
+eb
+gf
+Vr
+ty
 dA
 dA
 dA
-tb
-Ly
-eb
-Ls
-et
-eb
-eb
-eb
-eb
-eb
-eb
-eb
-et
-Ls
-fp
-tb
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -19439,25 +19402,25 @@ dA
 dA
 dA
 dA
+ty
+ty
+ty
+ty
+ty
+ty
+ty
 dA
 dA
 dA
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-tb
-Er
-tb
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -19712,9 +19675,9 @@ dA
 dA
 dA
 dA
-tb
-Er
-tb
+dA
+dA
+dA
 dA
 dA
 dA
@@ -19969,9 +19932,9 @@ dA
 dA
 dA
 dA
-tb
-Er
-tb
+dA
+dA
+dA
 dA
 dA
 dA
@@ -20226,9 +20189,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -20483,9 +20446,9 @@ dA
 dA
 dA
 dA
-bk
-ft
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -20740,9 +20703,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -20997,9 +20960,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -21254,9 +21217,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -21511,9 +21474,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -21768,9 +21731,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -22025,9 +21988,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -22282,9 +22245,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -22539,9 +22502,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -22796,9 +22759,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -23053,9 +23016,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -23310,9 +23273,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -23567,9 +23530,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -23824,9 +23787,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -24081,9 +24044,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -24338,9 +24301,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -24595,9 +24558,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -24852,9 +24815,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -25109,9 +25072,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -25366,9 +25329,9 @@ dA
 dA
 dA
 dA
-bk
-ft
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -25623,9 +25586,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -25880,9 +25843,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -26137,9 +26100,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -26394,9 +26357,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -26651,9 +26614,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -26908,9 +26871,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -27165,9 +27128,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -27422,9 +27385,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -27679,9 +27642,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -27936,9 +27899,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -28193,9 +28156,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -28450,9 +28413,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -28707,9 +28670,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -28964,9 +28927,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -29221,9 +29184,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -29478,9 +29441,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -29735,9 +29698,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -29992,9 +29955,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -30249,9 +30212,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -30506,9 +30469,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -30763,9 +30726,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -31020,9 +30983,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -31277,9 +31240,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -31534,9 +31497,9 @@ dA
 dA
 dA
 dA
-bk
-ft
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -31791,9 +31754,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -32048,9 +32011,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -32305,9 +32268,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -32562,9 +32525,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -32819,9 +32782,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -33076,9 +33039,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -33333,9 +33296,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -33590,9 +33553,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -33847,9 +33810,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -34104,9 +34067,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -34361,9 +34324,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -34618,9 +34581,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -34875,9 +34838,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -35132,9 +35095,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -35389,9 +35352,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -35646,9 +35609,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -35903,9 +35866,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -36160,9 +36123,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -36417,9 +36380,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -36674,9 +36637,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -36931,9 +36894,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -37188,9 +37151,9 @@ dA
 dA
 dA
 dA
-bk
-ft
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -37445,9 +37408,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -37702,9 +37665,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -37959,9 +37922,9 @@ dA
 dA
 dA
 dA
-bk
-Gg
-bk
+dA
+dA
+dA
 dA
 dA
 dA
@@ -38217,7 +38180,7 @@ dA
 dA
 dA
 bk
-gf
+bk
 bk
 bk
 bk
@@ -38474,7 +38437,7 @@ dA
 dA
 dA
 bk
-PM
+gm
 gm
 go
 gw
@@ -38732,8 +38695,8 @@ dA
 dA
 bk
 gl
-eb
-gp
+gm
+Ly
 gx
 gm
 bk

--- a/maps/site53/site53areas.dm
+++ b/maps/site53/site53areas.dm
@@ -347,6 +347,12 @@
 	area_flags = AREA_FLAG_RAD_SHIELDED
 	sound_env = SMALL_ENCLOSED
 
+/area/site53/ulcz/humanoidcontainment
+	name = "\improper Humanoid Containment"
+	icon_state = "research"
+	area_flags = AREA_FLAG_RAD_SHIELDED
+	sound_env = SMALL_ENCLOSED
+
 /area/site53/ulcz/scp999
 	name = "\improper SCP-999"
 	icon_state = "research"


### PR DESCRIPTION
## Why It's Good For The Game
Adds containment chamber for Mister Fish and future humanoid SCPs that aren't too dangerous
Improve HCZ and LCZ checkpoint (LCZ checkpoint is more compact and more secure)
Makes HCZ spawn much closer to their checkpoint like how it was in the previous versions
Maintenance tunnels (some) were removed or tweaked to make containment zones more secure

This PR also includes Pizza's and Bjorn's changes (removal of unused manuals + Adding new SOP files to the checkpoints)

Papers Please !

## Changelog

:cl:
add: Adds in in-game SOP for testing.
code: Deletes some unused paper objects.
add: Humanoid Containment Zone (now only includes Mister Fish that was newly added)
add: LCZ and HCZ checkpoint tweaks
add: HCZ Security offices relocated to HCZ checkpoint
add: Some maintenance tunnels were removed to make LCZ more secure
/:cl:

![image](https://user-images.githubusercontent.com/113508764/232825734-0b59d765-5cbd-42ec-8a98-65dcc88942b6.png)
![image](https://user-images.githubusercontent.com/113508764/232825752-018d37c7-8af7-433f-ab06-70e681f1e334.png)
![image](https://user-images.githubusercontent.com/113508764/232825794-6be35f94-1a74-48df-8506-d3224534be2e.png)
