### PR TITLE
Fix repetitive hear() checks in hear_say

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -61,12 +61,12 @@
 		if(get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH && (can_see(speaker)))
 			message = "<b>[message]</b>"
 
-	if(!can_hear(speaker) || get_sound_volume_multiplier() < 0.2)
+	if(is_deaf() || get_sound_volume_multiplier() < 0.2)
 		if(!language || !(language.flags & INNATE)) // INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
 			if(speaker == src)
 				to_chat(src, SPAN_WARNING("You cannot hear yourself speak!"))
 			else if(can_see(speaker))
-				to_chat(src, "<span class='name'>[speaker_name]</span>[alt_name] talks but you cannot hear \him.")
+				to_chat(src, "<span class='name'>[speaker_name]</span>[alt_name] says something you cannot hear.")
 	else
 		if (language)
 			var/nverb = verb

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -61,7 +61,7 @@
 		if(get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH && (can_see(speaker)))
 			message = "<b>[message]</b>"
 
-	if(is_deaf() || get_sound_volume_multiplier() < 0.2)
+	if(!can_hear() || get_sound_volume_multiplier() < 0.2)
 		if(!language || !(language.flags & INNATE)) // INNATE is the flag for audible-emote-language, so we don't want to show an "x talks but you cannot hear them" message if it's set
 			if(speaker == src)
 				to_chat(src, SPAN_WARNING("You cannot hear yourself speak!"))

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -107,6 +107,8 @@
 				if(M.stat == DEAD && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH)
 					M.hear_say(message,verb,speaking,null,null, src)
 					continue
+				else if(M.stat == DEAD)
+					continue
 				if(M in listening)
 					M.hear_say(message,verb,speaking,null,null, src)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -107,7 +107,7 @@
 				if(M.stat == DEAD && M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH)
 					M.hear_say(message,verb,speaking,null,null, src)
 					continue
-				if(M.loc && (M.locs[1] in hearturfs))
+				if(M in listening)
 					M.hear_say(message,verb,speaking,null,null, src)
 
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -308,9 +308,6 @@
 			return FALSE
 	return TRUE
 
-/mob/proc/is_deaf()
-	return ((sdisabilities & DEAFENED) || ear_deaf || incapacitated(INCAPACITATION_KNOCKOUT))
-
 /mob/proc/can_hear(atom/origin)
 	if((sdisabilities & DEAFENED) || ear_deaf || incapacitated(INCAPACITATION_KNOCKOUT))
 		return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -308,6 +308,9 @@
 			return FALSE
 	return TRUE
 
+/mob/proc/is_deaf()
+	return ((sdisabilities & DEAFENED) || ear_deaf || incapacitated(INCAPACITATION_KNOCKOUT))
+
 /mob/proc/can_hear(atom/origin)
 	if((sdisabilities & DEAFENED) || ear_deaf || incapacitated(INCAPACITATION_KNOCKOUT))
 		return FALSE


### PR DESCRIPTION
## About the Pull Request

For some reason, the is_deaf call in hear_say was replaced with a can_hear call in #1011. This is a horrible idea, because anything calling hear_say **already checks for people in range.** Essentially, the code was calling hear(7, get_turf(src)) twice per hear_say call, because the code calling hear_say already does this.

Review silicon say.dm and mob/living say.dm to verify.
Tested and working on a local server.

## Why It's Good For The Game

This change also broke several things, including being able to hear the AI when it talks through a holopad.
This may or may not fix #1093, it seems related to this change.
Also, `\him` wasn't working for some reason. I just ported the upstream Baystation fix for this issue, which changes it to 'says something you cannot hear'

## Changelog

:cl:
fix: The AI talking through holopad with :h now works correctly again.
spellcheck: 'talks but you cannot hear .' has been replaced with 'says something you cannot hear.'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
