### PR TITLE
SCP-173 Transfer to Lower LCZ (From Upper LCZ)

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -510,6 +510,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "bn" = (
@@ -632,6 +635,9 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "bA" = (
@@ -876,6 +882,9 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "cb" = (
@@ -1091,6 +1100,14 @@
 /obj/structure/closet/secure_closet/guard/specialistshotgun,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/entrance_checkpoint)
+"cy" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 8;
+	name = "intercom (SCP-173)";
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "cA" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/window/reinforced,
@@ -1154,11 +1171,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "cJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/cable/green{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
@@ -1581,6 +1601,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/assignment)
+"dA" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "dB" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -2679,6 +2703,9 @@
 	name = "Hallway"
 	},
 /obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "gc" = (
@@ -3305,6 +3332,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "hR" = (
@@ -3543,6 +3573,11 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor,
 /area/site53/lhcz/scp049containment)
+"ik" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "il" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -4598,10 +4633,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/canteen)
+"kG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "kH" = (
 /obj/structure/disposalpipe/segment,
 /turf/unsimulated/mineral,
 /area/space)
+"kI" = (
+/obj/structure/bed/chair/office/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "kJ" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /turf/simulated/floor/tiled/monotile/white,
@@ -4780,6 +4825,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/canteen)
+"lg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "173custodial";
+	name = "Custodial Access";
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "lh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6280,6 +6335,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/lhcz/scp049containment)
+"oJ" = (
+/obj/effect/floor_decal/industrial/outline/orange,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "oK" = (
 /obj/machinery/camera/network/scp049{
 	dir = 1;
@@ -6374,6 +6433,15 @@
 "oV" = (
 /turf/simulated/floor/lino,
 /area/site53/lhcz/scp049containment)
+"oW" = (
+/obj/machinery/button/blast_door{
+	id_tag = "173emerg";
+	name = "Observation Emergency Blast Doors button";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "oY" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/lhcz/scp049containment)
@@ -6625,6 +6693,25 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/cellbubble)
+"pK" = (
+/obj/machinery/door/airlock/science{
+	name = "SCP-173";
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/ulcz/scp173)
 "pL" = (
 /obj/machinery/light{
 	dir = 8
@@ -7365,6 +7452,13 @@
 	},
 /turf/simulated/floor/lino,
 /area/site53/llcz/dclass/canteen)
+"rg" = (
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/camera/network/scp173{
+	c_tag = "173 Containment"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "rh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7507,6 +7601,19 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/maintenance)
+"rw" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/site53/llcz/hallways)
 "rx" = (
 /obj/item/modular_computer/console/preset/civilian{
 	dir = 1;
@@ -7700,6 +7807,21 @@
 /obj/item/storage/pill_bottle/amnesticsa,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
+"rY" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/site53/llcz/hallways)
 "sa" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8461,6 +8583,16 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
+"tY" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/site53/llcz/hallways)
 "tZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile/white,
@@ -8677,6 +8809,17 @@
 /obj/structure/closet,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkpoint)
+"uD" = (
+/obj/item/device/flashlight/pen,
+/obj/item/device/taperecorder,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "uE" = (
 /obj/machinery/cooker/fryer,
 /obj/machinery/camera/network/lcz{
@@ -8987,6 +9130,14 @@
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/beach/sand,
 /area/site53/llcz/dclass/luxuryhall)
+"vo" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/blast/regular{
+	id_tag = "173"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating,
+/area/site53/ulcz/scp173)
 "vq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -9014,6 +9165,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/cells)
+"vs" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/ulcz/scp173)
 "vt" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -9028,6 +9186,11 @@
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/disposalpipe/junction/yjunction,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor,
 /area/site53/llcz/hallways)
 "vv" = (
@@ -9434,6 +9597,20 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/cells)
+"wo" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "wp" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular{
@@ -9966,6 +10143,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500)
+"xw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "xx" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -10255,6 +10437,10 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/luxuryhall)
+"yn" = (
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/scp173)
 "yo" = (
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/titanium,
@@ -10289,6 +10475,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500)
+"yv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "yw" = (
 /obj/item/modular_computer/console/preset/security{
 	dir = 8;
@@ -10305,6 +10500,14 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
+"yy" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "intercom (SCP-173)"
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "yA" = (
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
@@ -10397,6 +10600,10 @@
 	name = "vinyl wooden floor"
 	},
 /area/site53/llcz/dclass/luxuryhall)
+"yP" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor,
+/area/site53/ulcz/scp173)
 "yQ" = (
 /obj/structure/table/marble,
 /obj/machinery/light{
@@ -10478,6 +10685,18 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkpoint)
+"zd" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/hallways)
 "zf" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -10594,6 +10813,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
+"zy" = (
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating,
+/area/site53/ulcz/scp173)
 "zA" = (
 /obj/machinery/light{
 	dir = 1
@@ -10691,6 +10914,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/luxurylibrary)
+"zP" = (
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warning/corner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "zQ" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/disposalpipe/segment{
@@ -10883,6 +11112,16 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/llcz/dclass/medicalpost/surgery)
+"An" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/blast/regular/open{
+	icon_state = "pdoor0";
+	id_tag = "173emerg"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Ao" = (
 /obj/machinery/flasher{
 	id_tag = "cell9";
@@ -11893,10 +12132,27 @@
 /obj/machinery/flasher/portable,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkequip)
+"CY" = (
+/obj/item/device/radio/intercom/locked{
+	dir = 4;
+	name = "intercom (SCP-173)";
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "CZ" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/dclass/primaryhallway)
+"Da" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Db" = (
 /obj/item/device/flashlight/pen,
 /obj/machinery/power/apc,
@@ -12306,6 +12562,29 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/cells)
+"Ec" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "173";
+	name = "Southern 173 Gate";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "173north";
+	name = "Northern 173 Gate";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "173emerg";
+	name = "Observation Emergency Blast Doors button";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Ed" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -12507,6 +12786,12 @@
 	name = "vinyl wooden floor"
 	},
 /area/site53/llcz/dclass/luxuryhall)
+"ED" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "EE" = (
 /obj/machinery/camera/network/lcz{
 	dir = 4
@@ -12669,6 +12954,15 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp8containment)
+"Fc" = (
+/obj/effect/catwalk_plated/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/site53/llcz/hallways)
 "Fd" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
@@ -12932,6 +13226,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500)
+"FL" = (
+/obj/effect/paint_stripe/gray,
+/obj/item/device/radio/intercom/locked{
+	dir = 1;
+	name = "intercom (SCP-173)"
+	},
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/scp173)
 "FM" = (
 /obj/structure/table/rack,
 /obj/item/storage/firstaid/regular,
@@ -13340,6 +13642,16 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/site53/lhcz/scp049containment)
+"He" = (
+/obj/structure/table/standard,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Hf" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -13387,6 +13699,9 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled,
 /area/site53/llcz/dclass/briefing)
+"Hm" = (
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Hn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -14105,6 +14420,14 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
+"IU" = (
+/obj/structure/mopbucket,
+/obj/machinery/light/small,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "IV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -14299,6 +14622,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uhcz/scp106parts)
+"Jt" = (
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating,
+/area/site53/ulcz/scp173)
 "Ju" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -14333,6 +14663,13 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/reeducation)
+"Jy" = (
+/obj/machinery/door/airlock/science{
+	name = "SCP-173 Observation";
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "JA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -14560,6 +14897,14 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
+"JY" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "SCP-173 Containment Chamber";
+	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "JZ" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -14872,6 +15217,15 @@
 	},
 /turf/simulated/floor/beach/sand,
 /area/site53/llcz/dclass/luxuryhall)
+"KK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/science{
+	name = "SCP-173 Containment Chamber";
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "KL" = (
 /obj/machinery/embedded_controller/radio/airlock/access_controller{
 	dir = 1;
@@ -14933,6 +15287,20 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/hallways)
+"KV" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24;
+	req_access = list("ACCESS_SCIENCE_LEVEL1")
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "KZ" = (
 /obj/machinery/camera/network/lcz{
 	dir = 1
@@ -15145,6 +15513,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/llcz/dclass/luxuryhall)
+"Lz" = (
+/obj/machinery/status_display,
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/ulcz/scp173)
 "LA" = (
 /obj/effect/paint_stripe/red,
 /obj/structure/sign/warning/biohazard,
@@ -15209,6 +15582,23 @@
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/luxuryhall)
+"LK" = (
+/obj/structure/closet/l3closet,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "LL" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/monotile/white,
@@ -15319,6 +15709,17 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/luxuryhall)
+"LX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin";
+	pixel_y = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "LY" = (
 /obj/structure/table/standard,
 /obj/item/storage/slide_projector,
@@ -15333,6 +15734,11 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/dclass/medicalpost/morgue)
+"Ma" = (
+/obj/effect/floor_decal/industrial/outline/orange,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Mb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15490,6 +15896,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/llcz/dclass/primaryhallway)
+"MA" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "MB" = (
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
@@ -15807,6 +16224,13 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkpoint)
+"Nx" = (
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/muzzle,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Ny" = (
 /obj/structure/bed/chair/shuttle{
 	name = "Reeducation Chair"
@@ -15844,6 +16268,10 @@
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/botany)
+"NE" = (
+/obj/structure/scp173_cage,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "NG" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
@@ -15890,6 +16318,14 @@
 /obj/item/clothing/head/soft/orange,
 /turf/simulated/floor/wood/maple,
 /area/site53/llcz/dclass/luxurysleep)
+"NL" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/blast/regular{
+	id_tag = "173north"
+	},
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating,
+/area/site53/ulcz/scp173)
 "NM" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
@@ -16070,6 +16506,14 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/primaryhallway)
+"Oj" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	icon_state = "pdoor0";
+	id_tag = "173emerg"
+	},
+/turf/simulated/floor,
+/area/site53/ulcz/scp173)
 "Ok" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -16839,6 +17283,11 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/mine/unexplored)
+"Qt" = (
+/obj/item/paper/scp/euclid/scp173,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Qu" = (
 /obj/machinery/light{
 	dir = 8
@@ -17202,6 +17651,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/scp8containment)
+"Rt" = (
+/obj/machinery/door/airlock/science{
+	name = "SCP-173 Containment Chamber";
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Ru" = (
 /obj/machinery/light{
 	dir = 8
@@ -17339,6 +17795,16 @@
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
+"RO" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "SCP-173 Cleaning Supplies"
+	},
+/obj/machinery/door/blast/regular/open{
+	icon_state = "pdoor0";
+	id_tag = "173custodial"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "RQ" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
@@ -17410,6 +17876,19 @@
 	},
 /turf/simulated/floor,
 /area/site53/lhcz/hallway)
+"RZ" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
+"Sa" = (
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor/plating,
+/area/site53/ulcz/scp173)
 "Sb" = (
 /obj/effect/floor_decal/industrial/firstaid/corner{
 	dir = 1
@@ -17512,6 +17991,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp8containment)
+"Sp" = (
+/obj/structure/closet,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25;
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/scp173)
 "Sq" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/bed/roller,
@@ -17796,6 +18288,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/scp8containment)
+"Tc" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Td" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/leafybush,
@@ -18078,6 +18574,12 @@
 	},
 /turf/simulated/floor,
 /area/site53/llcz/dclass/medicalpost)
+"TT" = (
+/obj/effect/landmark{
+	name = "scp173"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "TU" = (
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 10
@@ -18204,6 +18706,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/mining/miningops)
+"Uk" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/site53/ulcz/scp173)
 "Ul" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera/network/lcz,
@@ -18212,6 +18721,11 @@
 /obj/item/stack/medical/splint,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
+"Um" = (
+/obj/machinery/light,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Un" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/freezer,
@@ -18609,10 +19123,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/llczmaint)
+"Vr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Vs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentline)
+"Vt" = (
+/obj/machinery/door/blast/regular/open{
+	icon_state = "pdoor0";
+	id_tag = "173emerg"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Vu" = (
 /obj/effect/floor_decal/industrial/warning/full,
 /obj/structure/cable/green{
@@ -18835,6 +19362,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uhcz/scp106parts)
+"Wa" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Wb" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -18983,6 +19519,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
+"Wx" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Wy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -19079,6 +19619,12 @@
 "WG" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkcryo)
+"WH" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "WI" = (
 /obj/machinery/camera/autoname{
 	network = list("SCP-247 CCTV Network")
@@ -19161,6 +19707,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/llcz/dclass/primaryhallway)
+"WW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "WX" = (
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/medicalpost/surgery)
@@ -19326,6 +19881,23 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/uhcz/scp8containment)
+"Xu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "173";
+	name = "Southern 173 Gate";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "173north";
+	name = "Northern 173 Gate";
+	pixel_y = 9;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Xv" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/bed/roller,
@@ -19417,6 +19989,18 @@
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
+"XF" = (
+/obj/structure/closet,
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 26
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/ulcz/scp173)
 "XG" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -19429,6 +20013,22 @@
 /obj/effect/floor_decal/corner/beige/mono,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/luxuryhall)
+"XI" = (
+/obj/structure/closet/l3closet,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/head/bio_hood/general,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/obj/item/clothing/shoes/white,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "XJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -19817,6 +20417,12 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/uhcz/scp106parts)
+"YK" = (
+/obj/item/device/radio,
+/obj/item/device/radio,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "YL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -20022,6 +20628,12 @@
 "Zr" = (
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/medicalpost/morgue)
+"Zs" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "Zt" = (
 /obj/structure/cable/green,
 /obj/effect/floor_decal/corner/b_green/mono,
@@ -20137,6 +20749,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
+"ZG" = (
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/site53/llcz/hallways)
 "ZH" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /turf/simulated/floor/tiled/steel_grid,
@@ -20218,6 +20834,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
+"ZU" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/scp173)
 "ZV" = (
 /obj/structure/table/rack,
 /obj/item/device/flashlight,
@@ -33945,29 +34567,29 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
 cQ
-cc
+vd
 cc
 tH
 cc
@@ -34202,29 +34824,29 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+ZG
+MG
+cc
+cc
+ex
+cc
+cc
+cc
+ex
+cc
+cc
+cc
+cc
+ex
+cc
+cc
+cc
+ex
+cc
+cc
+cF
 cQ
-vd
+MG
 ch
 ch
 ch
@@ -34459,30 +35081,30 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-cQ
-MG
-ch
+ZG
+cc
+rY
+Fc
+Fc
+Fc
+Fc
+Fc
+Fc
+Fc
+Fc
+Fc
+Fc
+Fc
+Fc
+tY
+Fc
+Fc
+Fc
+Fc
+Fc
+zd
+Fc
+Fc
 cJ
 hQ
 hQ
@@ -34716,29 +35338,29 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-cQ
+ZG
+MG
+rw
 cc
+ec
+cc
+cc
+cc
+ec
+cc
+cc
+cc
+cc
+ec
+cc
+cc
+cc
+ec
+cc
+cc
+cF
+cQ
+MG
 ch
 cW
 ff
@@ -34973,27 +35595,27 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+ZG
+cc
+rw
+cc
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
+ZG
 cQ
 cc
 cc
@@ -35230,11 +35852,11 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
+ZG
+MG
+rw
+cc
+ZG
 gq
 gq
 gq
@@ -35486,20 +36108,20 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+yn
+yn
+pK
+yn
+yn
+yn
+yn
+yn
+yn
+yn
+yn
+yn
+yn
 gq
 gq
 gq
@@ -35743,20 +36365,20 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+KV
+MA
+wo
+Zs
+Rt
+Hm
+ED
+Ma
+yn
+Tc
+Tc
+He
+yn
 gq
 gq
 gq
@@ -36000,26 +36622,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+Lz
+Nx
+Hm
+WW
+xw
+KK
+xw
+yv
+oJ
+yn
+IU
+Hm
+LK
+yn
+yn
+yn
+yn
+yn
+yn
+yn
 gq
 gq
 gq
@@ -36257,26 +36879,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+yP
+Jy
+yP
+yP
+Oj
+Hm
+Vr
+oJ
+yn
+IU
+Hm
+XI
+yn
+oJ
+Hm
+cy
+Hm
+oJ
+yn
 gq
 ho
 kH
@@ -36514,26 +37136,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+LX
+Hm
+JY
+uD
+Oj
+Hm
+Vr
+zP
+yn
+yn
+RO
+yn
+Lz
+Da
+Hm
+Hm
+Hm
+Wx
+yn
 gq
 Eh
 gq
@@ -36771,26 +37393,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+Hm
+Hm
+kI
+ik
+Oj
+Hm
+Vr
+Sa
+NL
+vs
+zy
+vs
+vo
+Jt
+Hm
+Hm
+Hm
+Hm
+yn
 gq
 Eh
 gq
@@ -37028,26 +37650,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+oW
+Hm
+dA
+Xu
+Oj
+Hm
+Vr
+Sa
+NL
+zy
+zy
+zy
+vo
+Jt
+Hm
+TT
+Hm
+Hm
+yn
 gq
 Eh
 gq
@@ -37285,26 +37907,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+NE
+Hm
+Hm
+yy
+Oj
+Hm
+Vr
+Sa
+NL
+Uk
+zy
+Uk
+vo
+Jt
+Hm
+Hm
+Hm
+Hm
+yn
 gq
 Eh
 gq
@@ -37542,26 +38164,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+Hm
+Hm
+kI
+ik
+Oj
+Hm
+Vr
+RZ
+yn
+yn
+Oj
+yn
+Lz
+Wa
+Hm
+Hm
+Hm
+Wx
+yn
 gq
 Eh
 gq
@@ -37799,26 +38421,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+WH
+Hm
+YK
+Qt
+Oj
+Vt
+An
+Vt
+yn
+Ec
+lg
+ik
+yn
+rg
+Hm
+CY
+Hm
+oJ
+yn
 gq
 Eh
 gq
@@ -38056,26 +38678,26 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+Hm
+Hm
+kG
+Hm
+Jy
+Hm
+Vr
+Hm
+Jy
+Hm
+Hm
+kI
+FL
+yn
+yn
+yn
+yn
+yn
+yn
 gq
 Eh
 gq
@@ -38313,20 +38935,20 @@ gq
 gq
 gq
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+Sp
+XF
+yn
+yn
+yn
+Hm
+ZU
+Wx
+yn
+LX
+YK
+Um
+yn
 gq
 gq
 gq
@@ -38570,20 +39192,20 @@ gq
 gq
 gq
 gq
+yn
+yn
+yn
+yn
 gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
-gq
+yn
+yn
+yn
+yn
+yn
+yn
+yn
+yn
+yn
 gq
 gq
 gq

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -38232,7 +38232,7 @@
 	id_tag = "ULCZ Checkpoint Central Window";
 	name = "ULCZ Checkpoint Central Window";
 	pixel_y = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/machinery/light{
 	dir = 8

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -3016,14 +3016,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/engineering/breakroom)
-"ajw" = (
-/obj/structure/mopbucket,
-/obj/machinery/light/small,
-/obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "ajx" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 10
@@ -4166,11 +4158,6 @@
 "aml" = (
 /turf/simulated/floor/reinforced/airless,
 /area/vacant/prototype/engine)
-"amm" = (
-/obj/machinery/status_display,
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/scp173)
 "amo" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/r_wall/prepainted,
@@ -10646,11 +10633,6 @@
 "aBZ" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp895)
-"aCa" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/plating,
-/area/site53/ulcz/scp173)
 "aCb" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/blast/regular{
@@ -10660,14 +10642,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
-"aCc" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/blast/regular{
-	id_tag = "173"
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/plating,
-/area/site53/ulcz/scp173)
 "aCd" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/monotile,
@@ -10759,13 +10733,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint)
-"aCr" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/plating,
-/area/site53/ulcz/scp173)
 "aCt" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -11639,22 +11606,6 @@
 /obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
-"aEx" = (
-/obj/structure/closet/l3closet,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/shoes/white,
-/obj/item/clothing/shoes/white,
-/obj/item/clothing/shoes/white,
-/obj/item/clothing/shoes/white,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aEz" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/structure/cable/green{
@@ -13156,36 +13107,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp151)
-"aJH" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	req_access = list("ACCESS_SCIENCE_LEVEL1")
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aJI" = (
-/obj/item/clothing/mask/muzzle,
-/obj/item/clothing/mask/muzzle,
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/muzzle,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aJL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aJM" = (
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aJN" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -13207,31 +13128,6 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/open,
 /area/site53/ulcz/hallways)
-"aJS" = (
-/obj/structure/closet,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25;
-	req_access = list("ACCESS_SECURITY_LEVEL1")
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/ulcz/scp173)
-"aJT" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "SCP-173 Containment Chamber";
-	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aJU" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aJX" = (
 /obj/machinery/light{
 	dir = 4
@@ -13243,12 +13139,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
 /area/site53/reswing/xenobiology)
-"aJZ" = (
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aKa" = (
 /obj/structure/railing/mapped,
 /obj/structure/cable/green{
@@ -13456,59 +13346,12 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
-"aKw" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aKx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aKy" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
-"aKA" = (
-/obj/item/paper/scp/euclid/scp173,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aKB" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aKC" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "intercom (SCP-173)"
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aKD" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aKE" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
@@ -13520,17 +13363,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
-"aKG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aKH" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -13548,41 +13380,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aKJ" = (
-/obj/machinery/door/airlock/science{
-	name = "SCP-173 Observation";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aKK" = (
 /obj/structure/extinguisher_cabinet,
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/prepainted,
 /area/site53/reswing/xenobiology)
-"aKL" = (
-/obj/structure/closet,
-/obj/item/device/radio,
-/obj/item/device/radio,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 26
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/site53/ulcz/scp173)
 "aKM" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
@@ -13593,10 +13400,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
-"aKO" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aKP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/civilian{
@@ -13604,33 +13407,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
-"aKQ" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aKR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aKS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aKT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aKW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13721,37 +13497,8 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aLf" = (
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aLg" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aLh" = (
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "173emerg"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aLi" = (
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aLk" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 8;
-	icon_state = "warningcorner"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
+/turf/space,
+/area/space)
 "aLl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -13826,38 +13573,6 @@
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
-"aLA" = (
-/obj/machinery/door/airlock/science{
-	name = "SCP-173";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/ulcz/scp173)
-"aLB" = (
-/obj/effect/floor_decal/industrial/outline/orange,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aLC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aLD" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/door/blast/regular/open{
@@ -13881,22 +13596,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
-"aLH" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/industrial/warning/corner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aLI" = (
-/obj/effect/floor_decal/industrial/outline/orange,
-/obj/machinery/camera/network/scp173{
-	c_tag = "173 Containment"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aLJ" = (
 /obj/structure/bed/chair/office/light{
 	dir = 1;
@@ -14010,31 +13709,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
-"aLZ" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 8;
-	name = "intercom (SCP-173)";
-	pixel_x = -32
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"aMa" = (
-/obj/effect/landmark{
-	name = "scp173"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aMb" = (
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
-"aMc" = (
-/obj/item/device/radio/intercom/locked{
-	dir = 4;
-	name = "intercom (SCP-173)";
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aMd" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
@@ -14060,10 +13737,6 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aMh" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aMi" = (
 /obj/machinery/light{
 	dir = 8
@@ -14107,10 +13780,6 @@
 "aMp" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics)
-"aMq" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor,
-/area/site53/ulcz/scp173)
 "aMt" = (
 /obj/machinery/power/terminal,
 /obj/structure/catwalk,
@@ -14154,14 +13823,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"aMy" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "173emerg"
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/scp173)
 "aMz" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light{
@@ -14180,10 +13841,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/hallways)
-"aMB" = (
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/scp173)
 "aMC" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
@@ -15864,17 +15521,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
-"aRK" = (
-/obj/item/device/flashlight/pen,
-/obj/item/device/taperecorder,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aRL" = (
 /obj/machinery/light{
 	dir = 4
@@ -16058,11 +15704,6 @@
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/surface/explorers)
-"aSv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aSx" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -16246,13 +15887,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
-"aTj" = (
-/obj/machinery/door/airlock/science{
-	name = "SCP-173 Containment Chamber";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aTk" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -16292,17 +15926,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aTs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aTu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -16445,15 +16068,6 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aTW" = (
-/obj/machinery/button/blast_door{
-	id_tag = "173emerg";
-	name = "Observation Emergency Blast Doors button";
-	pixel_y = 25;
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aTY" = (
 /obj/effect/paint_stripe/red,
 /obj/effect/paint_stripe/red,
@@ -17120,15 +16734,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
-"aWh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/science{
-	name = "SCP-173 Containment Chamber";
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aWj" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -17583,11 +17188,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
-"aXC" = (
-/obj/machinery/light,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "aXD" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/monotile/white,
@@ -20369,10 +19969,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/explorers)
-"bgz" = (
-/obj/structure/scp173_cage,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "bgE" = (
 /obj/machinery/camera/network/lcz,
 /turf/simulated/floor/tiled/monotile/white,
@@ -20877,12 +20473,6 @@
 "bix" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
-"biy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/prepainted,
-/area/site53/llcz/entrance_checkpoint)
 "biz" = (
 /obj/effect/floor_decal/corner/red/border,
 /obj/structure/table/reinforced,
@@ -22983,13 +22573,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
-"cYP" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/site53/ulcz/scp173)
 "cZG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/monotile,
@@ -23047,20 +22630,6 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
-"ddw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "SCP-173 Cleaning Supplies"
-	},
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "173custodial"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
-"ddz" = (
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/prepainted,
-/area/site53/llcz/entrance_checkpoint)
 "ddA" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/floor_decal/industrial/outline/red,
@@ -24581,7 +24150,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/catwalk_plated/white,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "fgG" = (
@@ -25274,14 +24842,6 @@
 /obj/item/clothing/glasses/blindfold,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
-"fSE" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/door/blast/regular{
-	id_tag = "173north"
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/plating,
-/area/site53/ulcz/scp173)
 "fSH" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /turf/simulated/floor/tiled/techmaint,
@@ -26946,13 +26506,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
-"hLQ" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/site53/ulcz/scp173)
 "hLU" = (
 /obj/machinery/botany/extractor,
 /obj/machinery/light{
@@ -27621,16 +27174,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
-"iqI" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	dir = 4;
-	id_tag = "173custodial";
-	name = "Custodial Access";
-	req_access = list("ACCESS_SECURITY_LEVEL5")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "iqN" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27740,29 +27283,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
-"izM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "173";
-	name = "Southern 173 Gate";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "173north";
-	name = "Northern 173 Gate";
-	pixel_y = 9;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "173emerg";
-	name = "Observation Emergency Blast Doors button";
-	pixel_y = 25;
-	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "izS" = (
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 4
@@ -27956,16 +27476,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
-"iNl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "173emerg"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "iNV" = (
 /obj/machinery/light{
 	dir = 1
@@ -31039,10 +30549,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp457containment)
-"msC" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "mtc" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
@@ -32174,23 +31680,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
-"nDH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "173";
-	name = "Southern 173 Gate";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "173north";
-	name = "Northern 173 Gate";
-	pixel_y = 9;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "nFS" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
@@ -34015,10 +33504,6 @@
 /area/site53/llcz/scp500{
 	requires_power = 0
 	})
-"pUO" = (
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor/plating,
-/area/site53/ulcz/scp173)
 "pVm" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters/open{
@@ -35075,8 +34560,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/catwalk_plated/white,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "rmE" = (
@@ -35755,14 +35238,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"scy" = (
-/obj/effect/paint_stripe/gray,
-/obj/item/device/radio/intercom/locked{
-	dir = 1;
-	name = "intercom (SCP-173)"
-	},
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/scp173)
 "sdl" = (
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
@@ -35808,13 +35283,14 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
 "sfp" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/sign/scp/euclid_scp{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "sgZ" = (
 /obj/machinery/light,
@@ -36015,23 +35491,6 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/llcz/scp066)
-"sqS" = (
-/obj/structure/closet/l3closet,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/suit/bio_suit/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/head/bio_hood/general,
-/obj/item/clothing/shoes/white,
-/obj/item/clothing/shoes/white,
-/obj/item/clothing/shoes/white,
-/obj/item/clothing/shoes/white,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "srm" = (
 /obj/machinery/bodyscanner{
 	dir = 1
@@ -38049,16 +37508,6 @@
 /obj/item/device/camera_film,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp513)
-"uWH" = (
-/obj/structure/table/standard,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/scp173)
 "uWI" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 9
@@ -39908,13 +39357,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/humanoidcontainment)
-"wZX" = (
-/obj/effect/paint_stripe/gray,
-/obj/structure/sign/directions/ez{
-	dir = 8
-	},
-/turf/simulated/wall/prepainted,
-/area/site53/ulcz/hallways)
 "xac" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/reinforced,
@@ -40908,17 +40350,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
 	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -50077,13 +49508,13 @@ aNI
 aNJ
 aNI
 ffT
-aVI
-aVI
+sfp
+sfp
 rmo
-vEB
-hCq
-vEB
-vEB
+aPp
+aPq
+aPp
+aPp
 aKI
 afp
 afp
@@ -50341,7 +49772,7 @@ aMX
 aVS
 apj
 aKq
-aWF
+aFe
 aKq
 aEt
 aVS
@@ -50598,7 +50029,7 @@ aVS
 aVS
 aWt
 aGM
-qKl
+aFe
 aGM
 aGM
 aVS
@@ -50855,7 +50286,7 @@ azA
 aVS
 aVS
 aVS
-aWw
+aTn
 aVS
 aVS
 aVS
@@ -51112,7 +50543,7 @@ azA
 azA
 aVS
 aXf
-qKl
+aFe
 aXf
 aVS
 azA
@@ -51369,7 +50800,7 @@ azA
 azA
 aVS
 aGM
-qKl
+aFe
 aGM
 aVS
 azA
@@ -51626,7 +51057,7 @@ azA
 azA
 aVS
 aGM
-qKl
+aFe
 cIC
 aVS
 azA
@@ -51883,7 +51314,7 @@ azA
 azA
 aVS
 aGM
-qKl
+aFe
 aGM
 aVS
 azA
@@ -52140,7 +51571,7 @@ azA
 azA
 aVS
 aGM
-qKl
+aFe
 aGM
 aVS
 azA
@@ -52397,7 +51828,7 @@ azA
 azA
 aVS
 pSE
-qKl
+aFe
 pSE
 aVS
 azA
@@ -52654,7 +52085,7 @@ azA
 aVS
 aVS
 aVS
-aWw
+aTn
 aVS
 aVS
 aVS
@@ -52911,7 +52342,7 @@ aVS
 aVS
 aGM
 aXf
-aWF
+aFe
 aXf
 aGM
 aVS
@@ -53168,7 +52599,7 @@ aEt
 aVS
 aGM
 aKq
-aWF
+aFe
 aKq
 aGM
 aVS
@@ -53682,7 +53113,7 @@ aEt
 aVS
 aGM
 aKq
-aWF
+aKq
 aKq
 aGM
 aVS
@@ -53939,7 +53370,7 @@ aVS
 aVS
 qYN
 pSE
-aWF
+aKq
 pSE
 aGM
 aVS
@@ -54196,7 +53627,7 @@ azA
 aVS
 aVS
 aVS
-aWw
+aVS
 aVS
 aVS
 aVS
@@ -54451,11 +53882,11 @@ azA
 azA
 azA
 azA
-aVS
-aXf
-qKl
-aXf
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -54708,11 +54139,11 @@ azA
 azA
 azA
 azA
-wZX
-aGM
-qKl
-aGM
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -54965,11 +54396,11 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-qKl
-cIC
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -55222,11 +54653,11 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-qKl
-aGM
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -55479,11 +54910,11 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-qKl
-aGM
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -55736,11 +55167,11 @@ azA
 azA
 azA
 azA
-aVS
-sfp
-qKl
-pSE
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -55992,20 +55423,20 @@ azA
 azA
 azA
 azA
-aMB
-aMB
-aMB
-aLA
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -56249,20 +55680,20 @@ azA
 azA
 azA
 azA
-aMB
-aJH
-aKG
-aKw
-aLg
-aTj
-aJM
-aKQ
-aLf
-aMB
-aKO
-aKO
-uWH
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -56506,26 +55937,26 @@ azA
 azA
 azA
 azA
-amm
-aJI
-aJM
-aKx
-aSv
-aWh
-aSv
-aKR
-aLB
-aMB
-ajw
-aJM
-sqS
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -56711,7 +56142,7 @@ azA
 azA
 azA
 azA
-azA
+aLf
 azA
 azA
 azA
@@ -56763,26 +56194,26 @@ azA
 azA
 azA
 azA
-aMB
-aMq
-aKJ
-aMq
-aMq
-aMy
-aJM
-aKS
-aLB
-aMB
-ajw
-aJM
-aEx
-aMB
-aLB
-aJM
-aLZ
-aJM
-aJM
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57020,26 +56451,26 @@ azA
 azA
 azA
 azA
-aMB
-aTs
-aJM
-aJT
-aRK
-aMy
-aJM
-aKS
-aLi
-aMB
-aMB
-ddw
-aMB
-amm
-aLC
-aJM
-aJM
-aJM
-aMh
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57277,26 +56708,26 @@ azA
 azA
 azA
 azA
-aMB
-aJM
-aJM
-aJU
-aKB
-aMy
-aJM
-aKS
-aCa
-fSE
-cYP
-pUO
-cYP
-aCc
-aCr
-aJM
-aJM
-aJM
-aJM
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57534,26 +56965,26 @@ azA
 azA
 azA
 azA
-aMB
-aTW
-aJM
-msC
-nDH
-aMy
-aJM
-aKS
-aCa
-fSE
-pUO
-pUO
-pUO
-aCc
-aCr
-aJM
-aMa
-aJM
-aJM
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57791,26 +57222,26 @@ azA
 azA
 azA
 azA
-aMB
-bgz
-aJM
-aJM
-aKC
-aMy
-aJM
-aKS
-aCa
-fSE
-hLQ
-pUO
-hLQ
-aCc
-aCr
-aJM
-aJM
-aJM
-aJM
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58048,26 +57479,26 @@ azA
 azA
 azA
 azA
-aMB
-aJM
-aJM
-aJU
-aKB
-aMy
-aJM
-aKS
-aLk
-aMB
-aMB
-aMy
-aMB
-amm
-aLH
-aJM
-aJM
-aJM
-aMh
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58305,26 +57736,26 @@ azA
 azA
 azA
 azA
-aMB
-aJL
-aJM
-aJZ
-aKA
-aMy
-aLh
-iNl
-aLh
-aMB
-izM
-iqI
-aKB
-aMB
-aLI
-aJM
-aMc
-aJM
-aLB
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58514,7 +57945,7 @@ azA
 azA
 azA
 azA
-azA
+aLf
 azA
 azA
 azA
@@ -58562,26 +57993,26 @@ azA
 azA
 azA
 azA
-aMB
-aJM
-aJM
-aKD
-aJM
-aKJ
-aJM
-aKS
-aJM
-aKJ
-aJM
-aJM
-aJU
-scy
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58819,20 +58250,20 @@ azA
 azA
 azA
 azA
-aMB
-aJS
-aKL
-aMB
-aMB
-aMB
-aJM
-aKT
-aMh
-aMB
-aTs
-aJZ
-aXC
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59076,20 +58507,20 @@ azA
 azA
 azA
 azA
-aMB
-aMB
-aMB
-aMB
 azA
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
-aMB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60340,7 +59771,7 @@ cqF
 aGZ
 ing
 hUS
-ddz
+cqF
 azA
 agU
 agU
@@ -60597,8 +60028,8 @@ cqF
 aGZ
 mXc
 qPN
-biy
-biy
+cqF
+cqF
 bjv
 kVb
 qhP

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -20425,12 +20425,12 @@
 /obj/structure/table/standard,
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL3");
+	req_access = list("ACCESS_SECURITY_LEVEL2");
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Booth";
-	req_access = list("ACCESS_SECURITY_LEVEL3");
+	req_access = list("ACCESS_SECURITY_LEVEL2");
 	dir = 8
 	},
 /obj/machinery/door/blast/shutters{

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -13496,9 +13496,6 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aLf" = (
-/turf/space,
-/area/space)
 "aLl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -56142,7 +56139,7 @@ azA
 azA
 azA
 azA
-aLf
+azA
 azA
 azA
 azA
@@ -57945,7 +57942,7 @@ azA
 azA
 azA
 azA
-aLf
+azA
 azA
 azA
 azA


### PR DESCRIPTION
## About the Pull Request
See title

## Why It's Good For The Game
Shorter travel time to escort Class Ds to the SCP. Important to avoid constant breaches. 

## Changelog

:cl:
add: SCP 173 Chamber on Upper LCZ has been moved down one Z-Level in the corridor that faces CDCZ. Getting there is now a small walk of 1 minute from CDCZ. 
add: Some pipings and wiring was removed or otherwise changed to pass checks and avoid redundancies
add: Fixed 3 inconsistent walls not being of same material as the others in ULCZ
fix: Fixed windoors and button access level in LCZ checkpoint
/:cl:


