### PR TITLE
R_MOD changes

### DIFF
--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -23,15 +23,15 @@
 	if(!message)	return
 	var/F = investigate_subject2file(subject)
 	if(!F)	return
-	to_chat(F, "<small>[time_stamp()] \ref[src] ([x],[y],[z])</small> || [src] [message]<br>")
+	to_file(F, "<small>[time_stamp()] \ref[src] ([x],[y],[z])</small> || [src] [message]<br>")
 
 //ADMINVERBS
-/client/proc/investigate_show( subject in list("hrefs","notes","singulo","telesci") )
+/client/proc/investigate_show( subject in list("hrefs","wires","singulo") )
 	set name = "Investigate"
 	set category = "Admin"
 	if(!holder)	return
 	switch(subject)
-		if("singulo", "telesci")			//general one-round-only stuff
+		if("singulo", "wires")			//general one-round-only stuff
 			var/F = investigate_subject2file(subject)
 			if(!F)
 				to_chat(src, SPAN_WARNING("Error: admin_investigate: [INVESTIGATE_DIR][subject] is an invalid path or cannot be accessed."))

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -303,7 +303,8 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/sendFax,
 	/client/proc/check_fax_history,
 	/datum/admins/proc/paralyze_mob, // right-click paralyze ,
-	/client/proc/cmd_admin_say
+	/client/proc/cmd_admin_say,
+	/client/proc/investigate_show
 )
 var/list/admin_verbs_mentors = list(
 	/client/proc/cmd_mentor_say,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -304,7 +304,8 @@ var/list/admin_verbs_mod = list(
 	/client/proc/check_fax_history,
 	/datum/admins/proc/paralyze_mob, // right-click paralyze ,
 	/client/proc/cmd_admin_say,
-	/client/proc/investigate_show
+	/client/proc/investigate_show,
+	/datum/admins/proc/view_txt_log
 )
 var/list/admin_verbs_mentors = list(
 	/client/proc/cmd_mentor_say,

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1120,7 +1120,7 @@
 		ticket.close(client_repository.get_lite_client(usr.client))
 
 	else if(href_list["adminplayerobservecoodjump"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN|R_MOD))	return
 
 		var/x = text2num(href_list["X"])
 		var/y = text2num(href_list["Y"])

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -93,7 +93,7 @@
 		ticket.close(client_repository.get_lite_client(usr.client))
 
 	if (GLOB.href_logfile)
-		to_chat(GLOB.href_logfile, "<small>[time2text(world.timeofday,"hh:mm")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>")
+		to_file(GLOB.href_logfile, "<small>[time2text(world.timeofday,"hh:mm")] [src] (usr:[usr])</small> || [hsrc ? "[hsrc] " : ""][href]<br>")
 
 	switch(href_list["_src_"])
 		if("holder")


### PR DESCRIPTION
## About the Pull Request

tin

## Why It's Good For The Game

some dude cut like every single wire to 106 and the only log is in investigate. a LOT of logs are only in investigate.
literally powerless since can't know who did it since no logs
there is 0 reason this verb can't be accessible

also, mods should have access to the adminplayerobservecoodjump, because they can already access most `JMP` buttons except for a few that use this
there's no reason i can access the attack logs but not any of the `JMP` buttons in there to see where the fight happened without manually varediting for x and y

## Changelog

:cl:
admin: Added investigate verb to mods.
admin: Mods can now check today's server logs for all rounds for the day.
admin: Mods can now use most `JMP` buttons on logs.
fix: Href logging now works, so does all other investigate_log categories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
