### PR TITLE
New EZ Office (Level 4); New LCZ Offices, Level 4 Command Sector Reorganization and Admin Panic Bunker

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -1557,12 +1557,13 @@
 "dv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 10;
+	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "dw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1661,21 +1662,27 @@
 /turf/simulated/floor,
 /area/site53/lhcz/scp049containment)
 "dH" = (
-/obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 6;
-	icon_state = "warning"
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/obj/structure/railing/mapped,
 /obj/structure/sign/dclass{
 	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Secure APC";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
@@ -1896,15 +1903,16 @@
 /area/site53/uhcz/scp8containment)
 "el" = (
 /obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 12
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
@@ -2159,16 +2167,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/assignmentbubble)
 "eP" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "eR" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -2180,11 +2183,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost/chem)
 "eS" = (
-/obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "eT" = (
@@ -2207,14 +2213,12 @@
 /area/site53/llcz/scp500)
 "eV" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warning{
-	dir = 9
-	},
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/obj/structure/railing/mapped{
-	dir = 1
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
@@ -4937,9 +4941,16 @@
 /area/site53/llcz/dclass/cellbubble)
 "lr" = (
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/industrial/warning/corner{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "ls" = (
@@ -6681,7 +6692,15 @@
 /obj/machinery/camera/network/lcz{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "pG" = (
 /obj/structure/cable/green{
@@ -8437,17 +8456,15 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost)
 "tF" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "tH" = (
 /obj/machinery/camera/network/lcz{
@@ -10680,7 +10697,15 @@
 /obj/machinery/camera/network/lcz{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "yY" = (
 /obj/structure/railing/mapped{
@@ -10984,12 +11009,6 @@
 /area/site53/llcz/dclass/briefing)
 "zT" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/blast_door{
-	id_tag = "dclasscells";
-	name = "Cell Lock";
-	pixel_y = 2;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/cellbubble)
 "zU" = (
@@ -11197,8 +11216,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
@@ -12256,6 +12277,17 @@
 /obj/structure/closet/secure_closet/freezer/kitchen/mining,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/kitchen)
+"Dl" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/dclass/primaryhallway)
 "Dm" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/button/flasher{
@@ -14991,14 +15023,25 @@
 	id_tag = "Security Bubble Window";
 	name = "Security Bubble Windows"
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	dir = 8;
-	id_tag = "Security Bubble Lockdown";
-	name = "Security Bubble Lockdown"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/checkpoint)
+"Kd" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/dclass/primaryhallway)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -15694,12 +15737,6 @@
 	id_tag = "Security Bubble Window";
 	name = "Security Bubble Windows"
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	dir = 8;
-	id_tag = "Security Bubble Lockdown";
-	name = "Security Bubble Lockdown"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/checkpoint)
 "LP" = (
@@ -15948,14 +15985,23 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/assignmentbubble)
 "Mz" = (
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/primaryhallway)
 "MA" = (
 /obj/structure/cable/green{
@@ -18173,12 +18219,6 @@
 /area/site53/llcz/dclass/assignmentbubble)
 "SF" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	dir = 8;
-	id_tag = "Security Bubble Lockdown";
-	name = "Security Bubble Lockdown"
-	},
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
 	id_tag = "Security Bubble Window";
@@ -20570,12 +20610,6 @@
 /area/site53/llcz/dclass/assignmentbubble)
 "YU" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	dir = 8;
-	id_tag = "Security Bubble Lockdown";
-	name = "Security Bubble Lockdown"
-	},
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
 	id_tag = "Security Bubble Window";
@@ -31883,7 +31917,7 @@ uf
 uf
 uf
 uf
-DM
+uf
 dC
 uf
 wV
@@ -32140,7 +32174,7 @@ uf
 uf
 uf
 uf
-DM
+uf
 dC
 uf
 uO
@@ -32398,7 +32432,7 @@ uf
 uf
 uf
 Mz
-dC
+Kd
 eZ
 wV
 tj
@@ -32655,7 +32689,7 @@ JV
 JV
 JV
 sf
-dC
+Dl
 uf
 NB
 et
@@ -32913,7 +32947,7 @@ rE
 tQ
 Nb
 Aq
-tF
+iD
 wu
 SG
 SG
@@ -33429,8 +33463,8 @@ Ks
 dH
 eP
 pF
-uf
-uf
+tF
+tF
 el
 Lt
 eS

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -11721,11 +11721,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aFf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
 "aFg" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
@@ -16298,13 +16293,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"aVB" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/research{
-	name = "Hallway"
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
 "aVD" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
@@ -21767,13 +21755,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
-"cqT" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
 "crR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -43969,13 +43950,13 @@ aGM
 aGt
 aGq
 aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
+aGM
+aGM
+aXf
+aGM
+aGM
+aXf
+aGM
 aVS
 azA
 azA
@@ -44228,10 +44209,10 @@ aGM
 aVS
 aGM
 aGM
-aXf
 aGM
 aGM
-aXf
+aGM
+aGM
 aGM
 aVS
 azA
@@ -44736,7 +44717,7 @@ azA
 aVS
 aGM
 aGM
-aKq
+aGM
 aHM
 aGM
 aVS
@@ -44993,7 +44974,7 @@ azA
 aVS
 aMz
 aGr
-aFf
+aGr
 aGu
 aEt
 aVS
@@ -45250,7 +45231,7 @@ azA
 aVS
 aVS
 aVS
-aVB
+aVS
 aVS
 aVS
 aVS
@@ -45505,11 +45486,11 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-aKq
-aGM
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -45762,11 +45743,11 @@ azA
 azA
 azA
 azA
-aVS
-apj
-aKq
-aGM
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -46016,12 +45997,12 @@ azA
 azA
 azA
 azA
-aVS
-aVS
-aVS
-aVS
-aGM
-aKq
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aVS
 aVS
@@ -46273,12 +46254,12 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-aXf
-aGM
-aGM
-aKq
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 xZp
@@ -46530,12 +46511,12 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-aKq
-aKq
-aKq
-aKq
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 aGM
@@ -46787,12 +46768,12 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-cqT
-aGM
-aGM
-cqT
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 aIo
@@ -47044,12 +47025,12 @@ azA
 azA
 azA
 azA
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 aIo

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -33545,6 +33545,17 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
+"pGX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "pHf" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/bin{
@@ -59405,7 +59416,7 @@ aVD
 azA
 azA
 aVD
-aUF
+pGX
 aVD
 azA
 azA

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -26336,14 +26336,14 @@
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
 "hEk" = (
-/obj/machinery/door/airlock/security{
-	name = "LCZ Security Section";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
 	id_tag = "LCZ Security Office Access Lock";
 	name = "LCZ Security Office Access Lock"
+	},
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/entrance_checkpoint)
@@ -28226,7 +28226,7 @@
 "jEt" = (
 /obj/machinery/door/airlock/security{
 	name = "LCZ Security Section";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -31173,13 +31173,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmtunnel)
 "mUD" = (
-/obj/machinery/door/airlock/security{
-	name = "LCZ Security Section";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "LCZ Security Office Access Lock";
 	name = "LCZ Security Office Access Lock"
+	},
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/entrance_checkpoint)

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -1364,9 +1364,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod)
 "aeE" = (
-/obj/structure/hygiene/shower,
+/obj/machinery/door/airlock/glass/security{
+	name = "Sergeant Equipment";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aeF" = (
 /obj/structure/sign/radiation,
 /obj/effect/paint_stripe/yellow,
@@ -1884,7 +1887,7 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/ulcz/maintenance)
 "agn" = (
-/obj/effect/floor_decal/corner/brown/mono,
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "agp" = (
@@ -2085,7 +2088,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/lowertrams/restaurantkitchenarea)
 "agU" = (
-/obj/effect/paint_stripe/gray,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "agV" = (
@@ -2199,18 +2204,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/hallways)
 "aho" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
@@ -3741,14 +3740,17 @@
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "all" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/random/soap,
-/obj/structure/table/rack,
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "alm" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -3921,27 +3923,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics)
 "alF" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "alG" = (
 /obj/effect/paint_stripe/green,
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
@@ -6462,22 +6447,15 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/engineering/primaryhallway)
 "arK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
@@ -6847,10 +6825,19 @@
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/maintenancetunnel)
 "asA" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/hallways)
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "asB" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/effect/catwalk_plated/dark,
@@ -8065,12 +8052,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
 "avx" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /obj/machinery/light{
-	dir = 8
+	dir = 4;
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "avy" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -10019,14 +10009,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
 "aAI" = (
-/obj/structure/table/rack,
-/obj/item/reagent_containers/spray/chemsprayer,
-/obj/item/reagent_containers/spray/chemsprayer,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor,
+/area/space)
 "aAJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10430,22 +10415,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
 "aBG" = (
-/obj/structure/table/rack,
-/obj/machinery/light,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aBH" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11341,13 +11317,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/engineering/engine_smes)
 "aDI" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aDK" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -11781,26 +11755,12 @@
 "aFf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aFg" = (
-/obj/machinery/power/apc/hyper{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/vending/security{
-	req_access = list()
-	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "aFj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12451,8 +12411,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHD" = (
 /obj/structure/disposalpipe/segment,
@@ -12507,11 +12466,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -12525,8 +12479,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -12551,11 +12504,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -12874,14 +12822,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aIR" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 5
 	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "aIT" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -13133,30 +13078,15 @@
 /turf/simulated/floor,
 /area/site53/reswing/xenobiology)
 "aKa" = (
-/obj/structure/railing/mapped,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/rack,
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/white,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "aKb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -13203,11 +13133,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -13850,6 +13775,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aMI" = (
@@ -13918,9 +13848,12 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aMQ" = (
-/obj/structure/hygiene/drain,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aMS" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -14161,13 +14094,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp999)
 "aNG" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aNH" = (
 /obj/machinery/vending/security{
@@ -14225,9 +14155,13 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aNO" = (
-/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aNR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -15055,12 +14989,9 @@
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
 "aPV" = (
-/obj/machinery/camera/network/lcz{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/personal,
+/obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aPX" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/simulated/floor/bluegrid/airless,
@@ -15909,13 +15840,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aTq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aTu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -15926,13 +15853,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aTw" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -15940,22 +15863,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTy" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/button/blast_door{
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aTA" = (
-/obj/machinery/light,
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
+/obj/effect/landmark/start{
+	name = "LCZ Zone Commander"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/structure/bed/chair/office/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aTB" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
@@ -15988,37 +15912,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTH" = (
-/obj/machinery/status_display,
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/llcz/checkequip)
-"aTI" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/structure/bed/chair/office/light{
+	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"aTI" = (
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aTJ" = (
@@ -16037,9 +15943,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aTM" = (
-/obj/structure/stairs/north,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aTN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16064,21 +15975,25 @@
 /turf/simulated/wall/titanium,
 /area/site53/lowertrams/hczmaint/east)
 "aTZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aUa" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
+/obj/structure/table/rack,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUb" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -16107,24 +16022,25 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
 "aUg" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "LCZ Security Center";
-	send_access = list("ACCESS_SECURITY_LEVEL1")
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aUh" = (
-/obj/machinery/light{
+/obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
+"aUh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "aUi" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aUj" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint,
@@ -16136,190 +16052,184 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod)
 "aUn" = (
-/obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aUo" = (
-/obj/machinery/vending/snack,
+/obj/structure/hygiene/shower,
+/obj/structure/hygiene/drain,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUp" = (
-/obj/effect/paint/silver,
-/obj/machinery/status_display,
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/llcz/checkequip)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "aUt" = (
-/obj/machinery/vending/cola,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/zonecommanderoffice)
+"aUu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aUu" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
 "aUv" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/door/blast/regular{
+	id_tag = "ULCZ Exit Point";
+	name = "ULCZ Exit Point"
 	},
-/obj/structure/window/reinforced{
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
+"aUy" = (
+/obj/structure/table/standard,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
+"aUz" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"aUA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aUy" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
-"aUz" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
-"aUA" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "aUB" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Armory";
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
+"aUF" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "ULCZ Secure Armoury";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
-"aUF" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUI" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu10,
-/obj/item/storage/mre/menu10,
-/obj/item/storage/mre/menu10,
-/obj/item/storage/mre/menu9,
-/obj/item/storage/mre/menu9,
-/obj/item/storage/mre/menu9,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aUK" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
+"aUK" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aUL" = (
-/obj/effect/floor_decal/spline/plain/blue{
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed/chair/padded/black,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"aUN" = (
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"aUO" = (
+/obj/structure/closet,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"aUP" = (
+/obj/structure/closet/secure_closet/guard/zone_commander{
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
+	},
+/obj/effect/floor_decal/carpet/blue2{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
-"aUN" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
-"aUO" = (
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "ULCZ Secure Armoury";
-	name = "ULCZ Secure Armoury";
-	pixel_x = 22;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
-"aUP" = (
-/obj/machinery/button/blast_door{
-	dir = 4;
-	id_tag = "ULCZ Secure Armoury";
-	name = "ULCZ Secure Armoury";
-	pixel_x = -22;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/item/gun/projectile/automatic/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/turf/simulated/floor/carpet/blue2,
+/area/space)
+"aUQ" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
-"aUQ" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
 /area/site53/llcz/checkequip)
 "aUR" = (
-/obj/effect/floor_decal/spline/plain/blue,
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/obj/structure/table/reinforced,
+/obj/item/storage/box/donut,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "aUU" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -16348,19 +16258,25 @@
 /turf/simulated/floor,
 /area/site53/ulcz/scp999)
 "aVa" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aVb" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aVf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/random,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "aVg" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-078 Containment Chamber";
@@ -16386,9 +16302,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/uhcz/securitypost)
 "aVk" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aVl" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/suit/bio_suit/general,
@@ -16406,12 +16328,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "aVm" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Break Room";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
+/obj/structure/table/glass,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aVn" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -16427,23 +16346,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "aVo" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin";
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aVq" = (
-/obj/structure/closet/secure_closet/guard/lcz,
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	pixel_y = -23
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aVr" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -16462,17 +16382,9 @@
 /turf/simulated/floor,
 /area/site53/ulcz/scp2427_3)
 "aVu" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aVw" = (
 /obj/structure/table/rack,
 /obj/item/melee/baton/loaded,
@@ -16490,49 +16402,40 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "aVx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aVy" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aVz" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/effect/paint_stripe/red,
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
-"aVA" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aVB" = (
-/obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
+"aVA" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"aVB" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/area/site53/ulcz/hallways)
 "aVD" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
@@ -16548,11 +16451,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/ulcz/scp216)
 "aVG" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/turf/simulated/open,
+/area/space)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -16565,21 +16465,11 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aVJ" = (
-/obj/structure/table/rack,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
+/obj/effect/landmark/start{
+	name = "LCZ Guard"
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aVK" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -16642,13 +16532,13 @@
 /turf/simulated/wall/prepainted,
 /area/site53/ulcz/hallways)
 "aVW" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled,
 /area/site53/llcz/entrance_checkpoint)
 "aVY" = (
@@ -17228,8 +17118,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/securitypost)
 "aXK" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17241,6 +17129,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "aXL" = (
@@ -18984,12 +18873,10 @@
 /area/site53/ulcz/hallways)
 "bdg" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "bdh" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -20068,39 +19955,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
 "bhh" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "ULCZ Secure Armoury";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/machinery/photocopier{
+	pixel_y = 3
 	},
-/obj/machinery/door/blast/regular/open{
-	begins_closed = 1;
-	icon_state = "pdoor0";
-	id_tag = "ULCZ Secure Armoury";
-	name = "ULCZ Secure Armoury"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/site53/llcz/entrance_checkpoint)
 "bhi" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "LCZ Security Offices";
-	req_access = list("ACCESS_SECURITY_LEVEL1")
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "bhl" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/bed/chair/comfy/blue{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "bhm" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/scp/saiga12/stunshell,
@@ -20139,13 +20011,18 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "bhr" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/structure/table/rack,
+/obj/machinery/light,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/site53/llcz/checkequip)
 "bhu" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -20535,8 +20412,7 @@
 "biK" = (
 /obj/structure/bed/chair,
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -20756,7 +20632,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "bjw" = (
@@ -20875,10 +20751,10 @@
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/south)
 "bjT" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bjU" = (
@@ -20986,28 +20862,33 @@
 /turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "bkn" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/site53/llcz/checkequip)
 "bko" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Zone Commander's Office";
+	send_access = list(204)
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "bkq" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
 /area/site53/llcz/scp012)
 "bkr" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "bks" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Center";
@@ -21024,32 +20905,19 @@
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
 "bku" = (
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/structure/closet{
-	name = "D-Class Prep"
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "bkw" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "bkL" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
@@ -21370,6 +21238,19 @@
 /obj/structure/cryofeed,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"bBC" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "LCZ Guard"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
+"bBM" = (
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "bBQ" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
@@ -21463,14 +21344,8 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bKj" = (
-/obj/structure/bed/chair/office/light,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "bKK" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/prepainted,
@@ -21505,6 +21380,10 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
+"bMX" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "bOD" = (
 /obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled,
@@ -21537,6 +21416,30 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"bQp" = (
+/obj/structure/table/rack,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "bQJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Zone Gate Security Post";
@@ -21603,9 +21506,20 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bTG" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
+/obj/structure/table/rack,
+/obj/machinery/light,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bTH" = (
@@ -21686,9 +21600,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
 "bWR" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "bWT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21713,6 +21633,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
+"bXK" = (
+/obj/machinery/power/smes/buildable/preset/ds90/substation_full{
+	RCon_tag = "Self-Destruct Substation"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
+"bXO" = (
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "bXP" = (
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -21924,15 +21856,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
 "cnC" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "cnW" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
@@ -21980,7 +21906,8 @@
 /area/site53/llcz/entrance_checkpoint)
 "cqF" = (
 /obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "cqI" = (
@@ -21997,9 +21924,12 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
 "cqT" = (
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
 "crR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22022,9 +21952,32 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"csn" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "csp" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/ulcz/generalpurpose)
+"cta" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "cvv" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -22108,6 +22061,12 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"czh" = (
+/obj/structure/table/reinforced,
+/obj/random/clipboard,
+/obj/effect/floor_decal/carpet/blue2,
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "czj" = (
 /obj/machinery/light{
 	dir = 1
@@ -22130,14 +22089,13 @@
 /turf/simulated/floor/reinforced,
 /area/site53/reswing/robotics)
 "cAm" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "cBj" = (
@@ -22278,6 +22236,10 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
 /area/site53/engineering/primaryhallway)
+"cJA" = (
+/obj/machinery/light,
+/turf/simulated/open,
+/area/space)
 "cKH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22381,6 +22343,12 @@
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/engineering/primaryhallway)
+"cPW" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "cQv" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
@@ -22445,12 +22413,32 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"cTo" = (
+/obj/structure/table/reinforced,
+/obj/item/material/ashtray/plastic,
+/obj/item/trash/cigbutt{
+	pixel_y = 7
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "cTw" = (
 /obj/structure/bed/chair/padded/black{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/securitypost)
+"cTM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "cVc" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -22604,6 +22592,15 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"daV" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "dbV" = (
 /obj/machinery/light{
 	dir = 1
@@ -22822,6 +22819,15 @@
 /obj/item/paper/scp/keter/scp106,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"drT" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "dsm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22881,6 +22887,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
+"dvt" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "dvP" = (
 /obj/machinery/body_scanconsole{
 	dir = 1
@@ -22930,6 +22946,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/surface/bunker)
+"dys" = (
+/obj/structure/window/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "dyu" = (
 /obj/item/modular_computer/console/preset/aislot/research,
 /turf/simulated/floor/tiled/techfloor,
@@ -23104,6 +23126,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"dKX" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "dKZ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -23467,6 +23498,13 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
+"ejX" = (
+/obj/structure/bed/chair/office/light,
+/obj/effect/landmark/start{
+	name = "LCZ Guard"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "ekr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23683,6 +23721,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"exB" = (
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "eyn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23895,6 +23947,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp096)
+"eOL" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "eOZ" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
@@ -24014,6 +24073,11 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"eXr" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/menu2,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "eXV" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 5
@@ -24021,6 +24085,15 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
+"eYp" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "eYt" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -24044,6 +24117,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp895)
+"fbx" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "fcc" = (
 /obj/machinery/button/blast_door{
 	id_tag = "096chamberlock";
@@ -24348,6 +24428,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/uhcz/scp106containment)
+"frW" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fsz" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/wood/mahogany,
@@ -24463,6 +24549,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
+"fwg" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fwm" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -24480,13 +24572,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
 "fwG" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/bed/chair/comfy/blue{
+	dir = 8
 	},
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "fwQ" = (
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
@@ -24512,7 +24602,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "fwU" = (
@@ -24539,18 +24629,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"fAR" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin";
+	pixel_y = 1
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "fCD" = (
-/obj/structure/table/rack,
-/obj/machinery/light,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury";
+	pixel_x = 22;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "fDv" = (
 /obj/structure/table/rack,
@@ -24583,6 +24678,15 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"fEA" = (
+/obj/structure/bed/chair/comfy/blue{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fEN" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/camera/network/entrance{
@@ -24608,13 +24712,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "fGE" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/camera/network/entrance{
 	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "fGK" = (
@@ -24664,6 +24768,14 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"fLg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fLT" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -25153,22 +25265,17 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "glY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/railing/mapped,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "gmw" = (
@@ -25238,14 +25345,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "goj" = (
-/obj/structure/bed/chair{
+/obj/effect/floor_decal/spline/plain/blue{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "goy" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 1
@@ -25318,18 +25422,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "gut" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/glass/security{
+	name = "Break Room";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
+"guy" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "gvB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25360,11 +25462,8 @@
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
 "gyj" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "gyC" = (
 /obj/machinery/camera/network/hcz{
@@ -25547,6 +25646,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"gLf" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "gLL" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/item/storage/box/bodybags,
@@ -25674,6 +25781,14 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"gRM" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "gSw" = (
 /obj/structure/table/standard,
 /obj/item/device/camera,
@@ -25814,6 +25929,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp999)
+"gZc" = (
+/obj/machinery/camera/network/lcz{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "haf" = (
 /obj/structure/crematorium{
 	dir = 1
@@ -25893,6 +26014,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"hbV" = (
+/obj/structure/table/reinforced,
+/obj/random/clipboard,
+/obj/effect/floor_decal/carpet/blue2,
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "hcC" = (
 /obj/machinery/camera/network/hcz{
 	dir = 4
@@ -25908,10 +26035,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "hed" = (
-/obj/machinery/door/airlock/civilian{
-	name = "Restroom";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/structure/table/rack,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "heA" = (
@@ -25936,10 +26069,11 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "hgr" = (
-/obj/effect/paint_stripe/gray,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"hgX" = (
+/obj/effect/floor_decal/spline/plain/blue,
+/turf/simulated/floor/wood,
 /area/site53/llcz/entrance_checkpoint)
 "hhj" = (
 /obj/structure/cable/green{
@@ -25948,16 +26082,15 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "hhA" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock";
+	pixel_x = 22;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "hiu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/blast_door{
@@ -26049,6 +26182,16 @@
 /area/site53/llcz/scp500{
 	requires_power = 0
 	})
+"hnt" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "hnw" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/bucket,
@@ -26235,6 +26378,31 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"hyk" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "hyr" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
@@ -26262,6 +26430,28 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"hAx" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "hAF" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
@@ -26414,6 +26604,21 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
+"hEk" = (
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "hFj" = (
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/uhcz/scp247containment)
@@ -26530,6 +26735,11 @@
 	temperature = 80
 	},
 /area/site53/upper_surface/serverfarminterior)
+"hNf" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "hNx" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled/techmaint,
@@ -26704,6 +26914,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"hTX" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "hUb" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500{
@@ -26941,6 +27155,21 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"idT" = (
+/obj/structure/table/glass,
+/obj/item/device/flashlight/lamp,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
+"iea" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "ieh" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -26990,6 +27219,25 @@
 /obj/machinery/light/spot,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"ihR" = (
+/obj/structure/closet/secure_closet/guard/zone_commander{
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 5
+	},
+/obj/item/gun/projectile/automatic/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "iik" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/morgue{
@@ -27051,9 +27299,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/securitypost)
 "ilH" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "imN" = (
@@ -27192,6 +27441,12 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/generalpurpose3)
+"isA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/menu2,
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "iuh" = (
 /obj/machinery/vending/snack{
 	dir = 8
@@ -27251,6 +27506,14 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"ixT" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "iyl" = (
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
@@ -27639,6 +27902,13 @@
 /obj/machinery/honey_extractor,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"iSt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "iTk" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -27651,11 +27921,18 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"iTu" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 10
+	},
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "iUu" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -27736,14 +28013,11 @@
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
 "iXa" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 10
 	},
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "iXE" = (
 /obj/machinery/light{
 	dir = 4
@@ -27784,28 +28058,17 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "jaN" = (
-/obj/machinery/door/airlock/civilian{
-	name = "Restroom";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/space)
 "jbo" = (
-/obj/structure/closet{
-	name = "D-Class Prep"
-	},
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
 /obj/machinery/camera/network/lcz,
+/obj/structure/closet{
+	name = "Confiscated items"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "jbv" = (
@@ -28128,12 +28391,21 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "jxJ" = (
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
 /obj/structure/closet{
-	name = "Confiscated items"
-	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	name = "D-Class Prep"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -28156,6 +28428,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"jyg" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/obj/machinery/light,
+/turf/simulated/open,
+/area/space)
 "jzT" = (
 /obj/effect/paint_stripe/red,
 /obj/structure/sign/monkey_painting,
@@ -28171,6 +28452,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
+"jAP" = (
+/obj/machinery/vending/fitness,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "jBd" = (
 /obj/effect/floor_decal/chapel,
 /obj/machinery/firealarm{
@@ -28179,6 +28467,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"jBr" = (
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "jBO" = (
 /obj/machinery/button/blast_door{
 	id_tag = "Humanoid Containment South";
@@ -28217,15 +28511,9 @@
 /turf/simulated/floor/plating,
 /area/site53/ulcz/hallways)
 "jCD" = (
-/obj/structure/table/rack,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "jDF" = (
 /obj/item/glass_jar{
 	pixel_y = 7
@@ -28251,6 +28539,19 @@
 "jEg" = (
 /turf/simulated/floor,
 /area/site53/surface/bunker)
+"jEt" = (
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "jFe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -28398,6 +28699,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
+"jOb" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "jOV" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/gray,
@@ -28472,11 +28780,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
 "jUp" = (
-/obj/structure/hygiene/shower{
+/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/light/small/red{
+	dir = 8
+	},
+/obj/structure/hygiene/toilet{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "jUv" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/orange/border{
@@ -28515,6 +28827,12 @@
 /obj/item/device/camera_film,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"jWg" = (
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "jWC" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -28522,6 +28840,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
+"jXr" = (
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "jYH" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -28537,6 +28862,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp106containment)
+"kag" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Security Office";
+	send_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "kao" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/paper_bin,
@@ -28761,11 +29094,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "klT" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/zonecommanderoffice)
 "kmK" = (
 /obj/structure/table/standard,
 /obj/machinery/camera/autoname{
@@ -29034,6 +29367,16 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"kDr" = (
+/obj/structure/table/rack,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "kDy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29127,6 +29470,15 @@
 /obj/machinery/light/small/red,
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
+"kIm" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Zone Commander's Office";
+	send_access = list(204)
+	},
+/obj/effect/floor_decal/corner/blue/border,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "kIy" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/light{
@@ -29160,6 +29512,15 @@
 	},
 /turf/simulated/floor,
 /area/site53/surface/explorers/surrounding)
+"kKc" = (
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Self-Destruct Bypass"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "kKf" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/corner/red/mono,
@@ -29216,6 +29577,16 @@
 /obj/item/device/assembly/prox_sensor,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"kPt" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "kPM" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -29265,6 +29636,17 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
+"kSF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "kUj" = (
 /obj/machinery/camera/network/hcz{
 	dir = 1
@@ -29289,6 +29671,16 @@
 	pixel_y = 9;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock";
+	pixel_x = -22;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "kVA" = (
@@ -29311,6 +29703,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
+"kVZ" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "kWi" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -29320,6 +29721,25 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
+"laq" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
+"laH" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "laQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29370,11 +29790,10 @@
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "lbS" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/hallways)
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "lcb" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -29479,6 +29898,12 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
+"lhd" = (
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "lhJ" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/effect/floor_decal/carpet/green{
@@ -30368,6 +30793,18 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"mim" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "mjg" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -30774,6 +31211,17 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/scp2427_3)
+"mBo" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Security Center";
+	send_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/structure/table/reinforced,
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "mBw" = (
 /obj/structure/table/standard,
 /obj/machinery/door/blast/shutters{
@@ -31095,6 +31543,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmtunnel)
+"mUD" = (
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "mVc" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/mil_rifle,
@@ -31191,6 +31653,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
+"mYl" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "mYw" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -31247,6 +31715,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
+"ncb" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "ndi" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -31290,14 +31769,13 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp216)
 "neg" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "nem" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -31491,6 +31969,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp263)
+"nsJ" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "nsM" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/grassybush,
@@ -31601,6 +32091,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
+"nxT" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "nyh" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/gray,
@@ -31730,6 +32227,15 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
+"nHd" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/machinery/vending/security{
+	req_access = list()
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "nHk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31789,14 +32295,21 @@
 	},
 /area/site53/upper_surface/serverfarminterior)
 "nJn" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "nJN" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/camera/network/hcz,
@@ -31856,6 +32369,12 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"nLV" = (
+/obj/effect/floor_decal/corner/blue/bordercee{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "nMl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31918,6 +32437,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
+"nQf" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "nQM" = (
 /obj/machinery/cooker/fryer,
 /obj/machinery/camera/autoname{
@@ -31951,11 +32482,11 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/ulcz/humanoidcontainment)
 "nRA" = (
-/obj/machinery/camera/network/lcz{
-	dir = 1
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "nTc" = (
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/monotile,
@@ -31997,12 +32528,52 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
-"nVn" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+"nUz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"nUQ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu10,
+/obj/item/storage/mre/menu10,
+/obj/item/storage/mre/menu10,
+/obj/item/storage/mre/menu9,
+/obj/item/storage/mre/menu9,
+/obj/item/storage/mre/menu9,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"nVn" = (
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "nVI" = (
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
@@ -32239,6 +32810,11 @@
 /area/site53/lowertrams/escape)
 "oni" = (
 /obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -32274,6 +32850,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"onW" = (
+/obj/machinery/vending/fitness,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "ooD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32561,6 +33141,15 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"oCP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "oDy" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -32717,6 +33306,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"oNG" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/blue,
+/obj/item/folder/red,
+/obj/item/folder,
+/obj/item/folder/yellow,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "oOF" = (
 /obj/machinery/microwave,
 /obj/structure/table/standard,
@@ -32771,10 +33368,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"oSH" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "oSR" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/site53/engineering/sleeproom)
+"oTb" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "oUj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -33009,10 +33616,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "pid" = (
-/obj/machinery/camera/network/lcz{
-	dir = 1
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "pih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33201,6 +33810,13 @@
 /obj/machinery/photocopier/faxmachine,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"pyP" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "pze" = (
 /obj/machinery/camera/autoname{
 	c_tag = "Comms Tower Basement";
@@ -33242,6 +33858,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"pBB" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "pCp" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -33346,9 +33972,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
 "pFU" = (
-/obj/structure/table/standard,
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "pHf" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/bin{
@@ -33436,6 +34063,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
+"pOj" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4;
+	name = "EXIT ONLY"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
 "pOk" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/camera/network/hcz{
@@ -33505,14 +34139,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "pTX" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
 	},
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "pUs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -33545,11 +34176,11 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
 "pXS" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/structure/railing/mapped,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled,
 /area/site53/llcz/entrance_checkpoint)
 "pXT" = (
@@ -33583,6 +34214,10 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uhcz/scp247containment)
+"qaD" = (
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "qaJ" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -33825,6 +34460,15 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/brownline)
+"qnx" = (
+/obj/structure/bed/chair/comfy/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "qnO" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -33867,8 +34511,7 @@
 /area/site53/ulcz/generalpurpose)
 "qqQ" = (
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -33892,6 +34535,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
+"qst" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "qsG" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/techmaint,
@@ -33934,6 +34583,22 @@
 "qvG" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/humanoidcontainment)
+"qwF" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"qxf" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "qxk" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/monotile,
@@ -33962,6 +34627,13 @@
 	},
 /turf/simulated/floor,
 /area/site53/lowertrams/hub)
+"qzE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "qzL" = (
 /obj/structure/table/standard,
 /obj/item/auto_cpr,
@@ -34263,6 +34935,15 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
+"qWb" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "qWj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34428,7 +35109,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "rcN" = (
@@ -34649,6 +35330,15 @@
 /area/site53/llcz/scp500{
 	requires_power = 0
 	})
+"rqq" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/camera/network/lcz{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "rqI" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -34783,15 +35473,13 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/science/aicobservation)
 "rzX" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "rBm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -34880,6 +35568,19 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"rFf" = (
+/obj/structure/table/standard,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "rFI" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donut,
@@ -35080,6 +35781,14 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
+"rVq" = (
+/obj/structure/table/reinforced,
+/obj/item/material/ashtray/plastic,
+/obj/item/trash/cigbutt{
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "rVI" = (
 /obj/machinery/light{
 	dir = 4
@@ -35148,6 +35857,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"rZm" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "rZL" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -35438,9 +36151,10 @@
 /turf/simulated/wall/prepainted,
 /area/site53/reswing/xenobiology)
 "sng" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "snm" = (
 /obj/machinery/door/airlock/security{
 	name = "UHCZ Checkpoint";
@@ -35470,12 +36184,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
 "spT" = (
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "sqv" = (
@@ -35812,6 +36525,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
+"sNd" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "sPg" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/reagent_dispensers/water_cooler{
@@ -36001,6 +36718,13 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/humanoidcontainment)
+"sZE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "tar" = (
 /obj/structure/mopbucket,
 /obj/structure/catwalk,
@@ -36120,6 +36844,13 @@
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/ulcz/scp999)
+"tiI" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "tjj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36198,6 +36929,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/containment_engineer)
+"tmC" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "tmK" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36278,6 +37015,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"ttg" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "ttE" = (
 /obj/effect/floor_decal/corner/yellow/bordercorner{
 	dir = 4
@@ -36330,6 +37076,19 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
+"twA" = (
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "twH" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Evacuation Bunker"
@@ -36566,6 +37325,16 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
+"tMm" = (
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "tMx" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -36607,6 +37376,16 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
+"tOa" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "tOm" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 4
@@ -37308,12 +38087,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/surface/explorers/surrounding)
 "uJG" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/llcz/entrance_checkpoint)
 "uJU" = (
 /obj/machinery/light_switch{
 	pixel_x = -25
@@ -37628,7 +38405,6 @@
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
 "vea" = (
-/obj/effect/paint_stripe/gray,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -37638,6 +38414,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "veT" = (
@@ -37786,6 +38563,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lowertrams/restaurantkitchenarea)
+"vny" = (
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "vnK" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
@@ -37980,6 +38761,21 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/xenobiology)
+"vxq" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
+"vxr" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "vxS" = (
 /obj/structure/table/reinforced,
 /obj/item/newspaper,
@@ -38052,14 +38848,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/generalpurpose3)
 "vCX" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "vDw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -38356,6 +39149,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
+"vTy" = (
+/obj/machinery/lapvend,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "vVj" = (
 /obj/structure/table/standard,
 /obj/item/device/radio/phone,
@@ -38392,6 +39189,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"vWB" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "vWZ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
@@ -38416,6 +39220,20 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
+"vXu" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
+"vXy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "vXz" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "SCP-012"
@@ -38498,6 +39316,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"wdh" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "wdB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -38556,6 +39384,14 @@
 /obj/item/device/tape,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"whj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "whL" = (
 /obj/machinery/recharge_station,
 /obj/machinery/camera/network/hcz{
@@ -38625,6 +39461,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"wkx" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
+"wlv" = (
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury";
+	pixel_x = -22;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "wmf" = (
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 4
@@ -38778,12 +39628,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
 "wwj" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/hallways)
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "wwJ" = (
 /obj/machinery/camera/autoname{
 	name = "SCP-247 Observation"
@@ -39065,6 +39916,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
+"wLF" = (
+/obj/effect/landmark/start{
+	name = "LCZ Zone Commander"
+	},
+/obj/structure/bed/chair/office/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "wLQ" = (
 /obj/structure/table/standard,
 /obj/item/deck/cards,
@@ -39184,6 +40044,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
+"wSd" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "wSy" = (
 /obj/machinery/light{
 	dir = 4
@@ -39241,9 +40108,16 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
+"wVg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "wVj" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -39266,6 +40140,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"wVD" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "wVK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39435,6 +40315,27 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"xfK" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "ULCZ Secure Armoury";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/armory)
 "xfS" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/telescreen/preset/generic{
@@ -39485,6 +40386,16 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
+"xjd" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "LCZ Armoury Section";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "xjn" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -39542,6 +40453,21 @@
 "xna" = (
 /turf/simulated/mineral,
 /area/site53/uhcz/scp247containment)
+"xnq" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "LCZ Security Offices";
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"xnC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "xoe" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -39554,6 +40480,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
+"xpa" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "xpf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39654,18 +40586,11 @@
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
 "xsq" = (
-/obj/structure/table/rack,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/item/modular_computer/laptop/preset/records,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "xst" = (
 /obj/machinery/camera/network/entrance,
 /obj/machinery/cooker/candy,
@@ -39845,29 +40770,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "xEG" = (
-/obj/structure/table/rack,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/machinery/door/airlock/security{
+	name = "Solitary Confinement";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"xET" = (
+/obj/machinery/camera/network/lcz{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "xFg" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -39910,6 +40824,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"xIs" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "xJI" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -40016,13 +40934,21 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
 "xRv" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "Security Center";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"xSo" = (
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "xSs" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a57,
@@ -40960,30 +41886,30 @@ azA
 azA
 azA
 azA
-aMC
-aMC
-aMC
-aMC
-aMC
-aMC
 azA
 azA
 azA
-lbS
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 azA
 azA
 azA
@@ -41216,17 +42142,17 @@ azA
 azA
 azA
 azA
-aMC
-aMC
-aVM
-vgG
-vgG
-aXh
-aMC
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 uis
 aGM
 aIT
@@ -41240,7 +42166,7 @@ qTt
 aXf
 vOc
 gNK
-asA
+aVS
 azA
 azA
 azA
@@ -41473,17 +42399,17 @@ azA
 azA
 azA
 azA
-aMC
-kcw
-aVL
-aXh
-aXh
-aXh
-maZ
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aMx
 aGM
 bhp
@@ -41497,7 +42423,7 @@ hqI
 aGM
 xXL
 dgI
-asA
+aVS
 azA
 azA
 azA
@@ -41730,17 +42656,17 @@ azA
 azA
 azA
 azA
-aMC
-nZl
-aVL
-bde
-icU
-aXh
-iQI
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 ahO
 aGM
 urN
@@ -41754,7 +42680,7 @@ uUQ
 aGM
 cmp
 gqe
-asA
+aVS
 azA
 azA
 azA
@@ -41987,17 +42913,17 @@ azA
 azA
 azA
 azA
-aMC
-eiL
-aVL
-wsM
-bhm
-aXh
-hbm
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 woc
 aGM
 aGM
@@ -42011,7 +42937,7 @@ aGM
 aGM
 aGM
 vtX
-asA
+aVS
 azA
 azA
 azA
@@ -42244,17 +43170,17 @@ azA
 azA
 azA
 azA
-aMC
-aEv
-aUN
-bdg
-aXh
-aXh
-xSs
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 orI
 aGM
 aGM
@@ -42268,7 +43194,7 @@ aGM
 aGM
 aGM
 pVt
-asA
+aVS
 azA
 azA
 azA
@@ -42501,17 +43427,17 @@ azA
 azA
 azA
 azA
-aMC
-aXh
-aUO
-aVL
-aXh
-aXh
-tPi
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 mCP
 aGM
 aME
@@ -42525,7 +43451,7 @@ nMl
 aGM
 fDz
 mSx
-asA
+aVS
 azA
 azA
 azA
@@ -42758,17 +43684,17 @@ azA
 azA
 azA
 azA
-qSc
-aMC
-aMC
-bhh
-aMC
-aMC
-qSc
-qSc
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 gMl
 aGM
 aME
@@ -42782,7 +43708,7 @@ hqI
 aGM
 xXL
 dgI
-asA
+aVS
 azA
 azA
 azA
@@ -43015,17 +43941,17 @@ azA
 azA
 azA
 azA
-aMC
-aUu
-aUP
-aVx
-aVJ
-aMC
 azA
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aME
 aGM
 aME
@@ -43039,7 +43965,7 @@ vOc
 pSE
 qTt
 tqR
-asA
+aVS
 azA
 azA
 azA
@@ -43272,31 +44198,31 @@ azA
 azA
 azA
 azA
-aMC
-alF
-aVa
-aVx
-aBG
-aMC
 azA
 azA
 azA
-asA
-lbS
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
 bhi
-asA
-asA
-wwj
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 azA
 azA
 azA
@@ -43529,30 +44455,30 @@ azA
 azA
 azA
 azA
-aMC
-aAI
-aVa
-aVx
-cnC
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 apj
 aGM
 aGM
 aGt
 aGq
-lbS
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-lbS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 azA
 azA
 azA
@@ -43780,28 +44706,28 @@ azA
 azA
 azA
 azA
-aVD
-aTJ
-aTJ
-aVD
-aTJ
-aTJ
-aMC
-aVa
-aVa
-aVx
-jCD
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aGM
-aKq
-aKq
+aGM
+aGM
 aHC
 aGM
-asA
+aVS
 aGM
 aGM
 aXf
@@ -43809,7 +44735,7 @@ aGM
 aGM
 aXf
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -44037,36 +44963,36 @@ azA
 azA
 azA
 azA
-aTJ
-aeE
-aMS
-aTJ
-aMS
-jUp
-aMC
-aUy
-aVf
-bhr
-fCD
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 bgE
+aGM
 aKq
-bhl
 aHL
-aMe
+aMK
 aho
-aMe
-aMe
-aMe
-aMe
-aMe
+aMK
+aMK
+aMK
+aMK
+aMK
 aHR
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -44294,36 +45220,36 @@ azA
 azA
 azA
 azA
-aTJ
-all
-aMQ
-aTJ
-aMQ
-all
-aMC
-aVx
-xsq
-xsq
-xEG
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aGM
 aGM
 aKq
-aFe
 aHM
 aGM
-asA
+aVS
 aGM
 aGM
 aGM
 aGM
 aGM
-aLv
+aUA
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -44551,36 +45477,36 @@ azA
 azA
 azA
 azA
-aTJ
-aTJ
-aNb
-aTJ
-aNb
-aTJ
-aTJ
-aUB
-aTJ
-aTJ
-aTJ
-aVD
-aTJ
-aTJ
 azA
-lbS
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aMz
 aGr
 aFf
 aGu
 aEt
-lbS
-asA
-asA
-asA
-lbS
+aVS
+aVS
+aVS
+aVS
+aVS
 apj
-aLv
+aUA
 aEt
-asA
+aVS
 azA
 azA
 azA
@@ -44808,36 +45734,36 @@ azA
 azA
 azA
 azA
-aTJ
-aMS
-aMS
-aMS
-aMS
-aTJ
-aNH
-aTq
-dJG
-sng
-wVj
-aVA
-nVn
-aTJ
 azA
-asA
-aVD
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
 aVB
-aTJ
-aTJ
-asA
+aVS
+aVS
+aVS
 azA
 azA
 azA
-asA
+aVS
 aGM
-aLv
+aUA
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -45065,36 +45991,36 @@ azA
 azA
 azA
 azA
-aTJ
-aMS
-aMS
-aMS
-aNs
-aTJ
-aFg
-aUF
-gut
-cAm
-aTv
-bKj
-aVo
-aTJ
-azA
-azA
-aTJ
-aMS
-pTX
-aMS
-aTJ
 azA
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aGM
-aLv
+aKq
 aGM
-asA
+aVS
+azA
+azA
+azA
+azA
+aVS
+aGM
+aUA
+aGM
+aVS
 azA
 azA
 azA
@@ -45322,36 +46248,36 @@ azA
 azA
 azA
 azA
-aTJ
-amA
-aMS
-aMS
-aDI
-aTJ
-aTI
-aTq
-aUv
-fwG
-aMS
-uJG
-aVu
-aTJ
 azA
 azA
-aTJ
-lbi
-pTX
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
 aVS
-lbS
-asA
+apj
+aKq
+aGM
+aVS
+azA
+azA
+azA
+aVS
+aVS
+aVS
 arK
-asA
-lbS
+aVS
+aVS
 aVS
 azA
 azA
@@ -45579,34 +46505,34 @@ azA
 azA
 azA
 azA
-aTJ
-amA
-aMS
-aVD
-aTJ
-aTJ
-aTZ
-xRv
-ilH
-aMS
-aMS
-aMS
-aTq
-aVD
-aTJ
-aTJ
-aVD
-aMS
-pTX
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
 aVS
+aVS
+aVS
+aVS
+aGM
+aKq
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 aff
 aff
-aKa
+glY
 aff
 aff
 aVS
@@ -45836,34 +46762,34 @@ azA
 azA
 azA
 azA
-aTJ
-amA
-aMS
-aTJ
-aTM
-aMS
-aMS
-aMS
-aTq
-aMS
-aMS
-aMS
-aTq
-aTJ
-aMS
-wVj
-aMS
-aMS
-pTX
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
+aGM
+aXf
+aGM
+aGM
+aKq
 aVS
-aVS
+aGM
+xZp
+aXf
+aGM
 aVS
 agK
 afG
-aLv
+aUA
 afR
 agL
 aVS
@@ -46093,29 +47019,29 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNs
-aTJ
-aTM
-aMS
-aMS
-aMS
-neg
-aMS
-aMS
-aMS
-aVy
-aVz
-iXa
-iXa
-iXa
-iXa
-aNG
-nRA
-aTJ
-xZp
-aIR
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aGM
+aKq
+aKq
+aKq
+aKq
+aVS
+aGM
+aGM
+aJt
 aJt
 aJC
 afF
@@ -46350,34 +47276,34 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aMS
-aTJ
-aTM
-aMS
-aMS
-aMS
-aTq
-aMS
-aMS
-aMS
-aVr
-aTJ
-aMS
-bko
-aMS
-aMS
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aGM
 cqT
-bko
-aTJ
+aGM
+aGM
+cqT
+aVS
+aGM
 aIo
 aGM
 aGM
 aVS
 uoR
 afI
-aLv
+aUA
 afS
 agL
 aVS
@@ -46607,27 +47533,27 @@ azA
 azA
 azA
 azA
-aTJ
-aTJ
-aNb
-aTJ
-aTJ
-aTJ
-aTL
-aMS
-aTq
-aMS
-aMS
-aMS
-akH
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-bkw
-aTJ
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aGM
 aIo
 aGM
 aGM
@@ -46864,34 +47790,34 @@ azA
 azA
 azA
 azA
-aTJ
-avx
-aMS
-hhA
-spT
-aVD
-aTP
-aMS
-aTq
-jnd
-gci
-jnd
-aVq
-aTJ
-bWR
-aMS
-bkr
-bku
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
+aGM
 aGM
 aGM
 aGM
 aVS
 aVS
 sYT
-aMW
+exB
 aVS
 aVS
 aVS
@@ -47121,34 +48047,34 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNO
-nJn
-aTy
-aTJ
-aUg
-aMS
-aTq
-jnd
-gci
-jnd
-aVq
-aTJ
-bWR
-aMS
-bkr
-pFU
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
-aVS
-aVS
-aVS
+aGM
+aGM
+aGM
+aGM
 aVS
 aVS
 aIQ
-aLv
+aUA
 aXf
 aVS
 azA
@@ -47378,26 +48304,26 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNO
-aNO
-vCX
-hed
-aMS
-aMS
-aTq
-jnd
-gci
-jnd
-aVq
-aTJ
-bWR
-aMS
-bkr
-aMS
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aVS
 aVS
 aVS
@@ -47405,7 +48331,7 @@ aVS
 aVS
 aVS
 aJE
-aNd
+aUh
 aGM
 aVS
 azA
@@ -47635,26 +48561,26 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNO
-aNO
-nJn
-jaN
-dMS
-dMS
-oni
-xxz
-gci
-wVp
-aVq
-aTJ
-bkn
-aMS
-bks
-aMS
-bko
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aHO
 aIt
@@ -47662,7 +48588,7 @@ aHq
 aGM
 aGM
 aGM
-aLv
+aUA
 aGM
 aVS
 azA
@@ -47892,26 +48818,26 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aPV
-aMS
-aNs
-aTJ
-aTJ
-aUp
-aVm
-aTJ
-aTJ
-aTJ
-aVD
-aVD
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aVD
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aIj
 aIu
@@ -48149,19 +49075,19 @@ azA
 azA
 azA
 azA
-aVD
-aTJ
-aTJ
-aTE
-aTE
-aTJ
-aUh
-aMS
-aMS
-aUI
-aMS
-goj
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -48406,19 +49332,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMu
-aMS
-aMS
-aMS
-aTJ
-aUi
-aMS
-aUz
-aUa
-aUQ
-aVk
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -48663,19 +49589,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aMS
-aMS
-aTA
-aTH
-aUn
-aMS
-aUA
-aUK
-aUR
-bTG
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -48920,19 +49846,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aNs
-aTJ
-aTJ
-aTJ
-aUo
-aMS
-aVG
-aUL
-klT
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -49177,19 +50103,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aMS
-aTE
-aTB
-aTJ
-aUt
-aMS
-aMS
-bWR
-aVk
-rzX
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -49434,19 +50360,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aMS
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aVD
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 bgX
 bgX
 aVS
@@ -49691,12 +50617,12 @@ azA
 azA
 azA
 azA
-aTJ
-aMu
-aMS
-aTE
-aTB
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -49948,12 +50874,12 @@ azA
 azA
 azA
 azA
-aVD
-aTJ
-aTJ
-aTJ
-aTJ
-aVD
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -55647,21 +56573,21 @@ aJj
 dpg
 mMC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
 azA
 azA
 azA
@@ -55904,21 +56830,21 @@ rdt
 dpg
 mMC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+uJG
+vTy
+hgr
+jOb
+cTM
+aVu
+bkr
+pFU
+pyP
+cTM
+aVu
+bkr
+pFU
+aDI
+uJG
 azA
 azA
 azA
@@ -56161,6 +57087,21 @@ mMC
 mMC
 mMC
 azA
+uJG
+oCP
+hgr
+hTX
+aNO
+aTH
+hgr
+aTq
+dys
+aNO
+aTH
+hgr
+aTq
+wVD
+uJG
 azA
 azA
 azA
@@ -56172,29 +57113,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
 azA
 azA
 azA
@@ -56418,6 +57344,21 @@ azA
 azA
 azA
 azA
+uJG
+bhh
+hgr
+kag
+pBB
+qxf
+hgr
+wVg
+pid
+pBB
+qxf
+hgr
+wVg
+qzE
+uJG
 azA
 azA
 azA
@@ -56429,29 +57370,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+eXr
+ncb
+nVn
+nVn
+laH
+nJn
+jaN
 azA
 azA
 azA
@@ -56662,6 +57588,34 @@ aGM
 aVS
 azA
 azA
+cqF
+cqF
+cqF
+cqF
+cqF
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+uJG
+aUR
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+oNG
+uJG
 azA
 azA
 azA
@@ -56673,42 +57627,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+cTo
+frW
+nVn
+nVn
+nVn
+guy
+jaN
 azA
 azA
 azA
@@ -56919,53 +57845,53 @@ aEt
 aVS
 azA
 azA
+cqF
+vxr
+mYl
+vxr
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+uJG
+hNf
+hgr
+hgr
+hgr
+hgr
+hgr
+sNd
+hgr
+hgr
+hgr
+hgr
+hgr
+iSt
+uJG
+azA
+azA
+aMC
+aMC
+aMC
+aMC
+aMC
+aMC
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aTM
+nVn
+aUp
+nVn
+aVJ
+cnC
+jaN
 azA
 azA
 azA
@@ -57176,53 +58102,53 @@ aGM
 aVS
 azA
 azA
+cqF
+aVb
+aVb
+aVb
+cqF
+aUz
+jUp
+cqF
+aUz
+jUp
+cqF
+aUz
+jUp
+uJG
+aUO
+hgr
+gyj
+nsJ
+nxT
+hgr
+qwF
+dvt
+mim
+nxT
+hgr
+qwF
+vXy
+uJG
+azA
+aMC
+aMC
+aVM
+vgG
+vgG
+aXh
+aMC
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jAP
+nVn
+nVn
+nVn
+aVJ
+sng
+jaN
 azA
 azA
 azA
@@ -57433,53 +58359,53 @@ aGM
 aVS
 azA
 azA
+cqF
+aVb
+aVb
+aVb
+cqF
+aUL
+aVf
+cqF
+aUL
+aVf
+cqF
+aUL
+aVf
+uJG
+tiI
+hgr
+gyj
+aNO
+aTH
+hgr
+aTq
+dys
+aNO
+aTH
+hgr
+aTq
+wVD
+uJG
+azA
+aMC
+kcw
+aVL
+aXh
+aXh
+aXh
+maZ
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+rZm
+nVn
+nVn
+nVn
+nVn
+nVn
+jaN
 azA
 azA
 azA
@@ -57689,60 +58615,60 @@ aLv
 aGM
 aVS
 azA
+cqF
+cqF
+xTl
+cqc
+xTl
+cqF
+aUN
+alF
+cqF
+aUN
+alF
+cqF
+aUN
+alF
+uJG
+gyj
+hgr
+gyj
+iea
+pFU
+xpa
+aVu
+lbS
+iea
+pFU
+xpa
+aVu
+aTv
+uJG
+azA
+aMC
+nZl
+aVL
+bde
+icU
+aXh
+iQI
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aAI
+aAI
+aeE
+aeE
+aAI
+aAI
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
 azA
 azA
 azA
@@ -57946,60 +58872,60 @@ jVk
 aGM
 aVS
 azA
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
+cqF
+aEE
+biQ
+aVb
+biQ
+cqF
+xEG
+xTl
+cqF
+xEG
+xTl
+cqF
+xEG
+xTl
+cqF
+xTl
+xnq
+xTl
+xTl
+xTl
+uJG
+xTl
+xTl
+xTl
+xTl
+uJG
+xTl
+xTl
+uJG
+azA
+aMC
+eiL
+aVL
+wsM
+bhm
+aXh
+hbm
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+fwg
+qaD
+aVG
+aVG
+jyg
+jaN
+cPW
+bku
+twA
+iTu
+jaN
 azA
 azA
 azA
@@ -58203,60 +59129,60 @@ jVk
 pSE
 aVS
 azA
-agU
+cqF
 jbo
 aVb
 aVb
-aEE
-biQ
-xTl
 aVb
-wkv
-agU
+bVr
+aVb
+aVb
+bVr
+aVb
+aVb
+bVr
+aVb
+aVb
+cqF
+aVb
+aVb
+aVb
+aVb
+aVb
+bVr
+aVb
+aVb
+aVb
+aVb
+bVr
+aVb
+aEA
+cqF
+azA
+aMC
+aEv
+aVL
+aXh
+aXh
+aXh
+xSs
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+wwj
+aUI
+aUI
+nVn
+nVn
+aUI
+aUI
+aUI
+eOL
+xSo
+nVn
+xnC
+gLf
+jaN
 azA
 azA
 azA
@@ -58460,60 +59386,60 @@ tjj
 aVS
 aVS
 azA
-agU
+cqF
 jxJ
+aUn
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+jEt
+dpC
+dpC
+drT
+dpC
+dpC
+dpC
+dpC
+bdg
 aVb
 aVb
 aVb
 aVb
-cqc
 aVb
-gyj
-agU
+cqF
+azA
+aMC
+fCD
+aVL
+aXh
+aXh
+aXh
+tPi
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aBG
+aBG
+all
+all
+all
+all
+all
+all
+nQf
+kSF
+aBG
+fLg
+kIm
+jaN
 azA
 azA
 azA
@@ -58717,60 +59643,60 @@ hyd
 aGM
 aVS
 azA
-agU
-biQ
-aVb
-aVb
+cqF
 aFD
-biQ
-xTl
+qhP
 aVb
-wkv
-agU
+aVb
+vCX
+aVb
+aVb
+vCX
+xET
+aVb
+aVb
+hhA
+aVb
+cqF
+aVb
+aVb
+aUi
+aVb
+aVb
+vCX
+aVb
+aUi
+aVb
+aVb
+vCX
+aVb
+aEA
+cqF
+azA
+qSc
+aMC
+xfK
+aMC
+aMC
+aMC
+qSc
+qSc
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aAI
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+cJA
+jaN
+qnx
+bhl
+nVn
+aTZ
+jaN
 azA
 azA
 azA
@@ -58974,60 +59900,60 @@ aPh
 aGM
 aVS
 azA
-agU
+cqF
 cme
-aVb
+qhP
 aVb
 lWh
-agU
-agU
-agU
-agU
-agU
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+mUD
+cqF
+cqF
+cqF
+klT
+aUt
+hnt
+aUt
+aUt
+klT
+aVD
+xRv
+bks
+aVD
+aVD
+aVD
+aVD
+aVD
+azA
+azA
+aVD
+aUF
+aVD
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+nVn
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+idT
+aVm
+aUp
+aVa
+jaN
 azA
 azA
 azA
@@ -59231,60 +60157,60 @@ aPh
 cIC
 aVS
 azA
-agU
+cqF
 iTk
 aMH
 aVb
 pyn
-agU
+cqF
 iYX
 nFS
 lYV
-agU
+cqF
+onW
+aVb
+aVb
+cqF
+azA
+klT
+qst
+tmC
+bKj
+bKj
+aUt
+aNH
+wVj
+aMS
+dJG
+nUz
+vny
+ilH
+aVD
+aVD
+aVD
+aVD
+aUF
+aVD
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+nVn
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+fEA
+fwG
+nVn
+xsq
+jaN
 azA
 azA
 azA
@@ -59488,7 +60414,7 @@ xpX
 nTU
 aVS
 azA
-agU
+cqF
 clC
 qhP
 aVb
@@ -59497,51 +60423,51 @@ fYk
 eQq
 eQq
 kFd
-agU
+cqF
+jCD
+aVb
+aVb
+cqF
+azA
+klT
+wdh
+neg
+bKj
+bKj
+aUt
+nHd
+wVj
+aMS
+spT
+bBC
+ejX
+vXu
+aVD
+csn
+aTI
+wlv
+wVj
+aUa
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+nVn
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+laq
+nVn
+nVn
+ixT
+jaN
 azA
 azA
 azA
@@ -59739,66 +60665,66 @@ azA
 azA
 azA
 azA
-cqF
+agU
 aGZ
 ing
 hUS
-cqF
+agU
 azA
-agU
-agU
+cqF
+cqF
 bia
-agU
-agU
-agU
+cqF
+cqF
+cqF
 woN
 eQq
 whL
-agU
+cqF
+cqF
+qqQ
+aVb
+cqF
+azA
+klT
+bBM
+bKj
+bKj
+bKj
+aUt
+hyk
+wVj
+aMS
+cAm
+aMS
+aNG
+sZE
+aVD
+hAx
+wVj
+aMS
+wVj
+bTG
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+pTX
+aVx
+aVx
+wSd
+jaN
 azA
 azA
 azA
@@ -59996,66 +60922,66 @@ azA
 azA
 azA
 azA
-cqF
+agU
 aGZ
 mXc
 qPN
-cqF
-cqF
+agU
+agU
 bjv
 kVb
 qhP
 vLm
-agU
-agU
-agU
-agU
-agU
-agU
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+aVb
+aVb
+cqF
+azA
+klT
+asA
+rzX
+aUy
+bKj
+aUt
+whj
+wVj
+aMS
+aMS
+aMS
+akH
+akH
+aVD
+aKa
+wVj
+aMS
+wVj
+cta
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+aUK
+aVq
+rFf
+gRM
+jaN
 azA
 azA
 azA
@@ -60257,62 +61183,62 @@ agU
 lkI
 bgK
 bjp
-aVb
+bVr
 aVb
 iRt
 aVb
 qhP
 aVb
 aVY
-aVb
 bVr
-wkv
-agU
+aVb
+qWb
+cqF
+azA
+cqF
+aVb
+aVb
+cqF
+azA
+klT
+jXr
+wLF
+hbV
+bKj
+fbx
+aMS
+aVy
+dMS
+dMS
+dMS
+dMS
+dMS
+xjd
+dMS
+oni
+dMS
+aUu
+kDr
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+jWg
+aTA
+czh
+vWB
+jaN
 azA
 azA
 azA
@@ -60524,52 +61450,52 @@ mEc
 aVb
 aVb
 wkv
-agU
+cqF
+azA
+cqF
+aVb
+aVb
+cqF
+azA
+klT
+ihR
+lhd
+tMm
+bKj
+aUt
+isA
+aVz
+oTb
+aMS
+aMS
+aMS
+aNs
+aVD
+lbi
+aMS
+aMS
+aMS
+bhr
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+jaN
+aUP
+kPt
+aVk
+nLV
+jaN
 azA
 azA
 azA
@@ -60780,53 +61706,53 @@ aGA
 gKy
 aVb
 aVb
-wkv
-agU
+rqq
+cqF
+azA
+cqF
+aTy
+aVb
+cqF
+azA
+klT
+tOa
+bko
+aFg
+wkx
+aUt
+rVq
+aVz
+aMS
+aMS
+aMS
+aMS
+aVr
+aVD
+aUQ
+aUQ
+hed
+hed
+bQp
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
 azA
 azA
 azA
@@ -61034,37 +61960,37 @@ fwS
 bhf
 bis
 aDO
-agU
+cqF
 qqQ
 aVb
 aEA
-agU
+cqF
+cqF
+cqF
+qqQ
+aVb
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+klT
+klT
+klT
+klT
+klT
+klT
+aTL
+wVj
+aMS
+aMS
+aMS
+aMS
+akH
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
 azA
 azA
 azA
@@ -61291,31 +62217,31 @@ fwS
 erI
 aao
 aEq
-agU
+cqF
 gmT
 aVb
-pid
-agU
+aVb
+cqF
+aVb
+aVb
+aVb
+aVb
+cqF
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+bXK
+kKc
+oSH
+aVD
+aTP
+wVj
+aMS
+jnd
+gci
+jnd
+gci
+aVD
 azA
 azA
 azA
@@ -61552,27 +62478,27 @@ iCg
 vVl
 biD
 aVb
-agU
+hEk
+aVb
+aVb
+aVb
+aVb
+cqF
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+bWR
+vxq
+kVZ
+bkn
+dMS
+aUu
+aMS
+jnd
+gci
+jnd
+gci
+aVD
 azA
 azA
 azA
@@ -61805,31 +62731,31 @@ rcM
 lKF
 ren
 cYI
-hgr
+cqF
 blf
 tpZ
 fQz
-agU
+cqF
+qqQ
+aVb
+aVb
+aVb
+cqF
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+cqF
+cqF
+cqF
+aVD
+mBo
+aMS
+aMS
+jnd
+gci
+jnd
+gci
+aVD
 azA
 azA
 azA
@@ -62059,34 +62985,34 @@ agU
 agU
 agU
 aXK
-agU
+cqF
 aCb
-agU
+cqF
 cqF
 bkh
 bkh
 bkh
-agU
+cqF
+cqF
+cqF
+xET
+aVb
+cqF
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aVD
+ttg
+aMS
+aMS
+xxz
+gci
+wVp
+gci
+aVD
 azA
 azA
 azA
@@ -62316,34 +63242,34 @@ azA
 azA
 azA
 acs
-agU
+cqF
+eYp
+cqF
+cqF
 bYK
-agU
-agU
 bYK
 bYK
-bYK
-agU
+cqF
 azA
+cqF
+cqF
+gut
+cqF
+cqF
+cqF
+cqF
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aTJ
+aTJ
+aTE
+aTJ
+aVD
+aVD
+aVD
+aVD
+aVD
 azA
 azA
 azA
@@ -62573,34 +63499,34 @@ aig
 aig
 aig
 aXK
-agU
-aCb
-agU
-agU
+cqF
+aUv
+cqF
+cqF
 bkh
 bkh
 bkh
-agU
+cqF
 azA
+cqF
+aMQ
+hgr
+hgr
+nUQ
+hgr
+dKX
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aVo
+aMS
+aMS
+aMS
+amA
+aoN
+amA
+aoN
+aVD
 azA
 azA
 azA
@@ -62831,7 +63757,7 @@ eCZ
 qnc
 vea
 agU
-bhO
+pOj
 aVW
 pXS
 bhO
@@ -62839,25 +63765,25 @@ bhO
 bhO
 agU
 azA
+cqF
+xIs
+hgr
+nRA
+jBr
+iXa
+aTv
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aMS
+aMS
+aMS
+aMS
+aMS
+aMS
+aMS
+aVD
 azA
 azA
 azA
@@ -63096,25 +64022,25 @@ aXT
 aXT
 agU
 azA
+cqF
+aPV
+hgr
+bXO
+fAR
+hgX
+aUg
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aNs
+aTJ
+aTJ
+aTJ
+aNb
+aTJ
+aNb
+aTJ
 azA
 azA
 azA
@@ -63353,25 +64279,25 @@ aXT
 pox
 agU
 azA
+cqF
+aVA
+hgr
+aIR
+goj
+aUB
+hgr
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aMS
+aTE
+aTB
+aTJ
+aUo
+aTJ
+aUo
+aTJ
 azA
 azA
 azA
@@ -63610,25 +64536,25 @@ aXT
 aXT
 agU
 azA
+cqF
+bkw
+gZc
+hgr
+bMX
+aTv
+avx
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aNs
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
 azA
 azA
 azA
@@ -63867,21 +64793,21 @@ bjT
 agn
 agU
 azA
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMu
+aMS
+aTE
+aTB
+aTJ
 azA
 azA
 azA
@@ -64133,12 +65059,12 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
 azA
 azA
 azA
@@ -77488,13 +78414,13 @@ ass
 sjI
 eAb
 ass
-viG
+daV
 agy
 ass
-viG
+daV
 agy
 ass
-viG
+daV
 agy
 ass
 ipQ

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -26342,14 +26342,14 @@
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
 "hEk" = (
-/obj/machinery/door/airlock/security{
-	name = "LCZ Security Section";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
 	id_tag = "LCZ Security Office Access Lock";
 	name = "LCZ Security Office Access Lock"
+	},
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/entrance_checkpoint)
@@ -28232,7 +28232,7 @@
 "jEt" = (
 /obj/machinery/door/airlock/security{
 	name = "LCZ Security Section";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -31179,13 +31179,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmtunnel)
 "mUD" = (
-/obj/machinery/door/airlock/security{
-	name = "LCZ Security Section";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "LCZ Security Office Access Lock";
 	name = "LCZ Security Office Access Lock"
+	},
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/entrance_checkpoint)

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -23361,6 +23361,9 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/boombox,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "epD" = (
@@ -27756,17 +27759,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
-"jaf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "SCP-151 Containment Chamber";
-	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/site53/ulcz/humanoidcontainment)
 "jbo" = (
 /obj/machinery/camera/network/lcz,
 /obj/structure/closet{
@@ -30619,10 +30611,12 @@
 /turf/simulated/floor/reinforced,
 /area/site53/surface/explorers/surrounding)
 "mrs" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/structure/table/standard,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/food/condiment/small/peppermill,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/humanoidcontainment)
 "mrP" = (
 /obj/structure/cable/green{
@@ -37136,12 +37130,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
-"ues" = (
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/site53/ulcz/humanoidcontainment)
 "ugr" = (
 /obj/machinery/light,
 /obj/machinery/disposal/deliveryChute{
@@ -39710,10 +39698,6 @@
 /area/site53/lhcz/hczguardgear)
 "wZG" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/beakers,
-/obj/item/reagent_containers/food/condiment/small/peppermill,
-/obj/item/reagent_containers/food/condiment/enzyme,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -85306,10 +85290,10 @@ urC
 azA
 urC
 juH
-iyl
+wUY
 eLf
 lOO
-ues
+iyl
 kEI
 kkD
 hyr
@@ -86087,7 +86071,7 @@ eWp
 qyR
 pCp
 ndr
-urC
+koI
 lfb
 fIB
 epk
@@ -86344,10 +86328,10 @@ nsU
 nsU
 nsU
 nsU
-urC
-cNb
 nsU
-mrs
+nsU
+nsU
+cNb
 urC
 nsU
 nsU
@@ -86598,14 +86582,14 @@ hMF
 gHs
 vNN
 nsU
-mrs
-nsU
-nsU
-tII
 nsU
 nsU
 nsU
-tII
+nsU
+nsU
+nsU
+nsU
+urC
 nsU
 nsU
 urC
@@ -86855,14 +86839,14 @@ hMF
 gHs
 inT
 nsU
-koI
 nsU
 nsU
-urC
-xCn
 nsU
-jaf
-urC
+nsU
+nsU
+nsU
+nsU
+tII
 nsU
 nsU
 urC
@@ -87115,13 +87099,13 @@ nsU
 nsU
 nsU
 nsU
-urC
-urC
-tII
-urC
+nsU
+sxX
+nsU
+sxX
 urC
 nsU
-nsU
+sxX
 urC
 azA
 azA
@@ -87373,12 +87357,12 @@ hiu
 pCp
 xCn
 urC
-sxX
-nsU
-sxX
+urC
 tII
-nsU
-sxX
+urC
+urC
+urC
+urC
 urC
 azA
 azA
@@ -87630,12 +87614,12 @@ jee
 jee
 jee
 urC
-urC
-tII
-urC
-urC
-urC
-urC
+nsU
+nsU
+nsU
+nsU
+nsU
+nsU
 urC
 azA
 azA
@@ -88654,7 +88638,7 @@ iRf
 kEI
 qEa
 uhy
-qvG
+mrs
 uhy
 hNz
 lRm

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -33551,6 +33551,17 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
+"pGX" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "pHf" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/bin{
@@ -59411,7 +59422,7 @@ aVD
 azA
 azA
 aVD
-aUF
+pGX
 aVD
 azA
 azA

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -1363,13 +1363,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod)
-"aeE" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Sergeant Equipment";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aeF" = (
 /obj/structure/sign/radiation,
 /obj/effect/paint_stripe/yellow,
@@ -3739,18 +3732,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
-"all" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "alm" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -10008,10 +9989,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
-"aAI" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor,
-/area/space)
 "aAJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10414,14 +10391,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
-"aBG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aBH" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15871,15 +15840,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
-"aTA" = (
-/obj/effect/landmark/start{
-	name = "LCZ Zone Commander"
-	},
-/obj/structure/bed/chair/office/comfy{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aTB" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
@@ -15942,15 +15902,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aTM" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aTN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15974,11 +15925,6 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/lowertrams/hczmaint/east)
-"aTZ" = (
-/obj/structure/filingcabinet,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aUa" = (
 /obj/structure/table/rack,
 /obj/item/melee/baton/loaded,
@@ -16066,10 +16012,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aUp" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aUt" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/monotile,
@@ -16149,26 +16091,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aUI" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
-"aUK" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aUL" = (
 /obj/effect/floor_decal/corner/black/full,
 /obj/structure/bed/chair/padded/black,
@@ -16187,25 +16109,6 @@
 /obj/item/device/toner,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"aUP" = (
-/obj/structure/closet/secure_closet/guard/zone_commander{
-	req_access = list("ACCESS_SCIENCE_LEVEL2")
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 5
-	},
-/obj/item/gun/projectile/automatic/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/box/rubbershot,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aUQ" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/adv,
@@ -16257,12 +16160,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
 /area/site53/ulcz/scp999)
-"aVa" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVb" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -16301,16 +16198,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/uhcz/securitypost)
-"aVk" = (
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aVl" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/suit/bio_suit/general,
@@ -16327,10 +16214,6 @@
 /obj/item/clothing/shoes/white,
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
-"aVm" = (
-/obj/structure/table/glass,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVn" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -16356,14 +16239,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aVq" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aVr" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -16401,12 +16276,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
-"aVx" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVy" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -16450,9 +16319,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/ulcz/scp216)
-"aVG" = (
-/turf/simulated/open,
-/area/space)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -16464,12 +16330,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aVJ" = (
-/obj/effect/landmark/start{
-	name = "LCZ Guard"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVK" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -19967,12 +19827,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"bhl" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "bhm" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/scp/saiga12/stunshell,
@@ -20904,12 +20758,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
-"bku" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "bkw" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -21608,7 +21456,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "bWT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21638,7 +21486,7 @@
 	RCon_tag = "Self-Destruct Substation"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "bXO" = (
 /obj/effect/floor_decal/spline/plain/blue{
 	dir = 1
@@ -21855,10 +21703,6 @@
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
-"cnC" = (
-/obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "cnW" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
@@ -22061,12 +21905,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"czh" = (
-/obj/structure/table/reinforced,
-/obj/random/clipboard,
-/obj/effect/floor_decal/carpet/blue2,
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "czj" = (
 /obj/machinery/light{
 	dir = 1
@@ -22236,10 +22074,6 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
 /area/site53/engineering/primaryhallway)
-"cJA" = (
-/obj/machinery/light,
-/turf/simulated/open,
-/area/space)
 "cKH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22343,12 +22177,6 @@
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/engineering/primaryhallway)
-"cPW" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "cQv" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
@@ -22413,17 +22241,6 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
-"cTo" = (
-/obj/structure/table/reinforced,
-/obj/item/material/ashtray/plastic,
-/obj/item/trash/cigbutt{
-	pixel_y = 7
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "cTw" = (
 /obj/structure/bed/chair/padded/black{
 	dir = 4
@@ -23947,13 +23764,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp096)
-"eOL" = (
-/obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "eOZ" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
@@ -24073,11 +23883,6 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
-"eXr" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/mre/menu2,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "eXV" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 5
@@ -24428,12 +24233,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/uhcz/scp106containment)
-"frW" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fsz" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/wood/mahogany,
@@ -24549,12 +24348,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
-"fwg" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fwm" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -24571,12 +24364,6 @@
 /obj/item/inflatable/door,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
-"fwG" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fwQ" = (
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
@@ -24678,15 +24465,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"fEA" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fEN" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/camera/network/entrance{
@@ -24768,14 +24546,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
-"fLg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fLT" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -25434,10 +25204,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"guy" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "gvB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25652,14 +25418,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"gLf" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "gLL" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/item/storage/box/bodybags,
@@ -25787,14 +25545,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
-"gRM" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "gSw" = (
 /obj/structure/table/standard,
 /obj/item/device/camera,
@@ -26615,9 +26365,6 @@
 	name = "LCZ Security Section";
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
 	id_tag = "LCZ Security Office Access Lock";
@@ -27161,14 +26908,6 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
-"idT" = (
-/obj/structure/table/glass,
-/obj/item/device/flashlight/lamp,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "iea" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27512,14 +27251,6 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
-"ixT" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "iyl" = (
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
@@ -27931,14 +27662,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
-"iTu" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 10
-	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "iUu" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -28063,10 +27786,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
-"jaN" = (
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
-/area/space)
 "jbo" = (
 /obj/machinery/camera/network/lcz,
 /obj/structure/closet{
@@ -28434,15 +28153,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
-"jyg" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/obj/machinery/light,
-/turf/simulated/open,
-/area/space)
 "jzT" = (
 /obj/effect/paint_stripe/red,
 /obj/structure/sign/monkey_painting,
@@ -28458,13 +28168,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
-"jAP" = (
-/obj/machinery/vending/fitness,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "jBd" = (
 /obj/effect/floor_decal/chapel,
 /obj/machinery/firealarm{
@@ -28833,12 +28536,6 @@
 /obj/item/device/camera_film,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
-"jWg" = (
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "jWC" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -29476,15 +29173,6 @@
 /obj/machinery/light/small/red,
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
-"kIm" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "LCZ Zone Commander's Office";
-	send_access = list(204)
-	},
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "kIy" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/light{
@@ -29526,7 +29214,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "kKf" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/corner/red/mono,
@@ -29583,16 +29271,6 @@
 /obj/item/device/assembly/prox_sensor,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
-"kPt" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "kPM" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -29642,17 +29320,6 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
-"kSF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "kUj" = (
 /obj/machinery/camera/network/hcz{
 	dir = 1
@@ -29717,7 +29384,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "kWi" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -29727,25 +29394,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
-"laq" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
-"laH" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "laQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31554,9 +31202,6 @@
 	name = "LCZ Security Section";
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "LCZ Security Office Access Lock";
 	name = "LCZ Security Office Access Lock"
@@ -31721,17 +31366,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
-"ncb" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "ndi" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -32233,15 +31867,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
-"nHd" = (
-/obj/machinery/power/apc/hyper{
-	dir = 1
-	},
-/obj/machinery/vending/security{
-	req_access = list()
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
 "nHk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -32300,22 +31925,6 @@
 	temperature = 80
 	},
 /area/site53/upper_surface/serverfarminterior)
-"nJn" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nJN" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/camera/network/hcz,
@@ -32375,12 +31984,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"nLV" = (
-/obj/effect/floor_decal/corner/blue/bordercee{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nMl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -32443,18 +32046,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
-"nQf" = (
-/obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nQM" = (
 /obj/machinery/cooker/fryer,
 /obj/machinery/camera/autoname{
@@ -32577,9 +32168,6 @@
 /obj/item/storage/mre/random,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"nVn" = (
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nVI" = (
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
@@ -33379,7 +32967,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "oSR" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
@@ -34144,12 +33732,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"pTX" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "pUs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -34220,10 +33802,6 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uhcz/scp247containment)
-"qaD" = (
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "qaJ" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -34466,15 +34044,6 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/brownline)
-"qnx" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "qnO" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -35574,19 +35143,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
-"rFf" = (
-/obj/structure/table/standard,
-/obj/item/pen,
-/obj/item/paper_bin,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "rFI" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donut,
@@ -35863,10 +35419,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
-"rZm" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "rZL" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -36156,11 +35708,6 @@
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/prepainted,
 /area/site53/reswing/xenobiology)
-"sng" = (
-/obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "snm" = (
 /obj/machinery/door/airlock/security{
 	name = "UHCZ Checkpoint";
@@ -37082,19 +36629,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
-"twA" = (
-/obj/machinery/power/apc/hyper{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "twH" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Evacuation Bunker"
@@ -38772,7 +38306,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "vxr" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -39195,13 +38729,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
-"vWB" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "vWZ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
@@ -39633,14 +39160,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
-"wwj" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "wwJ" = (
 /obj/machinery/camera/autoname{
 	name = "SCP-247 Observation"
@@ -40050,13 +39569,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
-"wSd" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "wSy" = (
 /obj/machinery/light{
 	dir = 4
@@ -40466,14 +39978,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"xnC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "xoe" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -40591,12 +40095,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
-"xsq" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/item/modular_computer/laptop/preset/records,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "xst" = (
 /obj/machinery/camera/network/entrance,
 /obj/machinery/cooker/candy,
@@ -40949,12 +40447,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"xSo" = (
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "xSs" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a57,
@@ -57119,14 +56611,14 @@ azA
 azA
 azA
 azA
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57376,14 +56868,14 @@ azA
 azA
 azA
 azA
-jaN
-eXr
-ncb
-nVn
-nVn
-laH
-nJn
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57633,14 +57125,14 @@ azA
 azA
 azA
 azA
-jaN
-cTo
-frW
-nVn
-nVn
-nVn
-guy
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57890,14 +57382,14 @@ aMC
 azA
 azA
 azA
-jaN
-aTM
-nVn
-aUp
-nVn
-aVJ
-cnC
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58147,14 +57639,14 @@ aMC
 aMC
 azA
 azA
-jaN
-jAP
-nVn
-nVn
-nVn
-aVJ
-sng
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58404,14 +57896,14 @@ maZ
 aMC
 azA
 azA
-jaN
-rZm
-nVn
-nVn
-nVn
-nVn
-nVn
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58661,20 +58153,20 @@ iQI
 aMC
 azA
 azA
-jaN
-aAI
-aAI
-aeE
-aeE
-aAI
-aAI
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58918,20 +58410,20 @@ hbm
 aMC
 azA
 azA
-jaN
-aVG
-aVG
-fwg
-qaD
-aVG
-aVG
-jyg
-jaN
-cPW
-bku
-twA
-iTu
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59175,20 +58667,20 @@ xSs
 aMC
 azA
 azA
-wwj
-aUI
-aUI
-nVn
-nVn
-aUI
-aUI
-aUI
-eOL
-xSo
-nVn
-xnC
-gLf
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59432,20 +58924,20 @@ tPi
 aMC
 azA
 azA
-aBG
-aBG
-all
-all
-all
-all
-all
-all
-nQf
-kSF
-aBG
-fLg
-kIm
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59689,20 +59181,20 @@ qSc
 qSc
 azA
 azA
-aAI
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-cJA
-jaN
-qnx
-bhl
-nVn
-aTZ
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59946,20 +59438,20 @@ azA
 azA
 azA
 azA
-nVn
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-idT
-aVm
-aUp
-aVa
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60203,20 +59695,20 @@ azA
 azA
 azA
 azA
-nVn
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-fEA
-fwG
-nVn
-xsq
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60441,7 +59933,7 @@ neg
 bKj
 bKj
 aUt
-nHd
+aNH
 wVj
 aMS
 spT
@@ -60460,20 +59952,20 @@ azA
 azA
 azA
 azA
-nVn
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-laq
-nVn
-nVn
-ixT
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60717,20 +60209,20 @@ azA
 azA
 azA
 azA
-jaN
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-pTX
-aVx
-aVx
-wSd
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60974,20 +60466,20 @@ azA
 azA
 azA
 azA
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-aUK
-aVq
-rFf
-gRM
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -61231,20 +60723,20 @@ azA
 azA
 azA
 azA
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-jWg
-aTA
-czh
-vWB
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -61488,20 +60980,20 @@ azA
 azA
 azA
 azA
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-jaN
-aUP
-kPt
-aVk
-nLV
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -61745,20 +61237,20 @@ azA
 azA
 azA
 azA
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -62235,7 +61727,7 @@ aVb
 cqF
 azA
 azA
-cqF
+aVD
 bXK
 kKc
 oSH
@@ -62492,7 +61984,7 @@ aVb
 cqF
 azA
 azA
-cqF
+aVD
 bWR
 vxq
 kVZ
@@ -62749,10 +62241,10 @@ aVb
 cqF
 azA
 azA
-cqF
-cqF
-cqF
-cqF
+aVD
+aVD
+aVD
+aVD
 aVD
 mBo
 aMS

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -741,19 +741,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
 "acs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/unsimulated/mineral,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/zonecommanderoffice)
 "acu" = (
 /obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/light{
@@ -1831,7 +1820,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/unsimulated/mineral,
+/turf/simulated/mineral/random{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/ulcz/maintenance)
 "agi" = (
 /obj/structure/cable/green{
@@ -2063,7 +2054,9 @@
 /area/site53/reswing/robotics)
 "agQ" = (
 /obj/structure/disposalpipe/segment,
-/turf/unsimulated/mineral,
+/turf/simulated/mineral/random{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/ulcz/maintenance)
 "agR" = (
 /obj/structure/cable/green{
@@ -2613,7 +2606,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/unsimulated/mineral,
+/turf/simulated/mineral/random{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/ulcz/maintenance)
 "ais" = (
 /turf/simulated/floor/plating,
@@ -3511,18 +3506,6 @@
 /area/site53/engineering/containment_engineer)
 "akH" = (
 /obj/structure/table/standard,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "akI" = (
@@ -6817,6 +6800,9 @@
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 9
 	},
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 9
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "asB" = (
@@ -9577,6 +9563,9 @@
 /area/site53/engineering/primaryhallway)
 "azx" = (
 /obj/machinery/camera/network/lcz,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "azz" = (
@@ -11289,6 +11278,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aDK" = (
@@ -11338,6 +11330,9 @@
 	dir = 1
 	},
 /obj/machinery/camera/network/lcz,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aDS" = (
@@ -11546,6 +11541,7 @@
 	},
 /obj/structure/table/rack,
 /obj/item/gun/energy/ionrifle,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "aEz" = (
@@ -11560,6 +11556,9 @@
 /area/site53/uhcz/hallways)
 "aEA" = (
 /obj/machinery/light,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aEC" = (
@@ -11569,6 +11568,9 @@
 /obj/structure/closet/crate/bin{
 	anchored = 1;
 	name = "trash bin"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -11723,7 +11725,10 @@
 /area/site53/ulcz/hallways)
 "aFg" = (
 /obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "aFj" = (
 /obj/structure/cable{
@@ -11860,6 +11865,9 @@
 /obj/structure/table/standard,
 /obj/machinery/photocopier{
 	pixel_y = 3
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -12069,6 +12077,9 @@
 	id_tag = "ULCZ Checkpoint Lockdown Lower";
 	name = "ULCZ Checkpoint Lockdown Lower";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -13048,6 +13059,8 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 23
 	},
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aKb" = (
@@ -13721,7 +13734,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/hallways)
 "aMC" = (
-/obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/dclass/armory)
@@ -14061,11 +14073,17 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "aNH" = (
 /obj/machinery/vending/security{
-	req_access = list()
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -14124,6 +14142,9 @@
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aNR" = (
@@ -15833,6 +15854,9 @@
 	pixel_y = 25;
 	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aTB" = (
@@ -15883,16 +15907,24 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aTJ" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/llcz/checkequip)
+/obj/structure/bed/chair{
+	dir = 1;
+	pixel_y = 13
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aTL" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier{
 	pixel_y = 3
 	},
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -15913,6 +15945,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aTY" = (
@@ -15932,8 +15967,7 @@
 /obj/item/melee/baton/loaded,
 /obj/item/melee/baton/loaded,
 /obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUb" = (
@@ -16038,6 +16072,9 @@
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 10
 	},
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 10
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "aUz" = (
@@ -16084,7 +16121,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark,
 /area/site53/llcz/checkequip)
 "aUL" = (
 /obj/effect/floor_decal/corner/black/full,
@@ -16102,30 +16139,26 @@
 /obj/item/device/toner,
 /obj/item/device/toner,
 /obj/item/device/toner,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aUQ" = (
 /obj/structure/table/standard,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donut,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aUU" = (
@@ -16253,6 +16286,9 @@
 /area/site53/ulcz/scp2427_3)
 "aVu" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aVw" = (
@@ -16294,8 +16330,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aVD" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/checkequip)
@@ -16344,6 +16378,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/closet/secure_closet/guard/specialistshotgun,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "aVN" = (
@@ -18713,6 +18748,7 @@
 /obj/item/ammo_magazine/scp/saiga12/beanbag,
 /obj/item/ammo_magazine/box/beanbag,
 /obj/item/ammo_magazine/box/beanbag,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "bdf" = (
@@ -19695,6 +19731,9 @@
 /area/site53/ulcz/hallways)
 "bgF" = (
 /obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bgI" = (
@@ -19727,6 +19766,9 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bgX" = (
@@ -19807,6 +19849,9 @@
 	pixel_y = 3
 	},
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "bhi" = (
@@ -19823,6 +19868,7 @@
 /obj/item/ammo_magazine/scp/saiga12/stunshell,
 /obj/item/ammo_magazine/box/stunshell,
 /obj/item/ammo_magazine/box/stunshell,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "bho" = (
@@ -19863,6 +19909,7 @@
 /obj/item/clothing/accessory/storage/bandolier,
 /obj/item/clothing/accessory/storage/bandolier,
 /obj/item/clothing/accessory/storage/bandolier,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bhu" = (
@@ -20256,6 +20303,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "biM" = (
@@ -20277,6 +20327,9 @@
 "biQ" = (
 /obj/structure/closet{
 	name = "Confiscated items"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -20719,7 +20772,10 @@
 	send_access = list(204)
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "bkq" = (
 /obj/effect/paint_stripe/gray,
@@ -20729,6 +20785,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "bks" = (
@@ -20736,7 +20795,7 @@
 	name = "Security Center";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/checkequip)
 "bkt" = (
 /obj/structure/cable/green{
@@ -20778,16 +20837,13 @@
 /turf/simulated/wall/titanium,
 /area/site53/ulcz/humanoidcontainment)
 "blf" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/effect/floor_decal/industrial/warning{
-	dir = 4
+	dir = 5;
+	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -20806,8 +20862,18 @@
 	name = "ULCZ South Gate";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"blL" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/combat,
+/obj/item/device/scanner/health,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "bmF" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -21081,11 +21147,14 @@
 /obj/effect/landmark/start{
 	name = "LCZ Guard"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "bBM" = (
 /obj/machinery/camera/network/lcz,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "bBQ" = (
 /obj/structure/hygiene/sink{
@@ -21180,7 +21249,8 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bKj" = (
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "bKK" = (
 /obj/effect/paint_stripe/yellow,
@@ -21261,19 +21331,7 @@
 /obj/item/ammo_magazine/box/beanbag,
 /obj/item/ammo_magazine/box/beanbag,
 /obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bQJ" = (
@@ -21356,6 +21414,7 @@
 /obj/item/shield/riot,
 /obj/item/shield/riot,
 /obj/item/shield/riot,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bTH" = (
@@ -21407,6 +21466,9 @@
 /area/site53/uhcz/commanderoffice)
 "bVr" = (
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -21634,6 +21696,9 @@
 /area/site53/surface/bunker)
 "clC" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "clO" = (
@@ -21643,6 +21708,9 @@
 /area/site53/lowertrams/hub)
 "cme" = (
 /obj/machinery/papershredder,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "cmh" = (
@@ -21737,7 +21805,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "cqF" = (
-/obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -21784,10 +21851,10 @@
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 23
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "csp" = (
@@ -21801,6 +21868,7 @@
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "cvv" = (
@@ -21915,7 +21983,10 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "cBj" = (
 /obj/structure/bed,
@@ -22235,6 +22306,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "cVc" = (
@@ -22693,6 +22767,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "dvP" = (
@@ -22748,6 +22825,7 @@
 /obj/structure/window/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "dyu" = (
@@ -22913,7 +22991,10 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "dJZ" = (
 /obj/structure/cable/green{
@@ -23287,6 +23368,7 @@
 "eiL" = (
 /obj/structure/table/rack,
 /obj/item/gun/energy/plasmastun,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "eiU" = (
@@ -23301,7 +23383,7 @@
 /obj/effect/landmark/start{
 	name = "LCZ Guard"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "ekr" = (
 /obj/structure/cable{
@@ -23367,11 +23449,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "epD" = (
-/obj/machinery/vending/security{
-	req_access = list()
-	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/vending/security{
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -23391,6 +23473,14 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"eqq" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "eqH" = (
 /obj/machinery/door/airlock/science{
 	name = "Tranqilizer Storage";
@@ -23911,7 +24001,7 @@
 	name = "Zone Commander's Office";
 	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "fcc" = (
 /obj/machinery/button/blast_door{
@@ -24089,6 +24179,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
+"fjn" = (
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "fjL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red/mono,
@@ -24140,6 +24236,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
+"foR" = (
+/obj/effect/paint_stripe/red,
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/zonecommanderoffice)
 "fpy" = (
 /obj/machinery/light{
 	dir = 8
@@ -24518,6 +24619,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
+"fII" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "fJe" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/industrial/outline/orange,
@@ -24614,6 +24722,7 @@
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
 "fQz" = (
+/obj/effect/floor_decal/corner/red/border,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
@@ -24636,6 +24745,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"fRt" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "fRx" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -24842,8 +24957,15 @@
 /area/space)
 "gci" = (
 /obj/structure/closet/secure_closet/guard/lcz,
+/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"gcN" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "gdE" = (
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = 22
@@ -24981,6 +25103,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
+"gju" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "gjy" = (
 /obj/machinery/camera/network/entrance{
 	c_tag = "Hub 2";
@@ -25219,6 +25348,7 @@
 /area/site53/ulcz/scp2427_3)
 "gyj" = (
 /obj/structure/filingcabinet,
+/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "gyC" = (
@@ -25423,6 +25553,18 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
+"gNi" = (
+/obj/structure/table/rack,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/item/ammo_magazine/box/flash,
+/obj/item/ammo_magazine/box/flash,
+/obj/item/ammo_magazine/box/flash,
+/obj/item/ammo_magazine/box/flash,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "gNK" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -25730,11 +25872,7 @@
 /obj/item/ammo_magazine/scp/p90_mag/rubber,
 /obj/item/ammo_magazine/scp/p90_mag/rubber,
 /obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "hbt" = (
@@ -25758,6 +25896,7 @@
 /obj/structure/table/reinforced,
 /obj/random/clipboard,
 /obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/spline/fancy/black,
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "hcC" = (
@@ -25766,6 +25905,15 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/generalpurpose3)
+"hcV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "hdg" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25775,16 +25923,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "hed" = (
-/obj/structure/table/rack,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "heA" = (
@@ -25822,12 +25969,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "hhA" = (
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "LCZ Security Office Access Lock";
-	name = "LCZ Security Office Access Lock";
-	pixel_x = 22;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -25930,7 +26073,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "hnw" = (
 /obj/structure/table/standard,
@@ -26141,6 +26284,9 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "hyr" = (
@@ -26177,19 +26323,13 @@
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/flashbangs,
 /obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 23
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "hAF" = (
@@ -26354,7 +26494,7 @@
 	name = "LCZ Security Section";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "hFj" = (
 /turf/simulated/floor/exoplanet/grass,
@@ -26462,6 +26602,15 @@
 "hMF" = (
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
+"hML" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "hMV" = (
 /obj/machinery/access_button/airlock_exterior{
 	master_tag = "comms_airlock";
@@ -26475,6 +26624,9 @@
 "hNf" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/camera/network/lcz,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "hNx" = (
@@ -26653,6 +26805,7 @@
 /area/chapel)
 "hTX" = (
 /obj/machinery/papershredder,
+/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "hUb" = (
@@ -26686,15 +26839,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
 "hUS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ULCZ Checkpoint Lockdown Upper";
-	name = "ULCZ Checkpoint Lockdown Upper"
-	},
-/obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/plating,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "hVd" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -26869,6 +27015,7 @@
 /obj/item/ammo_magazine/scp/saiga12/rubbershot,
 /obj/item/ammo_magazine/box/rubbershot,
 /obj/item/ammo_magazine/box/rubbershot,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "icV" = (
@@ -26897,6 +27044,9 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "ieh" = (
@@ -26965,6 +27115,9 @@
 /obj/item/ammo_magazine/box/rubbershot,
 /obj/item/ammo_magazine/box/beanbag,
 /obj/item/ammo_magazine/box/beanbag,
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 5
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "iik" = (
@@ -27032,7 +27185,10 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "imN" = (
 /obj/effect/floor_decal/corner/red/border{
@@ -27174,6 +27330,9 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/mre/menu2,
 /obj/machinery/camera/network/lcz,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "iuh" = (
@@ -27426,6 +27585,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"iJY" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "iKH" = (
 /obj/machinery/camera/autoname{
 	name = "SCP-247 Containment"
@@ -27522,18 +27690,15 @@
 /obj/item/ammo_magazine/scp/mk9,
 /obj/item/ammo_magazine/scp/mk9,
 /obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
+/obj/item/gun/projectile/pistol/mk9,
+/obj/item/gun/projectile/pistol/mk9,
+/obj/item/gun/projectile/pistol/mk9,
 /obj/item/ammo_magazine/scp/mk9,
 /obj/item/ammo_magazine/scp/mk9,
 /obj/item/gun/projectile/pistol/mk9,
-/obj/item/gun/projectile/pistol/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "iQZ" = (
@@ -27644,8 +27809,20 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"iTp" = (
+/obj/machinery/vending/security{
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "iUu" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -27765,6 +27942,9 @@
 	name = "Confiscated items"
 	},
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -27976,12 +28156,18 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"jrM" = (
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "jsp" = (
 /obj/machinery/door/airlock/science{
 	name = "SCP-529";
 	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
-/obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -28104,6 +28290,9 @@
 /obj/item/handcuffs,
 /obj/structure/closet{
 	name = "D-Class Prep"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -28232,7 +28421,7 @@
 /obj/structure/cable/green{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "jFe" = (
 /obj/structure/disposalpipe/segment{
@@ -28386,13 +28575,17 @@
 	anchored = 1;
 	name = "trash bin"
 	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "jOV" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/office)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "jPr" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/exoplanet/barren,
@@ -28521,6 +28714,9 @@
 	dir = 1
 	},
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "jYH" = (
@@ -28544,6 +28740,7 @@
 	send_access = list("ACCESS_SECURITY_LEVEL1")
 	},
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "kao" = (
@@ -28643,6 +28840,13 @@
 	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
 	},
 /area/site53/ulcz/maintenance)
+"kgE" = (
+/obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "kgM" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -28770,8 +28974,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "klT" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/zonecommanderoffice)
@@ -29051,6 +29253,7 @@
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "kDy" = (
@@ -29244,6 +29447,15 @@
 /obj/item/device/assembly/prox_sensor,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"kOS" = (
+/obj/structure/closet{
+	name = "Confiscated items"
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "kPM" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -29327,6 +29539,9 @@
 	pixel_x = -22;
 	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "kVA" = (
@@ -29339,6 +29554,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"kVF" = (
+/obj/effect/floor_decal/corner/red/border,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "kVV" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -29367,6 +29587,12 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
+"kXd" = (
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "laQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29419,6 +29645,9 @@
 "lbS" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "lcb" = (
@@ -29466,6 +29695,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"lei" = (
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "lfb" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -29529,6 +29765,9 @@
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 4
 	},
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "lhJ" = (
@@ -29578,6 +29817,9 @@
 /area/site53/surface/bunker)
 "lkI" = (
 /obj/structure/bed/chair,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
@@ -30227,6 +30469,7 @@
 /obj/structure/table/standard,
 /obj/item/boombox,
 /obj/item/device/megaphone,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "lWq" = (
@@ -30296,6 +30539,7 @@
 /obj/item/ammo_magazine/box/a357,
 /obj/item/gun/projectile/revolver/rhino,
 /obj/item/gun/projectile/revolver/rhino,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "mbs" = (
@@ -30388,6 +30632,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/hallways)
+"mgZ" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "mhh" = (
 /obj/machinery/light{
 	dir = 1
@@ -30403,6 +30653,12 @@
 /obj/item/modular_computer/console/preset/aislot/sysadmin,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aiccore)
+"mhW" = (
+/obj/effect/floor_decal/corner/red/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "mig" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 1
@@ -30430,6 +30686,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "mjg" = (
@@ -30849,6 +31108,9 @@
 /obj/structure/noticeboard{
 	pixel_y = 28
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "mBw" = (
@@ -30886,7 +31148,6 @@
 	name = "SCP-078";
 	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
-/obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -31173,16 +31434,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmtunnel)
 "mUD" = (
-/obj/machinery/door/blast/shutters{
-	id_tag = "LCZ Security Office Access Lock";
-	name = "LCZ Security Office Access Lock"
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
 	},
-/obj/machinery/door/airlock/security{
-	name = "LCZ Security Section";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/entrance_checkpoint)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "mVc" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/mil_rifle,
@@ -31283,6 +31539,9 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "mYw" = (
@@ -31323,6 +31582,22 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"naI" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "nbD" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/tiled/techmaint,
@@ -31389,7 +31664,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "nem" = (
 /obj/structure/closet/crate/bin{
@@ -31594,6 +31869,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "nsM" = (
@@ -31617,10 +31895,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/catwalk_plated/white,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp513)
 "ntR" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -31711,10 +31988,12 @@
 	dir = 8
 	},
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "nyh" = (
-/obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
 /area/site53/ulcz/hallways)
@@ -32105,7 +32384,10 @@
 	dir = 8
 	},
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "nUQ" = (
 /obj/structure/table/reinforced,
@@ -32172,6 +32454,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"nWR" = (
+/obj/effect/floor_decal/corner/red/bordercorner,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "nWT" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
@@ -32190,6 +32476,7 @@
 "nZl" = (
 /obj/structure/table/rack,
 /obj/item/gun/energy/ionrifle,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "oau" = (
@@ -32469,10 +32756,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "orD" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/prepainted,
-/area/site53/lowertrams/brownline)
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "orI" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/monotile/white,
@@ -32715,6 +33003,9 @@
 	dir = 1
 	},
 /obj/machinery/vending/coffee{
+	dir = 1
+	},
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -33190,6 +33481,9 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "pih" = (
@@ -33377,6 +33671,7 @@
 "pyn" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine,
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "pyP" = (
@@ -33384,6 +33679,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "pze" = (
@@ -33435,6 +33733,17 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"pBM" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "pCp" = (
@@ -33465,6 +33774,17 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
+"pDY" = (
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "pEv" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/corner/red/mono,
@@ -33543,6 +33863,9 @@
 "pFU" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "pGX" = (
@@ -33554,7 +33877,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark,
 /area/site53/llcz/checkequip)
 "pHf" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -33740,11 +34063,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "pVB" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/prepainted,
-/area/site53/ulcz/office)
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "pVL" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -34056,6 +34379,9 @@
 /obj/structure/closet/crate/hydroponics/prespawned,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"qoO" = (
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/llcz/checkequip)
 "qpB" = (
 /obj/effect/floor_decal/carpet/green,
 /obj/effect/floor_decal/carpet/green{
@@ -34072,6 +34398,9 @@
 /area/site53/ulcz/generalpurpose)
 "qqQ" = (
 /obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -34100,7 +34429,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "qsG" = (
 /obj/machinery/vending/coffee,
@@ -34150,6 +34482,9 @@
 	},
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "qxf" = (
@@ -34158,6 +34493,9 @@
 	},
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "qxk" = (
@@ -34193,6 +34531,9 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "qzL" = (
@@ -34203,6 +34544,15 @@
 /obj/item/screwdriver,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"qAg" = (
+/obj/machinery/camera/network/lcz{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "qAX" = (
 /obj/machinery/door/airlock/command{
 	name = "Command Security Compartment"
@@ -34433,7 +34783,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/science/aicobservation)
 "qSc" = (
-/obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -34502,6 +34851,9 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -34585,6 +34937,13 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
+"qZg" = (
+/obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "qZr" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/highsecurity{
@@ -34898,6 +35257,7 @@
 /obj/machinery/camera/network/lcz{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "rqI" = (
@@ -35037,6 +35397,9 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/spline/fancy/black{
 	dir = 8
 	},
 /turf/simulated/floor/carpet/blue2,
@@ -35236,6 +35599,18 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/generalpurpose2)
+"rNI" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "rOb" = (
 /obj/machinery/door/blast/shutters/open{
 	dir = 4;
@@ -35334,6 +35709,9 @@
 /obj/item/material/ashtray/plastic,
 /obj/item/trash/cigbutt{
 	pixel_y = 7
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -35728,7 +36106,10 @@
 	},
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "sqv" = (
 /obj/structure/cable/green{
@@ -35748,8 +36129,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
 "srm" = (
 /obj/machinery/bodyscanner{
@@ -36069,10 +36449,13 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "sPg" = (
-/obj/effect/floor_decal/industrial/warning,
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "sPh" = (
@@ -36173,6 +36556,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
+"sVq" = (
+/obj/structure/table/reinforced,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/item/towel/random,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "sVr" = (
 /obj/machinery/floodlight,
 /obj/structure/window/reinforced{
@@ -36262,7 +36655,10 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "tar" = (
 /obj/structure/mopbucket,
@@ -36388,6 +36784,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "tjj" = (
@@ -36408,6 +36807,11 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
+"tjl" = (
+/obj/effect/paint_stripe/red,
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/llcz/checkequip)
 "tjn" = (
 /obj/structure/table/steel,
 /obj/item/paper{
@@ -36472,7 +36876,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "tmK" = (
 /obj/structure/cable{
@@ -36510,6 +36914,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/plating,
 /area/site53/upper_surface/serverfarmcontrol)
+"tpr" = (
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/prepainted,
+/area/site53/llcz/scp500{
+	requires_power = 0
+	})
 "tpZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -36560,6 +36971,9 @@
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 23
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -36859,6 +37273,9 @@
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 6
 	},
+/obj/effect/floor_decal/spline/fancy/black{
+	dir = 6
+	},
 /turf/simulated/floor/carpet/blue2,
 /area/site53/zonecommanderoffice)
 "tMx" = (
@@ -36910,7 +37327,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "tOm" = (
 /obj/effect/floor_decal/carpet/green{
@@ -36943,6 +37363,10 @@
 /obj/item/gun/projectile/automatic/scp/p90,
 /obj/item/gun/projectile/automatic/scp/p90,
 /obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "tPQ" = (
@@ -37130,6 +37554,12 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
+"udU" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/zonecommanderoffice)
 "ugr" = (
 /obj/machinery/light,
 /obj/machinery/disposal/deliveryChute{
@@ -37607,7 +38037,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/surface/explorers/surrounding)
 "uJG" = (
-/obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
@@ -37914,6 +38343,11 @@
 /obj/machinery/photocopier/faxmachine,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"vdi" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "vdk" = (
 /obj/machinery/light/spot,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -37936,6 +38370,12 @@
 	},
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
+/area/site53/llcz/entrance_checkpoint)
+"vel" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "veT" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -37964,6 +38404,7 @@
 /obj/structure/table/rack,
 /obj/item/gun/projectile/automatic/scp/saiga12/rubbershot,
 /obj/item/gun/projectile/automatic/scp/saiga12/rubbershot,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "vhB" = (
@@ -38058,7 +38499,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/unsimulated/mineral,
+/turf/simulated/mineral/random{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/ulcz/maintenance)
 "vnm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -38085,7 +38528,10 @@
 /area/site53/lowertrams/restaurantkitchenarea)
 "vny" = (
 /obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "vnK" = (
 /obj/machinery/light,
@@ -38294,6 +38740,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "vxS" = (
@@ -38369,6 +38818,9 @@
 /area/site53/uhcz/generalpurpose3)
 "vCX" = (
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -38537,6 +38989,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "vNb" = (
@@ -38661,6 +39116,19 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
+"vSL" = (
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock";
+	pixel_x = 22;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "vSP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -38671,6 +39139,9 @@
 /area/site53/upper_surface/serverfarmcontrol)
 "vTy" = (
 /obj/machinery/lapvend,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "vVj" = (
@@ -38736,7 +39207,8 @@
 "vXu" = (
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "vXy" = (
 /obj/structure/window/reinforced{
@@ -38745,6 +39217,9 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "vXz" = (
@@ -38837,7 +39312,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "wdB" = (
 /obj/structure/cable/green{
@@ -38903,6 +39381,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "whL" = (
@@ -38912,6 +39393,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/llcz/entrance_checkpoint)
+"wic" = (
+/obj/effect/floor_decal/corner/red/border{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/zonecommanderoffice)
 "wio" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -38972,11 +39459,15 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/effect/floor_decal/corner/red/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "wkx" = (
 /obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/site53/zonecommanderoffice)
 "wlv" = (
 /obj/machinery/button/blast_door{
@@ -39070,6 +39561,7 @@
 /obj/item/ammo_magazine/scp/saiga12/flash,
 /obj/item/ammo_magazine/box/flash,
 /obj/item/ammo_magazine/box/flash,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "wti" = (
@@ -39211,6 +39703,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"wCH" = (
+/obj/structure/closet/secure_closet/guard/lcz,
+/obj/machinery/light,
+/obj/effect/floor_decal/industrial/outline/red,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "wDh" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -39611,6 +40109,9 @@
 	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/floor_decal/borderfloorwhite{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "wVj" = (
@@ -39627,6 +40128,9 @@
 	dir = 8;
 	pixel_x = 20
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "wVr" = (
@@ -39642,6 +40146,7 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/reinforced,
 /obj/machinery/light,
+/obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "wVK" = (
@@ -39828,7 +40333,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "xfS" = (
 /obj/structure/table/standard,
@@ -39952,7 +40457,7 @@
 	name = "LCZ Security Offices";
 	req_access = list("ACCESS_SECURITY_LEVEL1")
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "xoe" = (
 /obj/structure/cable/green{
@@ -39968,6 +40473,9 @@
 /area/site53/uhcz/commanderoffice)
 "xpa" = (
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/floor_decal/borderfloorwhite{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -40138,6 +40646,9 @@
 	dir = 4;
 	pixel_x = 11
 	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "xxC" = (
@@ -40259,6 +40770,12 @@
 "xET" = (
 /obj/machinery/camera/network/lcz{
 	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/floor_decal/corner/red/border{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -40421,7 +40938,7 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
+/turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/checkequip)
 "xSs" = (
 /obj/structure/table/rack,
@@ -40437,8 +40954,8 @@
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
 /obj/machinery/light,
+/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "xSP" = (
@@ -40507,7 +41024,7 @@
 /area/site53/surface/bunker)
 "xVn" = (
 /obj/machinery/vending/security{
-	req_access = list()
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
@@ -47543,7 +48060,7 @@ azA
 aVS
 aGM
 aGM
-aGM
+pSE
 aGM
 aVS
 aVS
@@ -56012,8 +56529,8 @@ azA
 azA
 bgX
 aiq
-bgX
-bgX
+keI
+keI
 bkq
 mRy
 pPO
@@ -56047,7 +56564,7 @@ aJj
 dpg
 mMC
 azA
-cqF
+uJG
 uJG
 uJG
 uJG
@@ -56306,15 +56823,15 @@ mMC
 azA
 uJG
 vTy
-hgr
+pVB
 jOb
 cTM
-aVu
+qZg
 bkr
 pFU
 pyP
 cTM
-aVu
+qZg
 bkr
 pFU
 aDI
@@ -56553,7 +57070,7 @@ azA
 azA
 azA
 azA
-mMC
+tpr
 mMC
 mMC
 mMC
@@ -57054,7 +57571,7 @@ nyL
 aeS
 aeS
 aeS
-pVB
+aeS
 aVS
 aGM
 qKl
@@ -57062,11 +57579,11 @@ aGM
 aVS
 azA
 azA
-cqF
-cqF
-cqF
-cqF
-cqF
+uJG
+uJG
+uJG
+uJG
+uJG
 azA
 azA
 azA
@@ -57319,19 +57836,19 @@ aEt
 aVS
 azA
 azA
-cqF
+uJG
 vxr
 mYl
-vxr
+rNI
+uJG
+uJG
+uJG
 cqF
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
+uJG
+uJG
+uJG
+uJG
+uJG
 uJG
 hNf
 hgr
@@ -57576,17 +58093,17 @@ aGM
 aVS
 azA
 azA
-cqF
+uJG
+orD
 aVb
-aVb
-aVb
-cqF
+hUS
+uJG
 aUz
 jUp
-cqF
+uJG
 aUz
 jUp
-cqF
+uJG
 aUz
 jUp
 uJG
@@ -57611,7 +58128,7 @@ aVM
 vgG
 vgG
 aXh
-aMC
+qSc
 aMC
 azA
 azA
@@ -57833,17 +58350,17 @@ aGM
 aVS
 azA
 azA
-cqF
+uJG
+vel
 aVb
-aVb
-aVb
-cqF
+fRt
+uJG
 aUL
 aVf
-cqF
+uJG
 aUL
 aVf
-cqF
+uJG
 aUL
 aVf
 uJG
@@ -58089,34 +58606,34 @@ aLv
 aGM
 aVS
 azA
-cqF
-cqF
+uJG
+uJG
 xTl
 cqc
 xTl
-cqF
-aUN
-alF
-cqF
-aUN
-alF
-cqF
+uJG
 aUN
 alF
 uJG
-gyj
+aUN
+alF
+uJG
+aUN
+alF
+uJG
+lei
 hgr
-gyj
+fII
 iea
-pFU
+pBM
 xpa
 aVu
 lbS
 iea
-pFU
+pBM
 xpa
 aVu
-aTv
+jrM
 uJG
 azA
 aMC
@@ -58346,21 +58863,21 @@ jVk
 aGM
 aVS
 azA
-cqF
+uJG
 aEE
 biQ
 aVb
-biQ
-cqF
+kOS
+uJG
 xEG
 xTl
-cqF
+uJG
 xEG
 xTl
-cqF
+uJG
 xEG
 xTl
-cqF
+uJG
 xTl
 xnq
 xTl
@@ -58581,7 +59098,7 @@ azA
 azA
 azA
 bgX
-hFz
+aiq
 keI
 keI
 keI
@@ -58603,35 +59120,35 @@ jVk
 pSE
 aVS
 azA
-cqF
+uJG
 jbo
 aVb
 aVb
-aVb
+fjn
 bVr
 aVb
-aVb
+hhA
 bVr
 aVb
-aVb
+hhA
 bVr
 aVb
+gcN
+uJG
+hML
 aVb
-cqF
-aVb
-aVb
-aVb
-aVb
-aVb
+hhA
+hhA
+hhA
 bVr
-aVb
-aVb
-aVb
-aVb
+hhA
+hhA
+hhA
+hhA
 bVr
-aVb
+hhA
 aEA
-cqF
+uJG
 azA
 aMC
 aEv
@@ -58860,7 +59377,7 @@ tjj
 aVS
 aVS
 azA
-cqF
+uJG
 jxJ
 aUn
 dpC
@@ -58887,8 +59404,8 @@ aVb
 aVb
 aVb
 aVb
-aVb
-cqF
+hUS
+uJG
 azA
 aMC
 fCD
@@ -59117,43 +59634,43 @@ hyd
 aGM
 aVS
 azA
-cqF
+uJG
 aFD
 qhP
 aVb
-aVb
+nWR
+vCX
+jOV
+jOV
+vCX
+qAg
+jOV
 vCX
 aVb
-aVb
+vSL
+uJG
+hcV
+jOV
+aUi
+jOV
+jOV
 vCX
-xET
-aVb
-aVb
-hhA
-aVb
-cqF
-aVb
-aVb
+jOV
 aUi
 aVb
-aVb
+jOV
 vCX
-aVb
-aUi
-aVb
-aVb
-vCX
-aVb
-aEA
-cqF
+jOV
+gju
+uJG
 azA
-qSc
+aMC
 aMC
 xfK
 aMC
 aMC
 aMC
-qSc
+aMC
 qSc
 azA
 azA
@@ -59374,20 +59891,20 @@ aPh
 aGM
 aVS
 azA
-cqF
+uJG
 cme
 qhP
 aVb
 lWh
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
-mUD
-cqF
-cqF
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+pDY
+uJG
 cqF
 klT
 aUt
@@ -59631,26 +60148,26 @@ aPh
 cIC
 aVS
 azA
-cqF
+uJG
 iTk
 aMH
 aVb
 pyn
-cqF
+uJG
 iYX
 nFS
 lYV
-cqF
+uJG
 onW
+mgZ
 aVb
-aVb
+gcN
 cqF
-azA
 klT
 qst
 tmC
-bKj
-bKj
+wic
+udU
 aUt
 aNH
 wVj
@@ -59662,7 +60179,7 @@ ilH
 aVD
 aVD
 aVD
-aVD
+tjl
 aUF
 aVD
 aVD
@@ -59881,35 +60398,35 @@ bhP
 bhP
 bhP
 bhP
-jOV
+bhP
 nyh
 nTU
 xpX
 nTU
 aVS
 azA
-cqF
+uJG
 clC
 qhP
-aVb
-aVb
+jOV
+iJY
 fYk
 eQq
 eQq
 kFd
-cqF
+uJG
 jCD
+orD
 aVb
-aVb
+hUS
 cqF
-azA
 klT
 wdh
 neg
-bKj
+acs
 bKj
 aUt
-aNH
+iTp
 wVj
 aMS
 spT
@@ -60139,38 +60656,38 @@ azA
 azA
 azA
 azA
-agU
+uJG
 aGZ
 ing
-hUS
-agU
+aGZ
+uJG
 azA
-cqF
-cqF
+uJG
+uJG
 bia
-cqF
-cqF
-cqF
+uJG
+uJG
+uJG
 woN
 eQq
 whL
-cqF
-cqF
+uJG
+uJG
 qqQ
 aVb
+kVF
 cqF
-azA
 klT
 bBM
-bKj
-bKj
+acs
+acs
 bKj
 aUt
 hyk
 wVj
 aMS
 cAm
-aMS
+qoO
 aNG
 sZE
 aVD
@@ -60396,7 +60913,7 @@ azA
 azA
 azA
 azA
-agU
+uJG
 aGZ
 mXc
 qPN
@@ -60406,17 +60923,17 @@ bjv
 kVb
 qhP
 vLm
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+orD
 aVb
-aVb
+hUS
 cqF
-azA
 klT
 asA
 rzX
@@ -60653,32 +61170,32 @@ azA
 azA
 azA
 azA
-agU
+uJG
 lkI
 bgK
 bjp
 bVr
-aVb
+hhA
 iRt
 aVb
 qhP
 aVb
 aVY
 bVr
-aVb
+hhA
 qWb
-cqF
+uJG
 azA
-cqF
+uJG
+orD
 aVb
-aVb
+hUS
 cqF
-azA
 klT
 jXr
 wLF
 hbV
-bKj
+acs
 fbx
 aMS
 aVy
@@ -60910,27 +61427,27 @@ azA
 azA
 azA
 azA
-agU
+uJG
 biK
 qhP
 aVb
 aVb
-aVb
+hUS
 sbE
 aDR
 odC
-aVb
+hUS
 mEc
 aVb
 aVb
 wkv
-cqF
+uJG
 azA
-cqF
+uJG
+orD
 aVb
-aVb
+hUS
 cqF
-azA
 klT
 ihR
 lhd
@@ -61167,27 +61684,27 @@ azA
 azA
 azA
 azA
-agU
+uJG
 bgF
 qhP
 aVb
 aVb
-aVb
+hUS
 bhB
 blg
 mNl
 aGA
 gKy
-aVb
+orD
 aVb
 rqq
-cqF
+uJG
 azA
-cqF
+uJG
 aTy
 aVb
+hUS
 cqF
-azA
 klT
 tOa
 bko
@@ -61203,9 +61720,9 @@ aMS
 aVr
 aVD
 aUQ
-aUQ
+naI
 hed
-hed
+gNi
 bQp
 aVD
 azA
@@ -61424,28 +61941,28 @@ azA
 azA
 azA
 azA
-agU
+uJG
 azx
 qhP
 aVb
 aVb
-aEE
+eqq
 fwS
 bhf
 bis
 aDO
-cqF
+uJG
 qqQ
 aVb
-aEA
-cqF
-cqF
-cqF
+vdi
+uJG
+uJG
+uJG
 qqQ
 aVb
+kVF
 cqF
-azA
-klT
+foR
 klT
 klT
 klT
@@ -61457,7 +61974,7 @@ aMS
 aMS
 aMS
 aMS
-akH
+blL
 aVD
 aVD
 aVD
@@ -61681,7 +62198,7 @@ azA
 azA
 azA
 azA
-agU
+uJG
 bgF
 rKp
 jxY
@@ -61691,17 +62208,17 @@ fwS
 erI
 aao
 aEq
-cqF
+uJG
 gmT
 aVb
+hUS
+uJG
+hML
+hhA
+kXd
 aVb
-cqF
-aVb
-aVb
-aVb
-aVb
-cqF
-azA
+hUS
+uJG
 azA
 aVD
 bXK
@@ -61938,7 +62455,7 @@ azA
 azA
 azA
 azA
-agU
+uJG
 qqQ
 bgI
 dpC
@@ -61957,8 +62474,8 @@ aVb
 aVb
 aVb
 aVb
-cqF
-azA
+hUS
+uJG
 azA
 aVD
 bWR
@@ -62195,29 +62712,29 @@ azA
 azA
 azA
 azA
-agU
-bgF
+uJG
+kgE
 bgW
-jxY
-aVb
+aTJ
+jOV
 sPg
 rcM
 lKF
 ren
 cYI
-cqF
+uJG
 blf
 tpZ
 fQz
-cqF
-qqQ
+uJG
+hcV
+jOV
+mhW
 aVb
-aVb
-aVb
-cqF
+hUS
+uJG
 azA
-azA
-aVD
+tjl
 aVD
 aVD
 aVD
@@ -62228,7 +62745,7 @@ aMS
 jnd
 gci
 jnd
-gci
+wCH
 aVD
 azA
 azA
@@ -62452,27 +62969,27 @@ azA
 azA
 azA
 azA
-agU
-agU
-agU
-agU
-agU
-agU
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
 aXK
-cqF
+uJG
 aCb
-cqF
-cqF
+uJG
+uJG
 bkh
 bkh
 bkh
-cqF
-cqF
-cqF
+uJG
+uJG
+uJG
 xET
 aVb
-cqF
-azA
+gju
+uJG
 azA
 azA
 azA
@@ -62481,7 +62998,7 @@ azA
 aVD
 ttg
 aMS
-aMS
+mUD
 xxz
 gci
 wVp
@@ -62715,30 +63232,30 @@ azA
 azA
 azA
 azA
-acs
-cqF
+aXK
+uJG
 eYp
-cqF
-cqF
+uJG
+uJG
 bYK
 bYK
 bYK
-cqF
+uJG
 azA
 cqF
-cqF
+uJG
 gut
-cqF
-cqF
-cqF
-cqF
-cqF
+uJG
+uJG
+uJG
+uJG
+uJG
 azA
-aTJ
-aTJ
-aTJ
+aVD
+aVD
+aVD
 aTE
-aTJ
+aVD
 aVD
 aVD
 aVD
@@ -62973,32 +63490,32 @@ aig
 aig
 aig
 aXK
-cqF
+uJG
 aUv
-cqF
-cqF
+uJG
+uJG
 bkh
 bkh
 bkh
-cqF
+uJG
 azA
-cqF
+uJG
 aMQ
 hgr
 hgr
 nUQ
 hgr
 dKX
-cqF
+uJG
 azA
-aTJ
+aVD
 aVo
 aMS
 aMS
 aMS
 amA
 aoN
-amA
+sVq
 aoN
 aVD
 azA
@@ -63230,25 +63747,25 @@ qnc
 eCZ
 qnc
 vea
-agU
+uJG
 pOj
 aVW
 pXS
 bhO
 bhO
 bhO
-agU
+uJG
 azA
-cqF
+uJG
 xIs
 hgr
 nRA
 jBr
 iXa
 aTv
-cqF
+uJG
 azA
-aTJ
+aVD
 aMv
 aMS
 aMS
@@ -63494,27 +64011,27 @@ aXT
 aXT
 aXT
 aXT
-agU
+uJG
 azA
-cqF
+uJG
 aPV
 hgr
 bXO
 fAR
 hgX
 aUg
-cqF
+uJG
 azA
-aTJ
+aVD
 aMv
 aNs
-aTJ
-aTJ
-aTJ
+aVD
+aVD
+aVD
 aNb
-aTJ
+aVD
 aNb
-aTJ
+aVD
 azA
 azA
 azA
@@ -63751,27 +64268,27 @@ aXT
 aXT
 aXT
 pox
-agU
+uJG
 azA
-cqF
+uJG
 aVA
 hgr
 aIR
 goj
 aUB
 hgr
-cqF
+uJG
 azA
-aTJ
+aVD
 aMv
 aMS
 aTE
 aTB
-aTJ
+aVD
 aUo
-aTJ
+aVD
 aUo
-aTJ
+aVD
 azA
 azA
 azA
@@ -64008,27 +64525,27 @@ aXT
 aXT
 aXT
 aXT
-agU
+uJG
 azA
-cqF
+uJG
 bkw
 gZc
 hgr
 bMX
 aTv
 avx
-cqF
+uJG
 azA
-aTJ
+aVD
 aMv
 aNs
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
 azA
 azA
 azA
@@ -64257,31 +64774,31 @@ adx
 adx
 adx
 xvH
-agU
-agU
+uJG
+uJG
 fGE
 agn
 bjT
 agn
 bjT
 agn
-agU
+uJG
 azA
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
-cqF
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
 azA
-aTJ
+aVD
 aMu
 aMS
 aTE
 aTB
-aTJ
+aVD
 azA
 azA
 azA
@@ -64514,15 +65031,15 @@ aiw
 aiw
 aiw
 aiw
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
+uJG
+cqF
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
 azA
 azA
 azA
@@ -64533,12 +65050,12 @@ azA
 azA
 azA
 azA
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
 azA
 azA
 azA
@@ -65026,9 +65543,9 @@ abI
 abI
 abI
 abI
-orD
 abI
-orD
+abI
+abI
 azA
 azA
 azA

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -23361,6 +23361,9 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/boombox,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "epD" = (
@@ -27750,17 +27753,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
-"jaf" = (
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "SCP-151 Containment Chamber";
-	send_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/site53/ulcz/humanoidcontainment)
 "jbo" = (
 /obj/machinery/camera/network/lcz,
 /obj/structure/closet{
@@ -30613,10 +30605,12 @@
 /turf/simulated/floor/reinforced,
 /area/site53/surface/explorers/surrounding)
 "mrs" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/steel_grid,
+/obj/structure/table/standard,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/food/condiment/small/peppermill,
+/obj/item/reagent_containers/food/condiment/enzyme,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/humanoidcontainment)
 "mrP" = (
 /obj/structure/cable/green{
@@ -37130,12 +37124,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
-"ues" = (
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/site53/ulcz/humanoidcontainment)
 "ugr" = (
 /obj/machinery/light,
 /obj/machinery/disposal/deliveryChute{
@@ -39704,10 +39692,6 @@
 /area/site53/lhcz/hczguardgear)
 "wZG" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/beakers,
-/obj/item/reagent_containers/food/condiment/small/peppermill,
-/obj/item/reagent_containers/food/condiment/enzyme,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -85300,10 +85284,10 @@ urC
 azA
 urC
 juH
-iyl
+wUY
 eLf
 lOO
-ues
+iyl
 kEI
 kkD
 hyr
@@ -86081,7 +86065,7 @@ eWp
 qyR
 pCp
 ndr
-urC
+koI
 lfb
 fIB
 epk
@@ -86338,10 +86322,10 @@ nsU
 nsU
 nsU
 nsU
-urC
-cNb
 nsU
-mrs
+nsU
+nsU
+cNb
 urC
 nsU
 nsU
@@ -86592,14 +86576,14 @@ hMF
 gHs
 vNN
 nsU
-mrs
-nsU
-nsU
-tII
 nsU
 nsU
 nsU
-tII
+nsU
+nsU
+nsU
+nsU
+urC
 nsU
 nsU
 urC
@@ -86849,14 +86833,14 @@ hMF
 gHs
 inT
 nsU
-koI
 nsU
 nsU
-urC
-xCn
 nsU
-jaf
-urC
+nsU
+nsU
+nsU
+nsU
+tII
 nsU
 nsU
 urC
@@ -87109,13 +87093,13 @@ nsU
 nsU
 nsU
 nsU
-urC
-urC
-tII
-urC
+nsU
+sxX
+nsU
+sxX
 urC
 nsU
-nsU
+sxX
 urC
 azA
 azA
@@ -87367,12 +87351,12 @@ hiu
 pCp
 xCn
 urC
-sxX
-nsU
-sxX
+urC
 tII
-nsU
-sxX
+urC
+urC
+urC
+urC
 urC
 azA
 azA
@@ -87624,12 +87608,12 @@ jee
 jee
 jee
 urC
-urC
-tII
-urC
-urC
-urC
-urC
+nsU
+nsU
+nsU
+nsU
+nsU
+nsU
 urC
 azA
 azA
@@ -88648,7 +88632,7 @@ iRf
 kEI
 qEa
 uhy
-qvG
+mrs
 uhy
 hNz
 lRm

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -1363,13 +1363,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod)
-"aeE" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Sergeant Equipment";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aeF" = (
 /obj/structure/sign/radiation,
 /obj/effect/paint_stripe/yellow,
@@ -3739,18 +3732,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
-"all" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "alm" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -10008,10 +9989,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
-"aAI" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor,
-/area/space)
 "aAJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10414,14 +10391,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
-"aBG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aBH" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -15871,15 +15840,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
-"aTA" = (
-/obj/effect/landmark/start{
-	name = "LCZ Zone Commander"
-	},
-/obj/structure/bed/chair/office/comfy{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aTB" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
@@ -15942,15 +15902,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aTM" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aTN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -15974,11 +15925,6 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/lowertrams/hczmaint/east)
-"aTZ" = (
-/obj/structure/filingcabinet,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aUa" = (
 /obj/structure/table/rack,
 /obj/item/melee/baton/loaded,
@@ -16066,10 +16012,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aUp" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aUt" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/monotile,
@@ -16149,26 +16091,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aUI" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
-"aUK" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aUL" = (
 /obj/effect/floor_decal/corner/black/full,
 /obj/structure/bed/chair/padded/black,
@@ -16187,25 +16109,6 @@
 /obj/item/device/toner,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"aUP" = (
-/obj/structure/closet/secure_closet/guard/zone_commander{
-	req_access = list("ACCESS_SCIENCE_LEVEL2")
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 5
-	},
-/obj/item/gun/projectile/automatic/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/box/rubbershot,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aUQ" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/adv,
@@ -16257,12 +16160,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
 /area/site53/ulcz/scp999)
-"aVa" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVb" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -16301,16 +16198,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/uhcz/securitypost)
-"aVk" = (
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aVl" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/suit/bio_suit/general,
@@ -16327,10 +16214,6 @@
 /obj/item/clothing/shoes/white,
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
-"aVm" = (
-/obj/structure/table/glass,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVn" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -16356,14 +16239,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aVq" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "aVr" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -16401,12 +16276,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
-"aVx" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVy" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -16450,9 +16319,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/ulcz/scp216)
-"aVG" = (
-/turf/simulated/open,
-/area/space)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -16464,12 +16330,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aVJ" = (
-/obj/effect/landmark/start{
-	name = "LCZ Guard"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "aVK" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -19967,12 +19827,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"bhl" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "bhm" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/scp/saiga12/stunshell,
@@ -20904,12 +20758,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
-"bku" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "bkw" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
@@ -21608,7 +21456,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "bWT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21638,7 +21486,7 @@
 	RCon_tag = "Self-Destruct Substation"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "bXO" = (
 /obj/effect/floor_decal/spline/plain/blue{
 	dir = 1
@@ -21855,10 +21703,6 @@
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
-"cnC" = (
-/obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "cnW" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
@@ -22061,12 +21905,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"czh" = (
-/obj/structure/table/reinforced,
-/obj/random/clipboard,
-/obj/effect/floor_decal/carpet/blue2,
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "czj" = (
 /obj/machinery/light{
 	dir = 1
@@ -22236,10 +22074,6 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
 /area/site53/engineering/primaryhallway)
-"cJA" = (
-/obj/machinery/light,
-/turf/simulated/open,
-/area/space)
 "cKH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22343,12 +22177,6 @@
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/engineering/primaryhallway)
-"cPW" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "cQv" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
@@ -22413,17 +22241,6 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
-"cTo" = (
-/obj/structure/table/reinforced,
-/obj/item/material/ashtray/plastic,
-/obj/item/trash/cigbutt{
-	pixel_y = 7
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "cTw" = (
 /obj/structure/bed/chair/padded/black{
 	dir = 4
@@ -23947,13 +23764,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp096)
-"eOL" = (
-/obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "eOZ" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
@@ -24073,11 +23883,6 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
-"eXr" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/mre/menu2,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "eXV" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 5
@@ -24428,12 +24233,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/uhcz/scp106containment)
-"frW" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fsz" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/wood/mahogany,
@@ -24549,12 +24348,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
-"fwg" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fwm" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -24571,12 +24364,6 @@
 /obj/item/inflatable/door,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
-"fwG" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fwQ" = (
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
@@ -24678,15 +24465,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"fEA" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fEN" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/camera/network/entrance{
@@ -24768,14 +24546,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
-"fLg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "fLT" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -25428,10 +25198,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"guy" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "gvB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25646,14 +25412,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
-"gLf" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "gLL" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/item/storage/box/bodybags,
@@ -25781,14 +25539,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
-"gRM" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "gSw" = (
 /obj/structure/table/standard,
 /obj/item/device/camera,
@@ -26609,9 +26359,6 @@
 	name = "LCZ Security Section";
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/blast/shutters{
 	begins_closed = 0;
 	id_tag = "LCZ Security Office Access Lock";
@@ -27155,14 +26902,6 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
-"idT" = (
-/obj/structure/table/glass,
-/obj/item/device/flashlight/lamp,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "iea" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27506,14 +27245,6 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
-"ixT" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "iyl" = (
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
@@ -27925,14 +27656,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
-"iTu" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 10
-	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "iUu" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -28057,10 +27780,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
-"jaN" = (
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
-/area/space)
 "jbo" = (
 /obj/machinery/camera/network/lcz,
 /obj/structure/closet{
@@ -28428,15 +28147,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
-"jyg" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/obj/machinery/light,
-/turf/simulated/open,
-/area/space)
 "jzT" = (
 /obj/effect/paint_stripe/red,
 /obj/structure/sign/monkey_painting,
@@ -28452,13 +28162,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
-"jAP" = (
-/obj/machinery/vending/fitness,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "jBd" = (
 /obj/effect/floor_decal/chapel,
 /obj/machinery/firealarm{
@@ -28827,12 +28530,6 @@
 /obj/item/device/camera_film,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
-"jWg" = (
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "jWC" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -29470,15 +29167,6 @@
 /obj/machinery/light/small/red,
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
-"kIm" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "LCZ Zone Commander's Office";
-	send_access = list(204)
-	},
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "kIy" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/light{
@@ -29520,7 +29208,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "kKf" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/corner/red/mono,
@@ -29577,16 +29265,6 @@
 /obj/item/device/assembly/prox_sensor,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
-"kPt" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "kPM" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -29636,17 +29314,6 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
-"kSF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "kUj" = (
 /obj/machinery/camera/network/hcz{
 	dir = 1
@@ -29711,7 +29378,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "kWi" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -29721,25 +29388,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
-"laq" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
-"laH" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "laQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31548,9 +31196,6 @@
 	name = "LCZ Security Section";
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/blast/shutters{
 	id_tag = "LCZ Security Office Access Lock";
 	name = "LCZ Security Office Access Lock"
@@ -31715,17 +31360,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
-"ncb" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "ndi" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -32227,15 +31861,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
-"nHd" = (
-/obj/machinery/power/apc/hyper{
-	dir = 1
-	},
-/obj/machinery/vending/security{
-	req_access = list()
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
 "nHk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -32294,22 +31919,6 @@
 	temperature = 80
 	},
 /area/site53/upper_surface/serverfarminterior)
-"nJn" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nJN" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/camera/network/hcz,
@@ -32369,12 +31978,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"nLV" = (
-/obj/effect/floor_decal/corner/blue/bordercee{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nMl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -32437,18 +32040,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
-"nQf" = (
-/obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nQM" = (
 /obj/machinery/cooker/fryer,
 /obj/machinery/camera/autoname{
@@ -32571,9 +32162,6 @@
 /obj/item/storage/mre/random,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"nVn" = (
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "nVI" = (
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
@@ -33373,7 +32961,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "oSR" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
@@ -34138,12 +33726,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"pTX" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "pUs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -34214,10 +33796,6 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uhcz/scp247containment)
-"qaD" = (
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "qaJ" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -34460,15 +34038,6 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/brownline)
-"qnx" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "qnO" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -35568,19 +35137,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
-"rFf" = (
-/obj/structure/table/standard,
-/obj/item/pen,
-/obj/item/paper_bin,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/space)
 "rFI" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donut,
@@ -35857,10 +35413,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
-"rZm" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "rZL" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -36150,11 +35702,6 @@
 /obj/effect/paint_stripe/mauve,
 /turf/simulated/wall/prepainted,
 /area/site53/reswing/xenobiology)
-"sng" = (
-/obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "snm" = (
 /obj/machinery/door/airlock/security{
 	name = "UHCZ Checkpoint";
@@ -37076,19 +36623,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
-"twA" = (
-/obj/machinery/power/apc/hyper{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "twH" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Evacuation Bunker"
@@ -38766,7 +38300,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/entrance_checkpoint)
+/area/site53/llcz/checkequip)
 "vxr" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -39189,13 +38723,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
-"vWB" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "vWZ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
@@ -39627,14 +39154,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
-"wwj" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "wwJ" = (
 /obj/machinery/camera/autoname{
 	name = "SCP-247 Observation"
@@ -40044,13 +39563,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
-"wSd" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "wSy" = (
 /obj/machinery/light{
 	dir = 4
@@ -40460,14 +39972,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"xnC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "xoe" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -40585,12 +40089,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
-"xsq" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/item/modular_computer/laptop/preset/records,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "xst" = (
 /obj/machinery/camera/network/entrance,
 /obj/machinery/cooker/candy,
@@ -40943,12 +40441,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"xSo" = (
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "xSs" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a57,
@@ -57113,14 +56605,14 @@ azA
 azA
 azA
 azA
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57370,14 +56862,14 @@ azA
 azA
 azA
 azA
-jaN
-eXr
-ncb
-nVn
-nVn
-laH
-nJn
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57627,14 +57119,14 @@ azA
 azA
 azA
 azA
-jaN
-cTo
-frW
-nVn
-nVn
-nVn
-guy
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -57884,14 +57376,14 @@ aMC
 azA
 azA
 azA
-jaN
-aTM
-nVn
-aUp
-nVn
-aVJ
-cnC
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58141,14 +57633,14 @@ aMC
 aMC
 azA
 azA
-jaN
-jAP
-nVn
-nVn
-nVn
-aVJ
-sng
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58398,14 +57890,14 @@ maZ
 aMC
 azA
 azA
-jaN
-rZm
-nVn
-nVn
-nVn
-nVn
-nVn
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58655,20 +58147,20 @@ iQI
 aMC
 azA
 azA
-jaN
-aAI
-aAI
-aeE
-aeE
-aAI
-aAI
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -58912,20 +58404,20 @@ hbm
 aMC
 azA
 azA
-jaN
-aVG
-aVG
-fwg
-qaD
-aVG
-aVG
-jyg
-jaN
-cPW
-bku
-twA
-iTu
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59169,20 +58661,20 @@ xSs
 aMC
 azA
 azA
-wwj
-aUI
-aUI
-nVn
-nVn
-aUI
-aUI
-aUI
-eOL
-xSo
-nVn
-xnC
-gLf
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59426,20 +58918,20 @@ tPi
 aMC
 azA
 azA
-aBG
-aBG
-all
-all
-all
-all
-all
-all
-nQf
-kSF
-aBG
-fLg
-kIm
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59683,20 +59175,20 @@ qSc
 qSc
 azA
 azA
-aAI
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-cJA
-jaN
-qnx
-bhl
-nVn
-aTZ
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -59940,20 +59432,20 @@ azA
 azA
 azA
 azA
-nVn
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-idT
-aVm
-aUp
-aVa
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60197,20 +59689,20 @@ azA
 azA
 azA
 azA
-nVn
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-fEA
-fwG
-nVn
-xsq
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60435,7 +59927,7 @@ neg
 bKj
 bKj
 aUt
-nHd
+aNH
 wVj
 aMS
 spT
@@ -60454,20 +59946,20 @@ azA
 azA
 azA
 azA
-nVn
-aAI
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-laq
-nVn
-nVn
-ixT
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60711,20 +60203,20 @@ azA
 azA
 azA
 azA
-jaN
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-pTX
-aVx
-aVx
-wSd
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -60968,20 +60460,20 @@ azA
 azA
 azA
 azA
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-aUK
-aVq
-rFf
-gRM
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -61225,20 +60717,20 @@ azA
 azA
 azA
 azA
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aAI
-jWg
-aTA
-czh
-vWB
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -61482,20 +60974,20 @@ azA
 azA
 azA
 azA
-jaN
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-aVG
-jaN
-aUP
-kPt
-aVk
-nLV
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -61739,20 +61231,20 @@ azA
 azA
 azA
 azA
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
-jaN
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -62229,7 +61721,7 @@ aVb
 cqF
 azA
 azA
-cqF
+aVD
 bXK
 kKc
 oSH
@@ -62486,7 +61978,7 @@ aVb
 cqF
 azA
 azA
-cqF
+aVD
 bWR
 vxq
 kVZ
@@ -62743,10 +62235,10 @@ aVb
 cqF
 azA
 azA
-cqF
-cqF
-cqF
-cqF
+aVD
+aVD
+aVD
+aVD
 aVD
 mBo
 aMS

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -11721,11 +11721,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aFf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
 "aFg" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
@@ -16298,13 +16293,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"aVB" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/research{
-	name = "Hallway"
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
 "aVD" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
@@ -21767,13 +21755,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
-"cqT" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
 "crR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -43963,13 +43944,13 @@ aGM
 aGt
 aGq
 aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
+aGM
+aGM
+aXf
+aGM
+aGM
+aXf
+aGM
 aVS
 azA
 azA
@@ -44222,10 +44203,10 @@ aGM
 aVS
 aGM
 aGM
-aXf
 aGM
 aGM
-aXf
+aGM
+aGM
 aGM
 aVS
 azA
@@ -44730,7 +44711,7 @@ azA
 aVS
 aGM
 aGM
-aKq
+aGM
 aHM
 aGM
 aVS
@@ -44987,7 +44968,7 @@ azA
 aVS
 aMz
 aGr
-aFf
+aGr
 aGu
 aEt
 aVS
@@ -45244,7 +45225,7 @@ azA
 aVS
 aVS
 aVS
-aVB
+aVS
 aVS
 aVS
 aVS
@@ -45499,11 +45480,11 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-aKq
-aGM
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -45756,11 +45737,11 @@ azA
 azA
 azA
 azA
-aVS
-apj
-aKq
-aGM
-aVS
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -46010,12 +45991,12 @@ azA
 azA
 azA
 azA
-aVS
-aVS
-aVS
-aVS
-aGM
-aKq
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aVS
 aVS
@@ -46267,12 +46248,12 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-aXf
-aGM
-aGM
-aKq
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 xZp
@@ -46524,12 +46505,12 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-aKq
-aKq
-aKq
-aKq
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 aGM
@@ -46781,12 +46762,12 @@ azA
 azA
 azA
 azA
-aVS
-aGM
-cqT
-aGM
-aGM
-cqT
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 aIo
@@ -47038,12 +47019,12 @@ azA
 azA
 azA
 azA
-aVS
-aVS
-aVS
-aVS
-aVS
-aVS
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aGM
 aIo

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -1364,9 +1364,12 @@
 /turf/simulated/floor/plating,
 /area/shuttle/escape_pod)
 "aeE" = (
-/obj/structure/hygiene/shower,
+/obj/machinery/door/airlock/glass/security{
+	name = "Sergeant Equipment";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aeF" = (
 /obj/structure/sign/radiation,
 /obj/effect/paint_stripe/yellow,
@@ -1884,7 +1887,7 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/ulcz/maintenance)
 "agn" = (
-/obj/effect/floor_decal/corner/brown/mono,
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "agp" = (
@@ -2085,7 +2088,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/lowertrams/restaurantkitchenarea)
 "agU" = (
-/obj/effect/paint_stripe/gray,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "agV" = (
@@ -2199,18 +2204,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/ulcz/hallways)
 "aho" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
@@ -3741,14 +3740,17 @@
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "all" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/random/soap,
-/obj/structure/table/rack,
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "alm" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -3921,27 +3923,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics)
 "alF" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "alG" = (
 /obj/effect/paint_stripe/green,
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth{
@@ -6462,22 +6447,15 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/engineering/primaryhallway)
 "arK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
@@ -6847,10 +6825,19 @@
 /turf/simulated/floor/plating,
 /area/site53/engineering/maintenance/maintenancetunnel)
 "asA" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/hallways)
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "asB" = (
 /obj/effect/floor_decal/industrial/outline/red,
 /obj/effect/catwalk_plated/dark,
@@ -8065,12 +8052,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
 "avx" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/bed/chair{
+	dir = 1
+	},
 /obj/machinery/light{
-	dir = 8
+	dir = 4;
+	pixel_x = 11
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "avy" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -10019,14 +10009,9 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
 "aAI" = (
-/obj/structure/table/rack,
-/obj/item/reagent_containers/spray/chemsprayer,
-/obj/item/reagent_containers/spray/chemsprayer,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor,
+/area/space)
 "aAJ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10430,22 +10415,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
 "aBG" = (
-/obj/structure/table/rack,
-/obj/machinery/light,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aBH" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -11341,13 +11317,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/engineering/engine_smes)
 "aDI" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aDK" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -11781,26 +11755,12 @@
 "aFf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aFg" = (
-/obj/machinery/power/apc/hyper{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/vending/security{
-	req_access = list()
-	},
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "aFj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12451,8 +12411,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHD" = (
 /obj/structure/disposalpipe/segment,
@@ -12507,11 +12466,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHL" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
@@ -12525,8 +12479,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -12551,11 +12504,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aHR" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -12874,14 +12822,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aIR" = (
-/obj/machinery/light{
-	dir = 8
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 5
 	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "aIT" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -13133,30 +13078,15 @@
 /turf/simulated/floor,
 /area/site53/reswing/xenobiology)
 "aKa" = (
-/obj/structure/railing/mapped,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/rack,
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/catwalk_plated/white,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "aKb" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -13203,11 +13133,6 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -13850,6 +13775,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aMI" = (
@@ -13918,9 +13848,12 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aMQ" = (
-/obj/structure/hygiene/drain,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aMS" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -14161,13 +14094,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp999)
 "aNG" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aNH" = (
 /obj/machinery/vending/security{
@@ -14225,9 +14155,13 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aNO" = (
-/obj/effect/floor_decal/corner/black/diagonal,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aNR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -15055,12 +14989,9 @@
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/hub)
 "aPV" = (
-/obj/machinery/camera/network/lcz{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/personal,
+/obj/machinery/vending/fitness,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aPX" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/simulated/floor/bluegrid/airless,
@@ -15909,13 +15840,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "aTq" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/bed/chair/office/light,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aTu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -15926,13 +15853,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aTw" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -15940,22 +15863,23 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTy" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	icon_state = "1-4"
+/obj/machinery/button/blast_door{
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aTA" = (
-/obj/machinery/light,
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
+/obj/effect/landmark/start{
+	name = "LCZ Zone Commander"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/structure/bed/chair/office/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aTB" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
@@ -15988,37 +15912,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
 "aTH" = (
-/obj/machinery/status_display,
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/llcz/checkequip)
-"aTI" = (
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/structure/bed/chair/office/light{
+	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"aTI" = (
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aTJ" = (
@@ -16037,9 +15943,14 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aTM" = (
-/obj/structure/stairs/north,
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aTN" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -16064,21 +15975,25 @@
 /turf/simulated/wall/titanium,
 /area/site53/lowertrams/hczmaint/east)
 "aTZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
+/obj/structure/filingcabinet,
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aUa" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
+/obj/structure/table/rack,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUb" = (
 /obj/effect/floor_decal/industrial/hatch/red,
@@ -16107,24 +16022,25 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/engine_smes)
 "aUg" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "LCZ Security Center";
-	send_access = list("ACCESS_SECURITY_LEVEL1")
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aUh" = (
-/obj/machinery/light{
+/obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
+"aUh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "aUi" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aUj" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint,
@@ -16136,190 +16052,184 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod)
 "aUn" = (
-/obj/machinery/vending/fitness,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/structure/cable/green{
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "aUo" = (
-/obj/machinery/vending/snack,
+/obj/structure/hygiene/shower,
+/obj/structure/hygiene/drain,
+/obj/machinery/light/small{
+	dir = 4;
+	icon_state = "bulb1"
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUp" = (
-/obj/effect/paint/silver,
-/obj/machinery/status_display,
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/llcz/checkequip)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "aUt" = (
-/obj/machinery/vending/cola,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/zonecommanderoffice)
+"aUu" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
-"aUu" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/machinery/recharger/wallcharger{
-	pixel_y = 23
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
 "aUv" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/door/blast/regular{
+	id_tag = "ULCZ Exit Point";
+	name = "ULCZ Exit Point"
 	},
-/obj/structure/window/reinforced{
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
+"aUy" = (
+/obj/structure/table/standard,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
+"aUz" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"aUA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aUy" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
-"aUz" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
-"aUA" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "aUB" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Armory";
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 6
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
+"aUF" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "ULCZ Secure Armoury";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
-"aUF" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aUI" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu2,
-/obj/item/storage/mre/menu10,
-/obj/item/storage/mre/menu10,
-/obj/item/storage/mre/menu10,
-/obj/item/storage/mre/menu9,
-/obj/item/storage/mre/menu9,
-/obj/item/storage/mre/menu9,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aUK" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
+"aUK" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 9
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aUL" = (
-/obj/effect/floor_decal/spline/plain/blue{
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed/chair/padded/black,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"aUN" = (
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"aUO" = (
+/obj/structure/closet,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/obj/item/device/toner,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"aUP" = (
+/obj/structure/closet/secure_closet/guard/zone_commander{
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
+	},
+/obj/effect/floor_decal/carpet/blue2{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
-"aUN" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
-"aUO" = (
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "ULCZ Secure Armoury";
-	name = "ULCZ Secure Armoury";
-	pixel_x = 22;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 5
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
-"aUP" = (
-/obj/machinery/button/blast_door{
-	dir = 4;
-	id_tag = "ULCZ Secure Armoury";
-	name = "ULCZ Secure Armoury";
-	pixel_x = -22;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/item/gun/projectile/automatic/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/turf/simulated/floor/carpet/blue2,
+/area/space)
+"aUQ" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
-"aUQ" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 10
-	},
-/turf/simulated/floor/wood,
 /area/site53/llcz/checkequip)
 "aUR" = (
-/obj/effect/floor_decal/spline/plain/blue,
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/obj/structure/table/reinforced,
+/obj/item/storage/box/donut,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "aUU" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -16348,19 +16258,25 @@
 /turf/simulated/floor,
 /area/site53/ulcz/scp999)
 "aVa" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aVb" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "aVf" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/random,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "aVg" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "SCP-078 Containment Chamber";
@@ -16386,9 +16302,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/uhcz/securitypost)
 "aVk" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aVl" = (
 /obj/structure/closet/l3closet,
 /obj/item/clothing/suit/bio_suit/general,
@@ -16406,12 +16328,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "aVm" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Break Room";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
+/obj/structure/table/glass,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "aVn" = (
 /obj/effect/floor_decal/chapel{
 	dir = 4
@@ -16427,23 +16346,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "aVo" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin";
+	pixel_y = 1
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aVq" = (
-/obj/structure/closet/secure_closet/guard/lcz,
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	pixel_y = -23
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "aVr" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -16462,17 +16382,9 @@
 /turf/simulated/floor,
 /area/site53/ulcz/scp2427_3)
 "aVu" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "aVw" = (
 /obj/structure/table/rack,
 /obj/item/melee/baton/loaded,
@@ -16490,49 +16402,40 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "aVx" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aVy" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "aVz" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/bed/chair{
+	dir = 1
 	},
-/obj/effect/paint_stripe/red,
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
-"aVA" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
-"aVB" = (
-/obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
+"aVA" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"aVB" = (
+/obj/effect/catwalk_plated/white,
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/area/site53/ulcz/hallways)
 "aVD" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/red,
@@ -16548,11 +16451,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/ulcz/scp216)
 "aVG" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/turf/simulated/open,
+/area/space)
 "aVI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -16565,21 +16465,11 @@
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "aVJ" = (
-/obj/structure/table/rack,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
+/obj/effect/landmark/start{
+	name = "LCZ Guard"
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "aVK" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -16642,13 +16532,13 @@
 /turf/simulated/wall/prepainted,
 /area/site53/ulcz/hallways)
 "aVW" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled,
 /area/site53/llcz/entrance_checkpoint)
 "aVY" = (
@@ -17228,8 +17118,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/securitypost)
 "aXK" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17241,6 +17129,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "aXL" = (
@@ -18984,12 +18873,10 @@
 /area/site53/ulcz/hallways)
 "bdg" = (
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "bdh" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -20068,39 +19955,24 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
 "bhh" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "ULCZ Secure Armoury";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
+/obj/machinery/photocopier{
+	pixel_y = 3
 	},
-/obj/machinery/door/blast/regular/open{
-	begins_closed = 1;
-	icon_state = "pdoor0";
-	id_tag = "ULCZ Secure Armoury";
-	name = "ULCZ Secure Armoury"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/site53/llcz/entrance_checkpoint)
 "bhi" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "LCZ Security Offices";
-	req_access = list("ACCESS_SECURITY_LEVEL1")
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "bhl" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/bed/chair/comfy/blue{
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "bhm" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/scp/saiga12/stunshell,
@@ -20139,13 +20011,18 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "bhr" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/structure/table/rack,
+/obj/machinery/light,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/gun/projectile/shotgun/pump,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/clothing/accessory/storage/bandolier,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/site53/llcz/checkequip)
 "bhu" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -20535,8 +20412,7 @@
 "biK" = (
 /obj/structure/bed/chair,
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -20756,7 +20632,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "bjw" = (
@@ -20875,10 +20751,10 @@
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/south)
 "bjT" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "bjU" = (
@@ -20986,28 +20862,33 @@
 /turf/simulated/floor/plating,
 /area/site53/llcz/entrance_checkpoint)
 "bkn" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/door/airlock/maintenance{
+	name = "Maintenance";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/site53/llcz/checkequip)
 "bko" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Zone Commander's Office";
+	send_access = list(204)
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "bkq" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
 /area/site53/llcz/scp012)
 "bkr" = (
-/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "bks" = (
 /obj/machinery/door/airlock/glass/security{
 	name = "Security Center";
@@ -21024,32 +20905,19 @@
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
 "bku" = (
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/structure/closet{
-	name = "D-Class Prep"
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "bkw" = (
-/obj/effect/catwalk_plated/white,
-/obj/machinery/door/airlock/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/machinery/vending/cola,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 11
 	},
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "bkL" = (
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/monotile,
@@ -21370,6 +21238,19 @@
 /obj/structure/cryofeed,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"bBC" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start{
+	name = "LCZ Guard"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
+"bBM" = (
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "bBQ" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
@@ -21463,14 +21344,8 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bKj" = (
-/obj/structure/bed/chair/office/light,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "bKK" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/prepainted,
@@ -21505,6 +21380,10 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/brownline)
+"bMX" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "bOD" = (
 /obj/machinery/chemical_dispenser/full,
 /turf/simulated/floor/tiled,
@@ -21537,6 +21416,30 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"bQp" = (
+/obj/structure/table/rack,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "bQJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Zone Gate Security Post";
@@ -21603,9 +21506,20 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/securitypost)
 "bTG" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
+/obj/structure/table/rack,
+/obj/machinery/light,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bTH" = (
@@ -21686,9 +21600,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
 "bWR" = (
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "bWT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21713,6 +21633,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
+"bXK" = (
+/obj/machinery/power/smes/buildable/preset/ds90/substation_full{
+	RCon_tag = "Self-Destruct Substation"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
+"bXO" = (
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "bXP" = (
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -21924,15 +21856,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp078)
 "cnC" = (
-/obj/structure/table/rack,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "cnW" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
@@ -21980,7 +21906,8 @@
 /area/site53/llcz/entrance_checkpoint)
 "cqF" = (
 /obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "cqI" = (
@@ -21997,9 +21924,12 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
 "cqT" = (
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/ulcz/hallways)
 "crR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22022,9 +21952,32 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"csn" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "csp" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/ulcz/generalpurpose)
+"cta" = (
+/obj/structure/table/rack,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "cvv" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -22108,6 +22061,12 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"czh" = (
+/obj/structure/table/reinforced,
+/obj/random/clipboard,
+/obj/effect/floor_decal/carpet/blue2,
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "czj" = (
 /obj/machinery/light{
 	dir = 1
@@ -22130,14 +22089,13 @@
 /turf/simulated/floor/reinforced,
 /area/site53/reswing/robotics)
 "cAm" = (
-/obj/structure/bed/chair/office/light{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "cBj" = (
@@ -22278,6 +22236,10 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
 /area/site53/engineering/primaryhallway)
+"cJA" = (
+/obj/machinery/light,
+/turf/simulated/open,
+/area/space)
 "cKH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22381,6 +22343,12 @@
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/engineering/primaryhallway)
+"cPW" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "cQv" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
@@ -22445,12 +22413,32 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"cTo" = (
+/obj/structure/table/reinforced,
+/obj/item/material/ashtray/plastic,
+/obj/item/trash/cigbutt{
+	pixel_y = 7
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "cTw" = (
 /obj/structure/bed/chair/padded/black{
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/securitypost)
+"cTM" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "cVc" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -22604,6 +22592,15 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"daV" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uhcz/securitypost)
 "dbV" = (
 /obj/machinery/light{
 	dir = 1
@@ -22822,6 +22819,15 @@
 /obj/item/paper/scp/keter/scp106,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"drT" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "dsm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22881,6 +22887,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
+"dvt" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "dvP" = (
 /obj/machinery/body_scanconsole{
 	dir = 1
@@ -22930,6 +22946,12 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/site53/surface/bunker)
+"dys" = (
+/obj/structure/window/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "dyu" = (
 /obj/item/modular_computer/console/preset/aislot/research,
 /turf/simulated/floor/tiled/techfloor,
@@ -23104,6 +23126,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"dKX" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "dKZ" = (
 /obj/machinery/light{
 	dir = 8;
@@ -23467,6 +23498,13 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
+"ejX" = (
+/obj/structure/bed/chair/office/light,
+/obj/effect/landmark/start{
+	name = "LCZ Guard"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "ekr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23683,6 +23721,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"exB" = (
+/obj/machinery/door/airlock/glass/research{
+	name = "Hallway"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/catwalk_plated/white,
+/turf/simulated/floor,
+/area/site53/ulcz/hallways)
 "eyn" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23895,6 +23947,13 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp096)
+"eOL" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "eOZ" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 6
@@ -24014,6 +24073,11 @@
 /obj/structure/bed/chair/comfy/black,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"eXr" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/menu2,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "eXV" = (
 /obj/effect/floor_decal/industrial/fire{
 	dir = 5
@@ -24021,6 +24085,15 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
+"eYp" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small,
+/obj/machinery/light/small{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/llcz/entrance_checkpoint)
 "eYt" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -24044,6 +24117,13 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp895)
+"fbx" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "fcc" = (
 /obj/machinery/button/blast_door{
 	id_tag = "096chamberlock";
@@ -24348,6 +24428,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/site53/uhcz/scp106containment)
+"frW" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fsz" = (
 /obj/structure/bed/chair/office/light,
 /turf/simulated/floor/wood/mahogany,
@@ -24463,6 +24549,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
+"fwg" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fwm" = (
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
@@ -24480,13 +24572,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
 "fwG" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/bed/chair/comfy/blue{
+	dir = 8
 	},
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "fwQ" = (
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
@@ -24512,7 +24602,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "fwU" = (
@@ -24539,18 +24629,23 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"fAR" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin";
+	pixel_y = 1
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "fCD" = (
-/obj/structure/table/rack,
-/obj/machinery/light,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury";
+	pixel_x = 22;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "fDv" = (
 /obj/structure/table/rack,
@@ -24583,6 +24678,15 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"fEA" = (
+/obj/structure/bed/chair/comfy/blue{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fEN" = (
 /obj/effect/catwalk_plated/white,
 /obj/machinery/camera/network/entrance{
@@ -24608,13 +24712,13 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
 "fGE" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/machinery/camera/network/entrance{
 	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "fGK" = (
@@ -24664,6 +24768,14 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"fLg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "fLT" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -25159,22 +25271,17 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "glY" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/railing/mapped,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/catwalk_plated/white,
-/obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 1
 	},
+/obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
 "gmw" = (
@@ -25244,14 +25351,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "goj" = (
-/obj/structure/bed/chair{
+/obj/effect/floor_decal/spline/plain/blue{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "goy" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 1
@@ -25324,18 +25428,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "gut" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/glass/security{
+	name = "Break Room";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
+"guy" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "gvB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25366,11 +25468,8 @@
 /turf/simulated/floor/wood,
 /area/site53/ulcz/scp2427_3)
 "gyj" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "gyC" = (
 /obj/machinery/camera/network/hcz{
@@ -25553,6 +25652,14 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"gLf" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "gLL" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/item/storage/box/bodybags,
@@ -25680,6 +25787,14 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"gRM" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "gSw" = (
 /obj/structure/table/standard,
 /obj/item/device/camera,
@@ -25820,6 +25935,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp999)
+"gZc" = (
+/obj/machinery/camera/network/lcz{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "haf" = (
 /obj/structure/crematorium{
 	dir = 1
@@ -25899,6 +26020,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"hbV" = (
+/obj/structure/table/reinforced,
+/obj/random/clipboard,
+/obj/effect/floor_decal/carpet/blue2,
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "hcC" = (
 /obj/machinery/camera/network/hcz{
 	dir = 4
@@ -25914,10 +26041,16 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "hed" = (
-/obj/machinery/door/airlock/civilian{
-	name = "Restroom";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/structure/table/rack,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "heA" = (
@@ -25942,10 +26075,11 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
 "hgr" = (
-/obj/effect/paint_stripe/gray,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/wall/titanium,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"hgX" = (
+/obj/effect/floor_decal/spline/plain/blue,
+/turf/simulated/floor/wood,
 /area/site53/llcz/entrance_checkpoint)
 "hhj" = (
 /obj/structure/cable/green{
@@ -25954,16 +26088,15 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "hhA" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin";
-	pixel_y = 1
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock";
+	pixel_x = 22;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/obj/structure/cable/green{
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "hiu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/blast_door{
@@ -26055,6 +26188,16 @@
 /area/site53/llcz/scp500{
 	requires_power = 0
 	})
+"hnt" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "hnw" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/bucket,
@@ -26241,6 +26384,31 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"hyk" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "hyr" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
@@ -26268,6 +26436,28 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"hAx" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "hAF" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
@@ -26420,6 +26610,21 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
+"hEk" = (
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/shutters{
+	begins_closed = 0;
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "hFj" = (
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/uhcz/scp247containment)
@@ -26536,6 +26741,11 @@
 	temperature = 80
 	},
 /area/site53/upper_surface/serverfarminterior)
+"hNf" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "hNx" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled/techmaint,
@@ -26710,6 +26920,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"hTX" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "hUb" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp500{
@@ -26947,6 +27161,21 @@
 /obj/structure/closet/radiation,
 /turf/simulated/floor/tiled/white,
 /area/site53/surface/bunker)
+"idT" = (
+/obj/structure/table/glass,
+/obj/item/device/flashlight/lamp,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
+"iea" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "ieh" = (
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -26996,6 +27225,25 @@
 /obj/machinery/light/spot,
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"ihR" = (
+/obj/structure/closet/secure_closet/guard/zone_commander{
+	req_access = list("ACCESS_SCIENCE_LEVEL2")
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 5
+	},
+/obj/item/gun/projectile/automatic/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "iik" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/morgue{
@@ -27057,9 +27305,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/securitypost)
 "ilH" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "imN" = (
@@ -27198,6 +27447,12 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/generalpurpose3)
+"isA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/menu2,
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "iuh" = (
 /obj/machinery/vending/snack{
 	dir = 8
@@ -27257,6 +27512,14 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"ixT" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "iyl" = (
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
@@ -27645,6 +27908,13 @@
 /obj/machinery/honey_extractor,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/ulcz/humanoidcontainment)
+"iSt" = (
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "iTk" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -27657,11 +27927,18 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"iTu" = (
+/obj/machinery/light,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 10
+	},
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "iUu" = (
 /obj/structure/bed/chair/wood{
 	dir = 8
@@ -27742,14 +28019,11 @@
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
 "iXa" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 10
 	},
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "iXE" = (
 /obj/machinery/light{
 	dir = 4
@@ -27790,28 +28064,17 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/humanoidcontainment)
 "jaN" = (
-/obj/machinery/door/airlock/civilian{
-	name = "Restroom";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/effect/paint_stripe/gray,
+/turf/simulated/wall/titanium,
+/area/space)
 "jbo" = (
-/obj/structure/closet{
-	name = "D-Class Prep"
-	},
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
 /obj/machinery/camera/network/lcz,
+/obj/structure/closet{
+	name = "Confiscated items"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "jbv" = (
@@ -28134,12 +28397,21 @@
 /turf/simulated/floor/carpet/green,
 /area/chapel)
 "jxJ" = (
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
 /obj/structure/closet{
-	name = "Confiscated items"
-	},
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	name = "D-Class Prep"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -28162,6 +28434,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
+"jyg" = (
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/obj/machinery/light,
+/turf/simulated/open,
+/area/space)
 "jzT" = (
 /obj/effect/paint_stripe/red,
 /obj/structure/sign/monkey_painting,
@@ -28177,6 +28458,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
+"jAP" = (
+/obj/machinery/vending/fitness,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "jBd" = (
 /obj/effect/floor_decal/chapel,
 /obj/machinery/firealarm{
@@ -28185,6 +28473,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"jBr" = (
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "jBO" = (
 /obj/machinery/button/blast_door{
 	id_tag = "Humanoid Containment South";
@@ -28223,15 +28517,9 @@
 /turf/simulated/floor/plating,
 /area/site53/ulcz/hallways)
 "jCD" = (
-/obj/structure/table/rack,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "jDF" = (
 /obj/item/glass_jar{
 	pixel_y = 7
@@ -28257,6 +28545,19 @@
 "jEg" = (
 /turf/simulated/floor,
 /area/site53/surface/bunker)
+"jEt" = (
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "jFe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -28404,6 +28705,13 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
+"jOb" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "jOV" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/gray,
@@ -28478,11 +28786,15 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
 "jUp" = (
-/obj/structure/hygiene/shower{
+/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/light/small/red{
+	dir = 8
+	},
+/obj/structure/hygiene/toilet{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "jUv" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/orange/border{
@@ -28521,6 +28833,12 @@
 /obj/item/device/camera_film,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"jWg" = (
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "jWC" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/effect/floor_decal/industrial/warning{
@@ -28528,6 +28846,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
+"jXr" = (
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 1
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "jYH" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -28543,6 +28868,14 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/scp106containment)
+"kag" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Security Office";
+	send_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "kao" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/paper_bin,
@@ -28767,11 +29100,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "klT" = (
-/obj/effect/floor_decal/spline/plain/blue{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/site53/llcz/checkequip)
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/zonecommanderoffice)
 "kmK" = (
 /obj/structure/table/standard,
 /obj/machinery/camera/autoname{
@@ -29040,6 +29373,16 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"kDr" = (
+/obj/structure/table/rack,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "kDy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29133,6 +29476,15 @@
 /obj/machinery/light/small/red,
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
+"kIm" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Zone Commander's Office";
+	send_access = list(204)
+	},
+/obj/effect/floor_decal/corner/blue/border,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "kIy" = (
 /obj/machinery/r_n_d/server/robotics,
 /obj/machinery/light{
@@ -29166,6 +29518,15 @@
 	},
 /turf/simulated/floor,
 /area/site53/surface/explorers/surrounding)
+"kKc" = (
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Self-Destruct Bypass"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "kKf" = (
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/corner/red/mono,
@@ -29222,6 +29583,16 @@
 /obj/item/device/assembly/prox_sensor,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"kPt" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "kPM" = (
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
@@ -29271,6 +29642,17 @@
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
+"kSF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "kUj" = (
 /obj/machinery/camera/network/hcz{
 	dir = 1
@@ -29295,6 +29677,16 @@
 	pixel_y = 9;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock";
+	pixel_x = -22;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
 "kVA" = (
@@ -29317,6 +29709,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/engineering/primaryhallway)
+"kVZ" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "kWi" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -29326,6 +29727,25 @@
 	},
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
+"laq" = (
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
+"laH" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "laQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29376,11 +29796,10 @@
 /turf/simulated/floor,
 /area/site53/uhcz/hallways)
 "lbS" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/hallways)
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "lcb" = (
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -29485,6 +29904,12 @@
 /obj/effect/catwalk_plated,
 /turf/simulated/floor,
 /area/site53/llcz/scp012)
+"lhd" = (
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "lhJ" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/effect/floor_decal/carpet/green{
@@ -30374,6 +30799,18 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"mim" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "mjg" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -30780,6 +31217,17 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/scp2427_3)
+"mBo" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "LCZ Security Center";
+	send_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/structure/table/reinforced,
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "mBw" = (
 /obj/structure/table/standard,
 /obj/machinery/door/blast/shutters{
@@ -31101,6 +31549,20 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmtunnel)
+"mUD" = (
+/obj/machinery/door/airlock/security{
+	name = "LCZ Security Section";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "LCZ Security Office Access Lock";
+	name = "LCZ Security Office Access Lock"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
 "mVc" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/mil_rifle,
@@ -31197,6 +31659,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/reswing/robotics)
+"mYl" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "mYw" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -31253,6 +31721,17 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp247observation)
+"ncb" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "ndi" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 9
@@ -31296,14 +31775,13 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp216)
 "neg" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 1;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/zonecommanderoffice)
 "nem" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -31497,6 +31975,18 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp263)
+"nsJ" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "nsM" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/grassybush,
@@ -31607,6 +32097,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/upper_surface/serverfarmcontrol)
+"nxT" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "nyh" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/paint_stripe/gray,
@@ -31736,6 +32233,15 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
+"nHd" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/machinery/vending/security{
+	req_access = list()
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "nHk" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -31795,14 +32301,21 @@
 	},
 /area/site53/upper_surface/serverfarminterior)
 "nJn" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "2-8"
-	},
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "nJN" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/camera/network/hcz,
@@ -31862,6 +32375,12 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
+"nLV" = (
+/obj/effect/floor_decal/corner/blue/bordercee{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "nMl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31924,6 +32443,18 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/ulcz/scp2427_3)
+"nQf" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "nQM" = (
 /obj/machinery/cooker/fryer,
 /obj/machinery/camera/autoname{
@@ -31957,11 +32488,11 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/ulcz/humanoidcontainment)
 "nRA" = (
-/obj/machinery/camera/network/lcz{
-	dir = 1
+/obj/effect/floor_decal/spline/plain/blue{
+	dir = 9
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/wood,
+/area/site53/llcz/entrance_checkpoint)
 "nTc" = (
 /obj/effect/floor_decal/corner/red/bordercorner,
 /turf/simulated/floor/tiled/monotile,
@@ -32003,12 +32534,52 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
-"nVn" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
+"nUz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"nUQ" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu2,
+/obj/item/storage/mre/menu10,
+/obj/item/storage/mre/menu10,
+/obj/item/storage/mre/menu10,
+/obj/item/storage/mre/menu9,
+/obj/item/storage/mre/menu9,
+/obj/item/storage/mre/menu9,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"nVn" = (
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "nVI" = (
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
@@ -32245,6 +32816,11 @@
 /area/site53/lowertrams/escape)
 "oni" = (
 /obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -32280,6 +32856,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
+"onW" = (
+/obj/machinery/vending/fitness,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "ooD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32567,6 +33147,15 @@
 	},
 /turf/simulated/open,
 /area/site53/uhcz/scp106containment)
+"oCP" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/coffee{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "oDy" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -32723,6 +33312,14 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"oNG" = (
+/obj/structure/table/reinforced,
+/obj/item/folder/blue,
+/obj/item/folder/red,
+/obj/item/folder,
+/obj/item/folder/yellow,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "oOF" = (
 /obj/machinery/microwave,
 /obj/structure/table/standard,
@@ -32777,10 +33374,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
+"oSH" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
 "oSR" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled,
 /area/site53/engineering/sleeproom)
+"oTb" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "oUj" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -33015,10 +33622,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "pid" = (
-/obj/machinery/camera/network/lcz{
-	dir = 1
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "pih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33207,6 +33816,13 @@
 /obj/machinery/photocopier/faxmachine,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"pyP" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "pze" = (
 /obj/machinery/camera/autoname{
 	c_tag = "Comms Tower Basement";
@@ -33248,6 +33864,16 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
+"pBB" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "pCp" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -33352,9 +33978,10 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
 "pFU" = (
-/obj/structure/table/standard,
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/site53/llcz/entrance_checkpoint)
 "pHf" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/crate/bin{
@@ -33442,6 +34069,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
+"pOj" = (
+/obj/effect/floor_decal/industrial/loading{
+	dir = 4;
+	name = "EXIT ONLY"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/llcz/entrance_checkpoint)
 "pOk" = (
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/machinery/camera/network/hcz{
@@ -33511,14 +34145,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
 "pTX" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 5
 	},
-/turf/simulated/floor,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "pUs" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile,
@@ -33551,11 +34182,11 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp457containment)
 "pXS" = (
-/obj/effect/floor_decal/corner/brown/mono,
 /obj/structure/railing/mapped,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled,
 /area/site53/llcz/entrance_checkpoint)
 "pXT" = (
@@ -33589,6 +34220,10 @@
 	},
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uhcz/scp247containment)
+"qaD" = (
+/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "qaJ" = (
 /obj/machinery/light,
 /obj/structure/table/reinforced,
@@ -33831,6 +34466,15 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled,
 /area/site53/lowertrams/brownline)
+"qnx" = (
+/obj/structure/bed/chair/comfy/blue{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "qnO" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -33873,8 +34517,7 @@
 /area/site53/ulcz/generalpurpose)
 "qqQ" = (
 /obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
@@ -33898,6 +34541,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/redline)
+"qst" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "qsG" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/techmaint,
@@ -33940,6 +34589,22 @@
 "qvG" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/humanoidcontainment)
+"qwF" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"qxf" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "qxk" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/monotile,
@@ -33968,6 +34633,13 @@
 	},
 /turf/simulated/floor,
 /area/site53/lowertrams/hub)
+"qzE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "qzL" = (
 /obj/structure/table/standard,
 /obj/item/auto_cpr,
@@ -34269,6 +34941,15 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor,
 /area/site53/lowertrams/hczmaint/east)
+"qWb" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "qWj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34434,7 +35115,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "rcN" = (
@@ -34655,6 +35336,15 @@
 /area/site53/llcz/scp500{
 	requires_power = 0
 	})
+"rqq" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/machinery/camera/network/lcz{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "rqI" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -34789,15 +35479,13 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/science/aicobservation)
 "rzX" = (
-/obj/structure/bed/chair{
-	dir = 1
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "rBm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -34886,6 +35574,19 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp066)
+"rFf" = (
+/obj/structure/table/standard,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 8
+	},
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 10
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/space)
 "rFI" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/donut,
@@ -35086,6 +35787,14 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/surface/bunker)
+"rVq" = (
+/obj/structure/table/reinforced,
+/obj/item/material/ashtray/plastic,
+/obj/item/trash/cigbutt{
+	pixel_y = 7
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "rVI" = (
 /obj/machinery/light{
 	dir = 4
@@ -35154,6 +35863,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"rZm" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "rZL" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -35444,9 +36157,10 @@
 /turf/simulated/wall/prepainted,
 /area/site53/reswing/xenobiology)
 "sng" = (
-/obj/structure/filingcabinet/chestdrawer,
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/area/space)
 "snm" = (
 /obj/machinery/door/airlock/security{
 	name = "UHCZ Checkpoint";
@@ -35476,12 +36190,11 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
 "spT" = (
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "sqv" = (
@@ -35818,6 +36531,10 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/bunker)
+"sNd" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "sPg" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/reagent_dispensers/water_cooler{
@@ -36007,6 +36724,13 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/humanoidcontainment)
+"sZE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "tar" = (
 /obj/structure/mopbucket,
 /obj/structure/catwalk,
@@ -36126,6 +36850,13 @@
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/ulcz/scp999)
+"tiI" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "tjj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36204,6 +36935,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/engineering/containment_engineer)
+"tmC" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "tmK" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36284,6 +37021,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"ttg" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 23
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "ttE" = (
 /obj/effect/floor_decal/corner/yellow/bordercorner{
 	dir = 4
@@ -36336,6 +37082,19 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
+"twA" = (
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "twH" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Evacuation Bunker"
@@ -36572,6 +37331,16 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/scp513)
+"tMm" = (
+/obj/effect/floor_decal/carpet/blue2,
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 4
+	},
+/obj/effect/floor_decal/carpet/blue2{
+	dir = 6
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "tMx" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -36613,6 +37382,16 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
+"tOa" = (
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "tOm" = (
 /obj/effect/floor_decal/carpet/green{
 	dir = 4
@@ -37314,12 +38093,10 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/surface/explorers/surrounding)
 "uJG" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/effect/paint_stripe/gray,
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/llcz/entrance_checkpoint)
 "uJU" = (
 /obj/machinery/light_switch{
 	pixel_x = -25
@@ -37634,7 +38411,6 @@
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
 "vea" = (
-/obj/effect/paint_stripe/gray,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -37644,6 +38420,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/paint_stripe/red,
 /turf/simulated/wall/titanium,
 /area/site53/llcz/entrance_checkpoint)
 "veT" = (
@@ -37792,6 +38569,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/lowertrams/restaurantkitchenarea)
+"vny" = (
+/obj/structure/closet/secure_closet/guard/lcz/sergeant,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "vnK" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning{
@@ -37986,6 +38767,21 @@
 /obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/xenobiology)
+"vxq" = (
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/site53/llcz/entrance_checkpoint)
+"vxr" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "vxS" = (
 /obj/structure/table/reinforced,
 /obj/item/newspaper,
@@ -38058,14 +38854,11 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/generalpurpose3)
 "vCX" = (
-/obj/effect/floor_decal/corner/black/diagonal,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "vDw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -38362,6 +39155,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
+"vTy" = (
+/obj/machinery/lapvend,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "vVj" = (
 /obj/structure/table/standard,
 /obj/item/device/radio/phone,
@@ -38398,6 +39195,13 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
+"vWB" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/corner/blue/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "vWZ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
@@ -38422,6 +39226,20 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/controlroom)
+"vXu" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
+"vXy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "vXz" = (
 /obj/machinery/door/airlock/glass/research{
 	name = "SCP-012"
@@ -38504,6 +39322,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uhcz/hallways)
+"wdh" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
 "wdB" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -38562,6 +39390,14 @@
 /obj/item/device/tape,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
+"whj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "whL" = (
 /obj/machinery/recharge_station,
 /obj/machinery/camera/network/hcz{
@@ -38631,6 +39467,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/entrance_checkpoint)
+"wkx" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/zonecommanderoffice)
+"wlv" = (
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury";
+	pixel_x = -22;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "wmf" = (
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 4
@@ -38784,12 +39634,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
 "wwj" = (
-/obj/effect/paint_stripe/gray,
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/ulcz/hallways)
+/obj/machinery/light{
+	dir = 8;
+	icon_state = "tube1";
+	pixel_x = -11
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "wwJ" = (
 /obj/machinery/camera/autoname{
 	name = "SCP-247 Observation"
@@ -39071,6 +39922,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearchera)
+"wLF" = (
+/obj/effect/landmark/start{
+	name = "LCZ Zone Commander"
+	},
+/obj/structure/bed/chair/office/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/site53/zonecommanderoffice)
 "wLQ" = (
 /obj/structure/table/standard,
 /obj/item/deck/cards,
@@ -39190,6 +40050,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp096)
+"wSd" = (
+/obj/effect/floor_decal/corner/blue/border,
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "wSy" = (
 /obj/machinery/light{
 	dir = 4
@@ -39247,9 +40114,16 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
+"wVg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "wVj" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -39272,6 +40146,12 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
+"wVD" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "wVK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -39441,6 +40321,27 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"xfK" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "ULCZ Secure Armoury";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "ULCZ Secure Armoury";
+	name = "ULCZ Secure Armoury"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/dclass/armory)
 "xfS" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/telescreen/preset/generic{
@@ -39491,6 +40392,16 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
+"xjd" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "LCZ Armoury Section";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/structure/cable/green{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "xjn" = (
 /obj/structure/table/reinforced,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -39548,6 +40459,21 @@
 "xna" = (
 /turf/simulated/mineral,
 /area/site53/uhcz/scp247containment)
+"xnq" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "LCZ Security Offices";
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
+"xnC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "xoe" = (
 /obj/structure/cable/green{
 	icon_state = "1-2"
@@ -39560,6 +40486,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/commanderoffice)
+"xpa" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "xpf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39660,18 +40592,11 @@
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/maintenance)
 "xsq" = (
-/obj/structure/table/rack,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
+/obj/effect/floor_decal/corner/blue/border,
+/obj/item/modular_computer/laptop/preset/records,
+/obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/area/space)
 "xst" = (
 /obj/machinery/camera/network/entrance,
 /obj/machinery/cooker/candy,
@@ -39851,29 +40776,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
 "xEG" = (
-/obj/structure/table/rack,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/machinery/door/airlock/security{
+	name = "Solitary Confinement";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/armory)
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/entrance_checkpoint)
+"xET" = (
+/obj/machinery/camera/network/lcz{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/llcz/entrance_checkpoint)
 "xFg" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -39916,6 +40830,10 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp247observation)
+"xIs" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/entrance_checkpoint)
 "xJI" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -40022,13 +40940,21 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
 "xRv" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "Security Center";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
+"xSo" = (
+/obj/effect/floor_decal/corner/blue/bordercorner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "xSs" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a57,
@@ -40966,30 +41892,30 @@ azA
 azA
 azA
 azA
-aMC
-aMC
-aMC
-aMC
-aMC
-aMC
 azA
 azA
 azA
-lbS
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 azA
 azA
 azA
@@ -41222,17 +42148,17 @@ azA
 azA
 azA
 azA
-aMC
-aMC
-aVM
-vgG
-vgG
-aXh
-aMC
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 uis
 aGM
 aIT
@@ -41246,7 +42172,7 @@ qTt
 aXf
 vOc
 gNK
-asA
+aVS
 azA
 azA
 azA
@@ -41479,17 +42405,17 @@ azA
 azA
 azA
 azA
-aMC
-kcw
-aVL
-aXh
-aXh
-aXh
-maZ
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aMx
 aGM
 bhp
@@ -41503,7 +42429,7 @@ hqI
 aGM
 xXL
 dgI
-asA
+aVS
 azA
 azA
 azA
@@ -41736,17 +42662,17 @@ azA
 azA
 azA
 azA
-aMC
-nZl
-aVL
-bde
-icU
-aXh
-iQI
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 ahO
 aGM
 urN
@@ -41760,7 +42686,7 @@ uUQ
 aGM
 cmp
 gqe
-asA
+aVS
 azA
 azA
 azA
@@ -41993,17 +42919,17 @@ azA
 azA
 azA
 azA
-aMC
-eiL
-aVL
-wsM
-bhm
-aXh
-hbm
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 woc
 aGM
 aGM
@@ -42017,7 +42943,7 @@ aGM
 aGM
 aGM
 vtX
-asA
+aVS
 azA
 azA
 azA
@@ -42250,17 +43176,17 @@ azA
 azA
 azA
 azA
-aMC
-aEv
-aUN
-bdg
-aXh
-aXh
-xSs
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 orI
 aGM
 aGM
@@ -42274,7 +43200,7 @@ aGM
 aGM
 aGM
 pVt
-asA
+aVS
 azA
 azA
 azA
@@ -42507,17 +43433,17 @@ azA
 azA
 azA
 azA
-aMC
-aXh
-aUO
-aVL
-aXh
-aXh
-tPi
-aMC
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 mCP
 aGM
 aME
@@ -42531,7 +43457,7 @@ nMl
 aGM
 fDz
 mSx
-asA
+aVS
 azA
 azA
 azA
@@ -42764,17 +43690,17 @@ azA
 azA
 azA
 azA
-qSc
-aMC
-aMC
-bhh
-aMC
-aMC
-qSc
-qSc
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 gMl
 aGM
 aME
@@ -42788,7 +43714,7 @@ hqI
 aGM
 xXL
 dgI
-asA
+aVS
 azA
 azA
 azA
@@ -43021,17 +43947,17 @@ azA
 azA
 azA
 azA
-aMC
-aUu
-aUP
-aVx
-aVJ
-aMC
 azA
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aME
 aGM
 aME
@@ -43045,7 +43971,7 @@ vOc
 pSE
 qTt
 tqR
-asA
+aVS
 azA
 azA
 azA
@@ -43278,31 +44204,31 @@ azA
 azA
 azA
 azA
-aMC
-alF
-aVa
-aVx
-aBG
-aMC
 azA
 azA
 azA
-asA
-lbS
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
 bhi
-asA
-asA
-wwj
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-asA
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 azA
 azA
 azA
@@ -43535,30 +44461,30 @@ azA
 azA
 azA
 azA
-aMC
-aAI
-aVa
-aVx
-cnC
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 apj
 aGM
 aGM
 aGt
 aGq
-lbS
-asA
-asA
-asA
-asA
-asA
-asA
-asA
-lbS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 azA
 azA
 azA
@@ -43786,28 +44712,28 @@ azA
 azA
 azA
 azA
-aVD
-aTJ
-aTJ
-aVD
-aTJ
-aTJ
-aMC
-aVa
-aVa
-aVx
-jCD
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aGM
-aKq
-aKq
+aGM
+aGM
 aHC
 aGM
-asA
+aVS
 aGM
 aGM
 aXf
@@ -43815,7 +44741,7 @@ aGM
 aGM
 aXf
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -44043,36 +44969,36 @@ azA
 azA
 azA
 azA
-aTJ
-aeE
-aMS
-aTJ
-aMS
-jUp
-aMC
-aUy
-aVf
-bhr
-fCD
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 bgE
+aGM
 aKq
-bhl
 aHL
-aMe
+aMK
 aho
-aMe
-aMe
-aMe
-aMe
-aMe
+aMK
+aMK
+aMK
+aMK
+aMK
 aHR
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -44300,36 +45226,36 @@ azA
 azA
 azA
 azA
-aTJ
-all
-aMQ
-aTJ
-aMQ
-all
-aMC
-aVx
-xsq
-xsq
-xEG
-aMC
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aGM
 aGM
 aKq
-aFe
 aHM
 aGM
-asA
+aVS
 aGM
 aGM
 aGM
 aGM
 aGM
-aLv
+aUA
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -44557,36 +45483,36 @@ azA
 azA
 azA
 azA
-aTJ
-aTJ
-aNb
-aTJ
-aNb
-aTJ
-aTJ
-aUB
-aTJ
-aTJ
-aTJ
-aVD
-aTJ
-aTJ
 azA
-lbS
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aMz
 aGr
 aFf
 aGu
 aEt
-lbS
-asA
-asA
-asA
-lbS
+aVS
+aVS
+aVS
+aVS
+aVS
 apj
-aLv
+aUA
 aEt
-asA
+aVS
 azA
 azA
 azA
@@ -44814,36 +45740,36 @@ azA
 azA
 azA
 azA
-aTJ
-aMS
-aMS
-aMS
-aMS
-aTJ
-aNH
-aTq
-dJG
-sng
-wVj
-aVA
-nVn
-aTJ
 azA
-asA
-aVD
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
 aVB
-aTJ
-aTJ
-asA
+aVS
+aVS
+aVS
 azA
 azA
 azA
-asA
+aVS
 aGM
-aLv
+aUA
 aGM
-asA
+aVS
 azA
 azA
 azA
@@ -45071,36 +45997,36 @@ azA
 azA
 azA
 azA
-aTJ
-aMS
-aMS
-aMS
-aNs
-aTJ
-aFg
-aUF
-gut
-cAm
-aTv
-bKj
-aVo
-aTJ
-azA
-azA
-aTJ
-aMS
-pTX
-aMS
-aTJ
 azA
 azA
 azA
 azA
-asA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aGM
-aLv
+aKq
 aGM
-asA
+aVS
+azA
+azA
+azA
+azA
+aVS
+aGM
+aUA
+aGM
+aVS
 azA
 azA
 azA
@@ -45328,36 +46254,36 @@ azA
 azA
 azA
 azA
-aTJ
-amA
-aMS
-aMS
-aDI
-aTJ
-aTI
-aTq
-aUv
-fwG
-aMS
-uJG
-aVu
-aTJ
 azA
 azA
-aTJ
-lbi
-pTX
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
 aVS
-lbS
-asA
+apj
+aKq
+aGM
+aVS
+azA
+azA
+azA
+aVS
+aVS
+aVS
 arK
-asA
-lbS
+aVS
+aVS
 aVS
 azA
 azA
@@ -45585,34 +46511,34 @@ azA
 azA
 azA
 azA
-aTJ
-amA
-aMS
-aVD
-aTJ
-aTJ
-aTZ
-xRv
-ilH
-aMS
-aMS
-aMS
-aTq
-aVD
-aTJ
-aTJ
-aVD
-aMS
-pTX
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
 aVS
+aVS
+aVS
+aVS
+aGM
+aKq
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
 aff
 aff
-aKa
+glY
 aff
 aff
 aVS
@@ -45842,34 +46768,34 @@ azA
 azA
 azA
 azA
-aTJ
-amA
-aMS
-aTJ
-aTM
-aMS
-aMS
-aMS
-aTq
-aMS
-aMS
-aMS
-aTq
-aTJ
-aMS
-wVj
-aMS
-aMS
-pTX
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
+aGM
+aXf
+aGM
+aGM
+aKq
 aVS
-aVS
+aGM
+xZp
+aXf
+aGM
 aVS
 agK
 afG
-aLv
+aUA
 afR
 agL
 aVS
@@ -46099,29 +47025,29 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNs
-aTJ
-aTM
-aMS
-aMS
-aMS
-neg
-aMS
-aMS
-aMS
-aVy
-aVz
-iXa
-iXa
-iXa
-iXa
-aNG
-nRA
-aTJ
-xZp
-aIR
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aGM
+aKq
+aKq
+aKq
+aKq
+aVS
+aGM
+aGM
+aJt
 aJt
 aJC
 afF
@@ -46356,34 +47282,34 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aMS
-aTJ
-aTM
-aMS
-aMS
-aMS
-aTq
-aMS
-aMS
-aMS
-aVr
-aTJ
-aMS
-bko
-aMS
-aMS
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aGM
 cqT
-bko
-aTJ
+aGM
+aGM
+cqT
+aVS
+aGM
 aIo
 aGM
 aGM
 aVS
 uoR
 afI
-aLv
+aUA
 afS
 agL
 aVS
@@ -46613,27 +47539,27 @@ azA
 azA
 azA
 azA
-aTJ
-aTJ
-aNb
-aTJ
-aTJ
-aTJ
-aTL
-aMS
-aTq
-aMS
-aMS
-aMS
-akH
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-bkw
-aTJ
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aVS
+aGM
 aIo
 aGM
 aGM
@@ -46870,34 +47796,34 @@ azA
 azA
 azA
 azA
-aTJ
-avx
-aMS
-hhA
-spT
-aVD
-aTP
-aMS
-aTq
-jnd
-gci
-jnd
-aVq
-aTJ
-bWR
-aMS
-bkr
-bku
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
+aGM
 aGM
 aGM
 aGM
 aVS
 aVS
 sYT
-aMW
+exB
 aVS
 aVS
 aVS
@@ -47127,34 +48053,34 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNO
-nJn
-aTy
-aTJ
-aUg
-aMS
-aTq
-jnd
-gci
-jnd
-aVq
-aTJ
-bWR
-aMS
-bkr
-pFU
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
-aVS
-aVS
-aVS
+aGM
+aGM
+aGM
+aGM
 aVS
 aVS
 aIQ
-aLv
+aUA
 aXf
 aVS
 azA
@@ -47384,26 +48310,26 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNO
-aNO
-vCX
-hed
-aMS
-aMS
-aTq
-jnd
-gci
-jnd
-aVq
-aTJ
-bWR
-aMS
-bkr
-aMS
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+aVS
 aVS
 aVS
 aVS
@@ -47411,7 +48337,7 @@ aVS
 aVS
 aVS
 aJE
-aNd
+aUh
 aGM
 aVS
 azA
@@ -47641,26 +48567,26 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aNO
-aNO
-nJn
-jaN
-dMS
-dMS
-oni
-xxz
-gci
-wVp
-aVq
-aTJ
-bkn
-aMS
-bks
-aMS
-bko
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aHO
 aIt
@@ -47668,7 +48594,7 @@ aHq
 aGM
 aGM
 aGM
-aLv
+aUA
 aGM
 aVS
 azA
@@ -47898,26 +48824,26 @@ azA
 azA
 azA
 azA
-aTJ
-aoN
-aPV
-aMS
-aNs
-aTJ
-aTJ
-aUp
-aVm
-aTJ
-aTJ
-aTJ
-aVD
-aVD
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aVD
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 aVS
 aIj
 aIu
@@ -48155,19 +49081,19 @@ azA
 azA
 azA
 azA
-aVD
-aTJ
-aTJ
-aTE
-aTE
-aTJ
-aUh
-aMS
-aMS
-aUI
-aMS
-goj
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -48412,19 +49338,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMu
-aMS
-aMS
-aMS
-aTJ
-aUi
-aMS
-aUz
-aUa
-aUQ
-aVk
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -48669,19 +49595,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aMS
-aMS
-aTA
-aTH
-aUn
-aMS
-aUA
-aUK
-aUR
-bTG
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -48926,19 +49852,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aNs
-aTJ
-aTJ
-aTJ
-aUo
-aMS
-aVG
-aUL
-klT
-aMS
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -49183,19 +50109,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aMS
-aTE
-aTB
-aTJ
-aUt
-aMS
-aMS
-bWR
-aVk
-rzX
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 aVS
@@ -49440,19 +50366,19 @@ azA
 azA
 azA
 azA
-aTJ
-aMv
-aMS
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aTJ
-aVD
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
 bgX
 bgX
 aVS
@@ -49697,12 +50623,12 @@ azA
 azA
 azA
 azA
-aTJ
-aMu
-aMS
-aTE
-aTB
-aTJ
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -49954,12 +50880,12 @@ azA
 azA
 azA
 azA
-aVD
-aTJ
-aTJ
-aTJ
-aTJ
-aVD
+azA
+azA
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -55653,21 +56579,21 @@ aJj
 dpg
 mMC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
+uJG
 azA
 azA
 azA
@@ -55910,21 +56836,21 @@ rdt
 dpg
 mMC
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+uJG
+vTy
+hgr
+jOb
+cTM
+aVu
+bkr
+pFU
+pyP
+cTM
+aVu
+bkr
+pFU
+aDI
+uJG
 azA
 azA
 azA
@@ -56167,6 +57093,21 @@ mMC
 mMC
 mMC
 azA
+uJG
+oCP
+hgr
+hTX
+aNO
+aTH
+hgr
+aTq
+dys
+aNO
+aTH
+hgr
+aTq
+wVD
+uJG
 azA
 azA
 azA
@@ -56178,29 +57119,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
 azA
 azA
 azA
@@ -56424,6 +57350,21 @@ azA
 azA
 azA
 azA
+uJG
+bhh
+hgr
+kag
+pBB
+qxf
+hgr
+wVg
+pid
+pBB
+qxf
+hgr
+wVg
+qzE
+uJG
 azA
 azA
 azA
@@ -56435,29 +57376,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+eXr
+ncb
+nVn
+nVn
+laH
+nJn
+jaN
 azA
 azA
 azA
@@ -56668,6 +57594,34 @@ aGM
 aVS
 azA
 azA
+cqF
+cqF
+cqF
+cqF
+cqF
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+uJG
+aUR
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+hgr
+oNG
+uJG
 azA
 azA
 azA
@@ -56679,42 +57633,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+cTo
+frW
+nVn
+nVn
+nVn
+guy
+jaN
 azA
 azA
 azA
@@ -56925,53 +57851,53 @@ aEt
 aVS
 azA
 azA
+cqF
+vxr
+mYl
+vxr
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+uJG
+hNf
+hgr
+hgr
+hgr
+hgr
+hgr
+sNd
+hgr
+hgr
+hgr
+hgr
+hgr
+iSt
+uJG
+azA
+azA
+aMC
+aMC
+aMC
+aMC
+aMC
+aMC
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aTM
+nVn
+aUp
+nVn
+aVJ
+cnC
+jaN
 azA
 azA
 azA
@@ -57182,53 +58108,53 @@ aGM
 aVS
 azA
 azA
+cqF
+aVb
+aVb
+aVb
+cqF
+aUz
+jUp
+cqF
+aUz
+jUp
+cqF
+aUz
+jUp
+uJG
+aUO
+hgr
+gyj
+nsJ
+nxT
+hgr
+qwF
+dvt
+mim
+nxT
+hgr
+qwF
+vXy
+uJG
+azA
+aMC
+aMC
+aVM
+vgG
+vgG
+aXh
+aMC
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jAP
+nVn
+nVn
+nVn
+aVJ
+sng
+jaN
 azA
 azA
 azA
@@ -57439,53 +58365,53 @@ aGM
 aVS
 azA
 azA
+cqF
+aVb
+aVb
+aVb
+cqF
+aUL
+aVf
+cqF
+aUL
+aVf
+cqF
+aUL
+aVf
+uJG
+tiI
+hgr
+gyj
+aNO
+aTH
+hgr
+aTq
+dys
+aNO
+aTH
+hgr
+aTq
+wVD
+uJG
+azA
+aMC
+kcw
+aVL
+aXh
+aXh
+aXh
+maZ
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+rZm
+nVn
+nVn
+nVn
+nVn
+nVn
+jaN
 azA
 azA
 azA
@@ -57695,60 +58621,60 @@ aLv
 aGM
 aVS
 azA
+cqF
+cqF
+xTl
+cqc
+xTl
+cqF
+aUN
+alF
+cqF
+aUN
+alF
+cqF
+aUN
+alF
+uJG
+gyj
+hgr
+gyj
+iea
+pFU
+xpa
+aVu
+lbS
+iea
+pFU
+xpa
+aVu
+aTv
+uJG
+azA
+aMC
+nZl
+aVL
+bde
+icU
+aXh
+iQI
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aAI
+aAI
+aeE
+aeE
+aAI
+aAI
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
 azA
 azA
 azA
@@ -57952,60 +58878,60 @@ jVk
 aGM
 aVS
 azA
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
-agU
+cqF
+aEE
+biQ
+aVb
+biQ
+cqF
+xEG
+xTl
+cqF
+xEG
+xTl
+cqF
+xEG
+xTl
+cqF
+xTl
+xnq
+xTl
+xTl
+xTl
+uJG
+xTl
+xTl
+xTl
+xTl
+uJG
+xTl
+xTl
+uJG
+azA
+aMC
+eiL
+aVL
+wsM
+bhm
+aXh
+hbm
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+fwg
+qaD
+aVG
+aVG
+jyg
+jaN
+cPW
+bku
+twA
+iTu
+jaN
 azA
 azA
 azA
@@ -58209,60 +59135,60 @@ jVk
 pSE
 aVS
 azA
-agU
+cqF
 jbo
 aVb
 aVb
-aEE
-biQ
-xTl
 aVb
-wkv
-agU
+bVr
+aVb
+aVb
+bVr
+aVb
+aVb
+bVr
+aVb
+aVb
+cqF
+aVb
+aVb
+aVb
+aVb
+aVb
+bVr
+aVb
+aVb
+aVb
+aVb
+bVr
+aVb
+aEA
+cqF
+azA
+aMC
+aEv
+aVL
+aXh
+aXh
+aXh
+xSs
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+wwj
+aUI
+aUI
+nVn
+nVn
+aUI
+aUI
+aUI
+eOL
+xSo
+nVn
+xnC
+gLf
+jaN
 azA
 azA
 azA
@@ -58466,60 +59392,60 @@ tjj
 aVS
 aVS
 azA
-agU
+cqF
 jxJ
+aUn
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+dpC
+jEt
+dpC
+dpC
+drT
+dpC
+dpC
+dpC
+dpC
+bdg
 aVb
 aVb
 aVb
 aVb
-cqc
 aVb
-gyj
-agU
+cqF
+azA
+aMC
+fCD
+aVL
+aXh
+aXh
+aXh
+tPi
+aMC
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aBG
+aBG
+all
+all
+all
+all
+all
+all
+nQf
+kSF
+aBG
+fLg
+kIm
+jaN
 azA
 azA
 azA
@@ -58723,60 +59649,60 @@ hyd
 aGM
 aVS
 azA
-agU
-biQ
-aVb
-aVb
+cqF
 aFD
-biQ
-xTl
+qhP
 aVb
-wkv
-agU
+aVb
+vCX
+aVb
+aVb
+vCX
+xET
+aVb
+aVb
+hhA
+aVb
+cqF
+aVb
+aVb
+aUi
+aVb
+aVb
+vCX
+aVb
+aUi
+aVb
+aVb
+vCX
+aVb
+aEA
+cqF
+azA
+qSc
+aMC
+xfK
+aMC
+aMC
+aMC
+qSc
+qSc
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aAI
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+cJA
+jaN
+qnx
+bhl
+nVn
+aTZ
+jaN
 azA
 azA
 azA
@@ -58980,60 +59906,60 @@ aPh
 aGM
 aVS
 azA
-agU
+cqF
 cme
-aVb
+qhP
 aVb
 lWh
-agU
-agU
-agU
-agU
-agU
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+mUD
+cqF
+cqF
+cqF
+klT
+aUt
+hnt
+aUt
+aUt
+klT
+aVD
+xRv
+bks
+aVD
+aVD
+aVD
+aVD
+aVD
+azA
+azA
+aVD
+aUF
+aVD
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+nVn
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+idT
+aVm
+aUp
+aVa
+jaN
 azA
 azA
 azA
@@ -59237,60 +60163,60 @@ aPh
 cIC
 aVS
 azA
-agU
+cqF
 iTk
 aMH
 aVb
 pyn
-agU
+cqF
 iYX
 nFS
 lYV
-agU
+cqF
+onW
+aVb
+aVb
+cqF
+azA
+klT
+qst
+tmC
+bKj
+bKj
+aUt
+aNH
+wVj
+aMS
+dJG
+nUz
+vny
+ilH
+aVD
+aVD
+aVD
+aVD
+aUF
+aVD
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+nVn
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+fEA
+fwG
+nVn
+xsq
+jaN
 azA
 azA
 azA
@@ -59494,7 +60420,7 @@ xpX
 nTU
 aVS
 azA
-agU
+cqF
 clC
 qhP
 aVb
@@ -59503,51 +60429,51 @@ fYk
 eQq
 eQq
 kFd
-agU
+cqF
+jCD
+aVb
+aVb
+cqF
+azA
+klT
+wdh
+neg
+bKj
+bKj
+aUt
+nHd
+wVj
+aMS
+spT
+bBC
+ejX
+vXu
+aVD
+csn
+aTI
+wlv
+wVj
+aUa
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+nVn
+aAI
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+laq
+nVn
+nVn
+ixT
+jaN
 azA
 azA
 azA
@@ -59745,66 +60671,66 @@ azA
 azA
 azA
 azA
-cqF
+agU
 aGZ
 ing
 hUS
-cqF
+agU
 azA
-agU
-agU
+cqF
+cqF
 bia
-agU
-agU
-agU
+cqF
+cqF
+cqF
 woN
 eQq
 whL
-agU
+cqF
+cqF
+qqQ
+aVb
+cqF
+azA
+klT
+bBM
+bKj
+bKj
+bKj
+aUt
+hyk
+wVj
+aMS
+cAm
+aMS
+aNG
+sZE
+aVD
+hAx
+wVj
+aMS
+wVj
+bTG
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+pTX
+aVx
+aVx
+wSd
+jaN
 azA
 azA
 azA
@@ -60002,66 +60928,66 @@ azA
 azA
 azA
 azA
-cqF
+agU
 aGZ
 mXc
 qPN
-cqF
-cqF
+agU
+agU
 bjv
 kVb
 qhP
 vLm
-agU
-agU
-agU
-agU
-agU
-agU
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+aVb
+aVb
+cqF
+azA
+klT
+asA
+rzX
+aUy
+bKj
+aUt
+whj
+wVj
+aMS
+aMS
+aMS
+akH
+akH
+aVD
+aKa
+wVj
+aMS
+wVj
+cta
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+aUK
+aVq
+rFf
+gRM
+jaN
 azA
 azA
 azA
@@ -60263,62 +61189,62 @@ agU
 lkI
 bgK
 bjp
-aVb
+bVr
 aVb
 iRt
 aVb
 qhP
 aVb
 aVY
-aVb
 bVr
-wkv
-agU
+aVb
+qWb
+cqF
+azA
+cqF
+aVb
+aVb
+cqF
+azA
+klT
+jXr
+wLF
+hbV
+bKj
+fbx
+aMS
+aVy
+dMS
+dMS
+dMS
+dMS
+dMS
+xjd
+dMS
+oni
+dMS
+aUu
+kDr
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aAI
+jWg
+aTA
+czh
+vWB
+jaN
 azA
 azA
 azA
@@ -60530,52 +61456,52 @@ mEc
 aVb
 aVb
 wkv
-agU
+cqF
+azA
+cqF
+aVb
+aVb
+cqF
+azA
+klT
+ihR
+lhd
+tMm
+bKj
+aUt
+isA
+aVz
+oTb
+aMS
+aMS
+aMS
+aNs
+aVD
+lbi
+aMS
+aMS
+aMS
+bhr
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+aVG
+jaN
+aUP
+kPt
+aVk
+nLV
+jaN
 azA
 azA
 azA
@@ -60786,53 +61712,53 @@ aGA
 gKy
 aVb
 aVb
-wkv
-agU
+rqq
+cqF
+azA
+cqF
+aTy
+aVb
+cqF
+azA
+klT
+tOa
+bko
+aFg
+wkx
+aUt
+rVq
+aVz
+aMS
+aMS
+aMS
+aMS
+aVr
+aVD
+aUQ
+aUQ
+hed
+hed
+bQp
+aVD
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
+jaN
 azA
 azA
 azA
@@ -61040,37 +61966,37 @@ fwS
 bhf
 bis
 aDO
-agU
+cqF
 qqQ
 aVb
 aEA
-agU
+cqF
+cqF
+cqF
+qqQ
+aVb
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+klT
+klT
+klT
+klT
+klT
+klT
+aTL
+wVj
+aMS
+aMS
+aMS
+aMS
+akH
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
 azA
 azA
 azA
@@ -61297,31 +62223,31 @@ fwS
 erI
 aao
 aEq
-agU
+cqF
 gmT
 aVb
-pid
-agU
+aVb
+cqF
+aVb
+aVb
+aVb
+aVb
+cqF
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+bXK
+kKc
+oSH
+aVD
+aTP
+wVj
+aMS
+jnd
+gci
+jnd
+gci
+aVD
 azA
 azA
 azA
@@ -61558,27 +62484,27 @@ iCg
 vVl
 biD
 aVb
-agU
+hEk
+aVb
+aVb
+aVb
+aVb
+cqF
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+bWR
+vxq
+kVZ
+bkn
+dMS
+aUu
+aMS
+jnd
+gci
+jnd
+gci
+aVD
 azA
 azA
 azA
@@ -61811,31 +62737,31 @@ rcM
 lKF
 ren
 cYI
-hgr
+cqF
 blf
 tpZ
 fQz
-agU
+cqF
+qqQ
+aVb
+aVb
+aVb
+cqF
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+cqF
+cqF
+cqF
+cqF
+aVD
+mBo
+aMS
+aMS
+jnd
+gci
+jnd
+gci
+aVD
 azA
 azA
 azA
@@ -62065,34 +62991,34 @@ agU
 agU
 agU
 aXK
-agU
+cqF
 aCb
-agU
+cqF
 cqF
 bkh
 bkh
 bkh
-agU
+cqF
+cqF
+cqF
+xET
+aVb
+cqF
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aVD
+ttg
+aMS
+aMS
+xxz
+gci
+wVp
+gci
+aVD
 azA
 azA
 azA
@@ -62322,34 +63248,34 @@ azA
 azA
 azA
 acs
-agU
+cqF
+eYp
+cqF
+cqF
 bYK
-agU
-agU
 bYK
 bYK
-bYK
-agU
+cqF
 azA
+cqF
+cqF
+gut
+cqF
+cqF
+cqF
+cqF
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aTJ
+aTJ
+aTE
+aTJ
+aVD
+aVD
+aVD
+aVD
+aVD
 azA
 azA
 azA
@@ -62579,34 +63505,34 @@ aig
 aig
 aig
 aXK
-agU
-aCb
-agU
-agU
+cqF
+aUv
+cqF
+cqF
 bkh
 bkh
 bkh
-agU
+cqF
 azA
+cqF
+aMQ
+hgr
+hgr
+nUQ
+hgr
+dKX
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aVo
+aMS
+aMS
+aMS
+amA
+aoN
+amA
+aoN
+aVD
 azA
 azA
 azA
@@ -62837,7 +63763,7 @@ eCZ
 qnc
 vea
 agU
-bhO
+pOj
 aVW
 pXS
 bhO
@@ -62845,25 +63771,25 @@ bhO
 bhO
 agU
 azA
+cqF
+xIs
+hgr
+nRA
+jBr
+iXa
+aTv
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aMS
+aMS
+aMS
+aMS
+aMS
+aMS
+aMS
+aVD
 azA
 azA
 azA
@@ -63102,25 +64028,25 @@ aXT
 aXT
 agU
 azA
+cqF
+aPV
+hgr
+bXO
+fAR
+hgX
+aUg
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aNs
+aTJ
+aTJ
+aTJ
+aNb
+aTJ
+aNb
+aTJ
 azA
 azA
 azA
@@ -63359,25 +64285,25 @@ aXT
 pox
 agU
 azA
+cqF
+aVA
+hgr
+aIR
+goj
+aUB
+hgr
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aMS
+aTE
+aTB
+aTJ
+aUo
+aTJ
+aUo
+aTJ
 azA
 azA
 azA
@@ -63616,25 +64542,25 @@ aXT
 aXT
 agU
 azA
+cqF
+bkw
+gZc
+hgr
+bMX
+aTv
+avx
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMv
+aNs
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
 azA
 azA
 azA
@@ -63873,21 +64799,21 @@ bjT
 agn
 agU
 azA
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
+cqF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aMu
+aMS
+aTE
+aTB
+aTJ
 azA
 azA
 azA
@@ -64139,12 +65065,12 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
+aTJ
 azA
 azA
 azA
@@ -77494,13 +78420,13 @@ ass
 sjI
 eAb
 ass
-viG
+daV
 agy
 ass
-viG
+daV
 agy
 ass
-viG
+daV
 agy
 ass
 ipQ

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -4710,11 +4710,6 @@
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"mG" = (
-/obj/effect/paint_stripe/orange,
-/obj/effect/paint_stripe/orange,
-/turf/simulated/wall/titanium,
-/area/site53/uez/repoffice/internaltribunal)
 "mI" = (
 /turf/simulated/floor/wood/walnut,
 /area/site53/surface/surface)
@@ -5635,10 +5630,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/repoffice/ethics)
-"rB" = (
-/obj/effect/paint_stripe/orange,
-/turf/simulated/wall/titanium,
-/area/site53/uez/repoffice/internaltribunal)
 "rC" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/stamp/scp/o5rep,
@@ -44252,14 +44243,14 @@ dA
 dA
 dA
 dA
-rB
-rB
-rB
-rB
-rB
-rB
-rB
-mG
+dt
+dt
+dt
+Zp
+Zp
+Zp
+Zp
+NX
 Zp
 NX
 bO

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -57,11 +57,6 @@
 "aj" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroomstairs)
-"ak" = (
-/obj/structure/table/standard,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "al" = (
 /obj/structure/disposalpipe/down,
 /obj/structure/lattice,
@@ -326,9 +321,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/isolation)
-"aQ" = (
-/turf/simulated/open,
-/area/site53/zonecommanderoffice)
 "aR" = (
 /obj/machinery/door/airlock/engineering{
 	req_access = list("ACCESS_ADMIN_LEVEL1")
@@ -669,18 +661,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
-"bB" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable/green,
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "bC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/exoplanet/grass,
@@ -1117,12 +1097,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
-"ct" = (
-/obj/structure/closet,
-/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
-/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
-/turf/simulated/floor/tiled,
-/area/site53/uez/armory)
 "cv" = (
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/titanium,
@@ -1183,13 +1157,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/entrancezone/securitypost)
-"cC" = (
-/obj/machinery/light/small,
-/obj/structure/closet/secure_closet/engineering_electrical{
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "cD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -1355,13 +1322,6 @@
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"cU" = (
-/obj/structure/table/standard,
-/obj/machinery/photocopier{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
 "cV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/white,
@@ -1404,46 +1364,9 @@
 /obj/machinery/status_display,
 /turf/simulated/wall/titanium,
 /area/site53/uez/bridge)
-"dc" = (
-/obj/structure/table/woodentable/ebony,
-/obj/machinery/button/blast_door{
-	dir = 4;
-	id_tag = "tribrep";
-	name = "Shutters";
-	pixel_x = -6;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
-"dd" = (
-/obj/structure/bed/chair/shuttle{
-	name = "Reeducation Chair"
-	},
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "de" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/mentalhealth/isolation)
-"df" = (
-/obj/structure/crematorium{
-	dir = 4;
-	id = "EZT Crematorium"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
-"dg" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Maintenance";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/zonecommanderoffice)
 "dh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1474,14 +1397,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"dk" = (
-/obj/effect/paint_stripe/red,
-/obj/machinery/button/crematorium{
-	id_tag = "EZT Crematorium";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/wall/titanium,
-/area/site53/uez/equipmentroom)
 "dl" = (
 /obj/effect/paint_stripe/green,
 /turf/simulated/wall/prepainted,
@@ -1559,12 +1474,6 @@
 "du" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/infirmary)
-"dv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "dw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -1584,13 +1493,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
-"dy" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/obj/item/storage/box/bodybags,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "dz" = (
 /obj/structure/table/standard,
 /obj/machinery/button/blast_door{
@@ -1734,17 +1636,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
-"dP" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/red/half{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "dQ" = (
 /obj/effect/paint_stripe/white,
 /obj/machinery/door/airlock/multi_tile/glass/medical{
@@ -1793,24 +1684,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
-"dV" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"dW" = (
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "EZ Termination";
-	name = "EZ Termination";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"dX" = (
-/obj/structure/flora/pottedplant/tropical,
-/turf/simulated/floor/grass,
-/area/site53/zonecommanderoffice)
 "dY" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1824,9 +1697,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op2)
-"eb" = (
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "ec" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/titanium,
@@ -1964,14 +1834,6 @@
 /obj/effect/floor_decal/corner/purple/half,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/chemistry)
-"et" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "eu" = (
 /obj/structure/closet/secure_closet/medical2{
 	req_access = list("ACCESS_MEDICAL_LEVEL3")
@@ -2079,11 +1941,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
-"eK" = (
-/obj/effect/floor_decal/corner/red/border,
-/obj/structure/closet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "eL" = (
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/button/windowtint{
@@ -2136,13 +1993,6 @@
 "eQ" = (
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
-"eR" = (
-/obj/machinery/door/airlock/security{
-	name = "EZ Employment Termination Room";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "eS" = (
 /obj/effect/paint_stripe/white,
 /obj/effect/paint_stripe/white,
@@ -2270,10 +2120,6 @@
 /obj/effect/floor_decal/corner/black/border,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"fi" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "fj" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
@@ -2333,16 +2179,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"fo" = (
-/obj/structure/closet,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
-"fp" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "fq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2368,23 +2204,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
-"fs" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
-"ft" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "fu" = (
 /obj/structure/table/woodentable/walnut,
 /obj/structure/bookcase/manuals/medical{
@@ -2412,18 +2231,6 @@
 /obj/structure/flora/bush,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"fy" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "east bump";
-	pixel_y = 24
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/armory)
 "fz" = (
 /obj/structure/table/woodentable/walnut,
 /obj/structure/bookcase{
@@ -2434,12 +2241,6 @@
 /obj/item/device/camera_film,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
-"fA" = (
-/obj/structure/morgue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "fB" = (
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 1
@@ -2585,12 +2386,6 @@
 /obj/structure/iv_drip,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"fV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "fW" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating,
@@ -2621,11 +2416,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception/waiting)
-"ga" = (
-/obj/structure/table/woodentable/ebony,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "gb" = (
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/equipstorage)
@@ -2645,13 +2435,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/hall)
-"gf" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_y = 8
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "gg" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/boombox,
@@ -2703,14 +2486,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"gp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "gq" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/mcrsubstation)
@@ -2771,10 +2546,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"gz" = (
-/obj/structure/flora/pottedplant,
-/turf/simulated/floor/grass,
-/area/site53/zonecommanderoffice)
 "gA" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -4123,18 +3894,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception)
-"kb" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	id_tag = "tribrep"
-	},
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "facilitylockdown";
-	name = "Exterior Lockdown Blast Door"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "kc" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -4239,13 +3998,6 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/site53/medical/chemistry)
-"km" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "kn" = (
 /obj/structure/table/standard,
 /obj/item/stack/material/phoron/ten,
@@ -4290,12 +4042,6 @@
 "ks" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmreception)
-"kt" = (
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "kv" = (
 /obj/structure/morgue,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -4390,14 +4136,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
-"kI" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "kJ" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
@@ -4451,16 +4189,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"kR" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "kS" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Psychiatrist's Office"
@@ -4468,10 +4196,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
-"kT" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/uez/armory)
 "kU" = (
 /turf/simulated/floor/plating,
 /area/site53/medical/morgue)
@@ -4757,16 +4481,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
-"lA" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
-"lC" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/uez/senioragentoffice)
 "lD" = (
 /obj/effect/paint_stripe/white,
 /turf/simulated/floor/tiled/white,
@@ -4775,12 +4489,6 @@
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/titanium,
 /area/site53/surface/surface)
-"lF" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
 "lH" = (
 /obj/machinery/light{
 	dir = 8
@@ -4790,10 +4498,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"lI" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "lJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -4830,20 +4534,12 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/grass,
 /area/site53/upper_surface/maincontrolroomstairs)
-"lS" = (
-/obj/structure/closet/secure_closet/guard/ez,
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("Entrance Zone Network")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "lW" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
 	},
-/obj/machinery/door/airlock/multi_tile/glass/security{
-	name = "Security Center"
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
@@ -4892,28 +4588,6 @@
 /obj/item/clothing/suit/surgicalapron,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op2)
-"mf" = (
-/obj/structure/table/rack,
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "mh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian{
@@ -4984,14 +4658,6 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 10
 	},
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "mq" = (
@@ -5006,76 +4672,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "mr" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
-"ms" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
-"mt" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/effect/floor_decal/corner/red/border,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
-"mu" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
-"mv" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("Entrance Zone Network")
-	},
-/obj/effect/floor_decal/corner/red/border,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
-"mw" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
-	},
-/obj/machinery/light{
+/obj/effect/floor_decal/corner/orange/bordercorner{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "mx" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
-	},
+/obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "my" = (
@@ -5107,36 +4710,6 @@
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"mC" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
-"mD" = (
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("Entrance Zone Network")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
-"mE" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
-"mF" = (
-/obj/machinery/light{
-	dir = 1;
-	icon_state = "tube1"
-	},
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "mG" = (
 /obj/effect/paint_stripe/orange,
 /obj/effect/paint_stripe/orange,
@@ -5146,11 +4719,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/surface/surface)
 "mJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/floor_decal/corner/orange/border,
 /obj/structure/cable/green{
 	icon_state = "2-8"
@@ -5217,99 +4785,14 @@
 /obj/effect/floor_decal/corner/orange/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"mQ" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"mR" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"mS" = (
-/obj/machinery/door/airlock/multi_tile/security{
-	name = "\improper Entrance Zone Guard Equipment";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "mT" = (
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"mU" = (
-/obj/structure/closet/secure_closet/engineering_welding{
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
-"mW" = (
-/obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"mY" = (
-/obj/effect/landmark/start{
-	name = "EZ Junior Agent"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"mZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
 "nd" = (
 /obj/structure/barricade/spike,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"ng" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
-"nh" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"ni" = (
-/obj/structure/closet/secure_closet/guard/ez,
-/obj/machinery/recharger/wallcharger{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "nj" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -5334,12 +4817,6 @@
 /obj/structure/bed/chair/wood,
 /turf/simulated/floor/exoplanet/concrete,
 /area/site53/surface/surface)
-"nn" = (
-/obj/machinery/vending/coffee{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "nq" = (
 /obj/vehicle/train/cargo/trolley,
 /obj/structure/cable{
@@ -5358,55 +4835,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/repoffice/ethics)
-"nt" = (
-/obj/structure/closet/secure_closet/guard/ez,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"nu" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"nv" = (
-/obj/machinery/vending/fitness,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"nw" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"nx" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"ny" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
 "nz" = (
 /turf/unsimulated/mineral,
 /area/site53/medical/surgery/hall)
-"nA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
 "nE" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
@@ -5414,60 +4845,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/exoplanet/concrete,
 /area/site53/surface/surface)
-"nH" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
-"nI" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Entrance Zone Commander's Office";
-	send_access = list(204)
-	},
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"nJ" = (
-/obj/structure/table/reinforced,
-/obj/item/device/radio/phone,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"nK" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"nL" = (
-/obj/machinery/light,
-/obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("Entrance Zone Network")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"nM" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
 "nO" = (
 /obj/structure/table/woodentable,
 /obj/item/instrument/guitar,
@@ -5490,16 +4867,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/substation)
-"nT" = (
-/obj/structure/closet/secure_closet/guard/zone_commander,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
 "nU" = (
 /turf/unsimulated/mineral,
 /area/site53/medical/mentalhealth/isolation)
@@ -5513,13 +4880,6 @@
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"od" = (
-/obj/machinery/door/window/brigdoor/northright,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "oe" = (
 /obj/structure/railing/mapped,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -5653,16 +5013,6 @@
 "ou" = (
 /turf/simulated/floor/plating,
 /area/site53/entrancezone/substation)
-"ov" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/blast/shutters{
-	id_tag = "tribrep"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "ow" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -5674,12 +5024,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/entrancezone/substation)
-"ox" = (
-/obj/structure/table/woodentable/ebony,
-/obj/item/paper_bin,
-/obj/item/pen/fancy/quill,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
 "oy" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -5760,10 +5104,6 @@
 "oJ" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/commstower)
-"oK" = (
-/obj/structure/flora/pottedplant/tall,
-/turf/simulated/floor/grass,
-/area/site53/zonecommanderoffice)
 "oN" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -5807,10 +5147,6 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/grass,
 /area/site53/upper_surface/maincontrolroomstairs)
-"oZ" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "pb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/orange/bordercorner{
@@ -5920,20 +5256,11 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/site53/upper_surface/maincontrolroomstairs)
-"pt" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/donut,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "pu" = (
 /obj/effect/paint_stripe/gray,
 /obj/machinery/status_display,
 /turf/simulated/wall/prepainted,
 /area/site53/uez/bridge)
-"px" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/entrancezone/forensicsstairwell)
 "pz" = (
 /obj/effect/paint_stripe/white,
 /obj/structure/cable{
@@ -6034,10 +5361,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/tramhubhallwayentry)
-"qb" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
 "qf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6046,20 +5369,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroomstairs)
-"qm" = (
-/obj/machinery/light,
-/turf/simulated/open,
-/area/site53/zonecommanderoffice)
-"qo" = (
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 6
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
 "qp" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -6238,14 +5547,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfaceeast)
-"rh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "ri" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters{
@@ -6265,9 +5566,6 @@
 "rm" = (
 /turf/simulated/mineral,
 /area/site53/surface/surface)
-"rn" = (
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "ro" = (
 /obj/machinery/light,
 /obj/structure/closet,
@@ -6297,12 +5595,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/repoffice/ethics)
-"rs" = (
-/obj/machinery/door/airlock/glass/command{
-	name = "Internal Tribunal Department Representitive"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "rt" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -6389,34 +5681,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
-"rJ" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"rK" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "rL" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Primary Storage";
@@ -6709,14 +5973,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
-"sy" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "sD" = (
 /obj/structure/railing/mapped,
 /obj/structure/window/reinforced{
@@ -6729,10 +5985,6 @@
 "sE" = (
 /turf/simulated/open,
 /area/site53/surface/surface)
-"sG" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "sJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -6766,259 +6018,10 @@
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
-"sQ" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 9
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
-"sR" = (
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
-"sS" = (
-/obj/structure/closet/secure_closet/guard/zone_commander{
-	req_access = list("ACCESS_SCIENCE_LEVEL2")
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 1
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 5
-	},
-/obj/item/gun/projectile/automatic/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/box/rubbershot,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
-"sT" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/reinforced,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
-"sU" = (
-/obj/effect/landmark/start{
-	name = "LCZ Zone Commander"
-	},
-/obj/structure/bed/chair/office/comfy{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
-"sV" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
-"sY" = (
-/obj/machinery/vending/cigarette{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"sZ" = (
-/obj/structure/table/reinforced,
-/obj/random/clipboard,
-/obj/effect/floor_decal/carpet/blue2,
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
 "tb" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/titanium,
 /area/site53/maintenance/surfacewest)
-"td" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"te" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tf" = (
-/obj/structure/table/glass,
-/obj/item/device/flashlight/lamp,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tg" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"th" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"ti" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tj" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tk" = (
-/obj/structure/table/glass,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tl" = (
-/obj/structure/bed/chair/comfy/blue{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tm" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tn" = (
-/obj/machinery/power/apc/hyper{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"to" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 10
-	},
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tp" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tq" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "LCZ Zone Commander's Office";
-	send_access = list(204)
-	},
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tr" = (
-/obj/structure/filingcabinet,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"ts" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tt" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/item/modular_computer/laptop/preset/records,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tu" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tv" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tw" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tx" = (
-/obj/effect/floor_decal/corner/blue/bordercee{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"ty" = (
-/obj/effect/paint_stripe/gray,
-/turf/simulated/wall/titanium,
-/area/site53/zonecommanderoffice)
-"tz" = (
-/obj/machinery/door/airlock/multi_tile/security{
-	id_tag = "ezguns";
-	locked = 1;
-	name = "\improper Entrance Zone Armoury";
-	req_access = list("ACCESS_SECURITY_LEVEL2");
-	secured_wires = 1
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "EZ Armoury Lockdown";
-	name = "EZ Armoury Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
-"tB" = (
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "tD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7028,33 +6031,6 @@
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"tE" = (
-/obj/structure/table/standard,
-/obj/item/device/camera_film,
-/obj/item/device/camera_film,
-/obj/item/device/camera,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"tH" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/obj/machinery/recharger,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"tK" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"tL" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "tM" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -7065,61 +6041,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/entrancezone/hallway)
-"tN" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "tO" = (
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/site53/uez/bridge)
-"tQ" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/site53/uez/senioragentoffice)
-"tR" = (
-/obj/machinery/door/airlock/multi_tile/glass/security{
-	name = "Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"tS" = (
-/obj/effect/paint_stripe/red,
-/obj/machinery/status_display,
-/turf/simulated/wall/titanium,
-/area/site53/uez/equipmentroom)
-"tU" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"tV" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8
-	},
-/obj/structure/closet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"tW" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"tX" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"tY" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "tZ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/shutters/open{
@@ -7132,82 +6057,8 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
-"ub" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"uc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"ud" = (
-/turf/unsimulated/mineral,
-/area/site53/uez/equipmentroom)
-"uf" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"ug" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"uh" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/half{
-	dir = 4
-	},
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"ui" = (
-/obj/structure/table/standard,
-/obj/machinery/photocopier{
-	pixel_y = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"uj" = (
-/obj/machinery/light,
-/obj/structure/table/standard,
-/obj/machinery/photocopier/faxmachine{
-	department = "EZ Security Center";
-	send_access = list("ACCESS_SECURITY_LEVEL1")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "uk" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/red/border{
+/obj/effect/floor_decal/corner/orange/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -7614,14 +6465,6 @@
 "vH" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/equipstorage)
-"vK" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "vO" = (
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -7647,10 +6490,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
-"we" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "wj" = (
 /obj/structure/table/woodentable/ebony,
 /obj/machinery/photocopier,
@@ -7680,18 +6519,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
-"ww" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/mono,
-/obj/item/boombox,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"wz" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/standard,
-/obj/item/device/taperecorder,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "wC" = (
 /obj/effect/paint_stripe/green,
 /obj/structure/closet/crate/secure/biohazard{
@@ -7735,13 +6562,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"wO" = (
-/obj/structure/sign/warning/secure_area/armory{
-	pixel_x = -32;
-	pixel_y = 27
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/armory)
 "wP" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/exoplanet/grass,
@@ -7782,28 +6602,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
-"xa" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
-	},
-/obj/structure/table/steel,
-/obj/item/clothing/head/helmet/facecover,
-/obj/item/clothing/head/helmet/facecover,
-/obj/item/clothing/head/helmet/facecover,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/handcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "xb" = (
 /obj/effect/landmark{
 	name = "JoinLateCryo"
@@ -7824,12 +6622,6 @@
 /obj/item/storage/box/freezer,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
-"xg" = (
-/obj/effect/landmark/start{
-	name = "EZ Senior Agent"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
 "xh" = (
 /obj/effect/paint_stripe/white,
 /obj/effect/paint_stripe/white,
@@ -7857,18 +6649,6 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"xn" = (
-/obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "xs" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
@@ -7883,33 +6663,6 @@
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"xF" = (
-/obj/machinery/power/smes/buildable/preset/ds90/substation_full{
-	RCon_tag = "Self-Destruct Substation"
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
-"xK" = (
-/obj/machinery/button/alternate/door/bolts{
-	id_tag = "ezcell3";
-	name = "Cell 3 bolts";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"xW" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/gun/projectile/revolver/rhino,
-/obj/item/gun/projectile/revolver/rhino,
-/obj/item/gun/projectile/revolver/rhino,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "yg" = (
 /obj/effect/floor_decal/corner/purple/mono,
 /obj/machinery/light{
@@ -7917,17 +6670,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"yk" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "yo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -7946,14 +6688,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"yt" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
 "yv" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 8
@@ -8018,10 +6752,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/equipstorage)
-"yI" = (
-/obj/structure/table/woodentable/ebony,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
 "yJ" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -8035,13 +6765,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/maintenance/surfaceeast)
-"yW" = (
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "yX" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -8066,20 +6789,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
-"zc" = (
-/obj/machinery/button/alternate/door/bolts{
-	dir = 4;
-	id_tag = "ezguns";
-	name = "EZ Armory Access button";
-	pixel_x = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
 "zf" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -8168,13 +6877,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"zw" = (
-/obj/machinery/vending/tool{
-	dir = 1;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "zx" = (
 /obj/machinery/organ_printer/robot/mapped,
 /obj/machinery/light{
@@ -8199,23 +6901,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"zG" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/box/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/ammo_magazine/scp/mk9,
-/obj/item/gun/projectile/pistol/mk9,
-/obj/item/gun/projectile/pistol/mk9,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "zH" = (
 /obj/structure/table/rack,
 /obj/item/storage/firstaid/adv,
@@ -8225,10 +6910,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
-"zI" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "zJ" = (
 /obj/effect/floor_decal/corner/paleblue/half,
 /obj/structure/bed/chair{
@@ -8239,9 +6920,6 @@
 "zO" = (
 /turf/simulated/floor/tiled,
 /area/site53/surface/surface)
-"zP" = (
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "zR" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -8284,10 +6962,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Ac" = (
-/obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "Ad" = (
 /obj/effect/floor_decal/corner/paleblue/border{
 	dir = 8
@@ -8324,39 +6998,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
-"Ak" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
-	},
-/obj/structure/table/steel,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/under/scp/dclass,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/shoes/orange,
-/obj/item/clothing/shoes/orange,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"Am" = (
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "ezcell";
-	name = "Holding Cell";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Ao" = (
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
@@ -8410,12 +7051,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/isolation)
-"AR" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "AT" = (
 /turf/simulated/floor/reinforced,
 /area/site53/surface/surface)
@@ -8444,30 +7079,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op1)
-"Bc" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/machinery/button/alternate/door/bolts{
-	id_tag = "ezcell";
-	name = "Holding Cell Lock button";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"Bf" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 8
-	},
-/obj/machinery/vending/security{
-	dir = 4;
-	req_access = list()
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Bj" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
@@ -8523,12 +7134,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
-"BA" = (
-/obj/machinery/vending/fitness{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "BO" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -8552,25 +7157,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"BQ" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"BR" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/hallway)
 "BT" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/railing/mapped,
@@ -8612,14 +7198,6 @@
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/prepainted,
 /area/site53/maintenance/surfaceeast)
-"Ck" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/half{
-	dir = 4
-	},
-/obj/item/device/megaphone,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Cn" = (
 /obj/structure/table/woodentable{
 	dir = 5
@@ -8657,11 +7235,6 @@
 /obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/prepainted,
 /area/site53/medical/infirmary)
-"CF" = (
-/obj/structure/closet/secure_closet/guard/lcz/sergeant,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "CG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -8689,14 +7262,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/op1)
-"Df" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Dg" = (
 /obj/machinery/door/airlock/multi_tile/glass/medical{
 	name = "Staff Area";
@@ -8709,24 +7274,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Dn" = (
-/obj/structure/table/woodentable/ebony,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/repoffice/internaltribunal)
 "Do" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logistics)
-"Dz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "DD" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable{
@@ -8871,24 +7423,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/restaurantkitchenarea)
-"Er" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
-"Es" = (
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "ezcell3";
-	name = "Holding Cell 3";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Ew" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -8911,10 +7445,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"EJ" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "EO" = (
 /obj/machinery/door/airlock/glass/virology{
 	id_tag = "iso1";
@@ -8975,14 +7505,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroomstairs)
-"Fi" = (
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "ezcell2";
-	name = "Holding Cell 2";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Fl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -9053,19 +7575,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"FQ" = (
-/obj/structure/table/standard,
-/obj/item/pen,
-/obj/item/paper_bin,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 8
-	},
-/obj/effect/floor_decal/carpet/blue2,
-/obj/effect/floor_decal/carpet/blue2{
-	dir = 10
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/site53/zonecommanderoffice)
 "Ga" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
@@ -9088,10 +7597,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"Gi" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/uez/equipmentroom)
 "Gk" = (
 /obj/structure/bed/roller,
 /obj/structure/iv_drip,
@@ -9130,12 +7635,6 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"Gx" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "GH" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -9219,27 +7718,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/maintenance/surfaceeast)
-"Hf" = (
-/obj/structure/bed,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"Hj" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/scp/usp45,
-/obj/item/ammo_magazine/box/a45,
-/obj/item/ammo_magazine/box/a45,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/gun/projectile/pistol/usp45,
-/obj/item/gun/projectile/pistol/usp45,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "Hl" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/white,
@@ -9249,19 +7727,6 @@
 /obj/structure/bed/chair/wheelchair,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/hall)
-"Ho" = (
-/obj/structure/closet/secure_closet/guard/ez/sergeant,
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
-"Hq" = (
-/obj/structure/hygiene/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Hs" = (
 /obj/structure/iv_drip,
 /turf/simulated/floor/carpet/orange,
@@ -9281,38 +7746,9 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
-"Hz" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/saiga12/rubbershot,
-/obj/item/ammo_magazine/scp/saiga12/rubbershot,
-/obj/item/ammo_magazine/scp/saiga12/rubbershot,
-/obj/item/ammo_magazine/scp/saiga12/rubbershot,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/rubbershot,
-/obj/item/ammo_magazine/box/rubbershot,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "HG" = (
-/obj/effect/floor_decal/corner/red/border,
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/obj/machinery/door/airlock/security{
-	name = "Forensics Laboratory";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensicsstairwell)
+/obj/effect/paint_stripe/orange,
+/turf/simulated/wall/titanium)
 "HH" = (
 /obj/structure/bed/roller,
 /obj/structure/iv_drip,
@@ -9333,13 +7769,6 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"HL" = (
-/obj/structure/closet/secure_closet/guard/ez/sergeant,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
 "HM" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -9463,10 +7892,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfaceeast)
-"IK" = (
-/obj/structure/stairs/north,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensicsstairwell)
 "IL" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
@@ -9505,10 +7930,6 @@
 	},
 /turf/unsimulated/mineral,
 /area/space)
-"Jr" = (
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "Js" = (
 /obj/effect/paint_stripe/green,
 /obj/structure/table/standard,
@@ -9516,42 +7937,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op1)
-"Jt" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters/open{
-	begins_closed = 1;
-	id_tag = "EZ Security Shutter";
-	name = "EZ Security Shutter"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/equipmentroom)
-"Jv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"Jx" = (
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -30
-	},
-/obj/structure/table/rack,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/obj/item/melee/baton/loaded,
-/turf/simulated/floor/tiled,
-/area/site53/uez/equipmentroom)
 "Jy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9573,13 +7958,6 @@
 	},
 /turf/simulated/floor/wood/maple,
 /area/site53/surface/surface)
-"JR" = (
-/obj/structure/table/woodentable/ebony,
-/obj/machinery/photocopier/faxmachine{
-	department = "Tribunal Officer's Fax"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "JU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9663,12 +8041,6 @@
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
-"Ky" = (
-/obj/effect/landmark/start{
-	name = "LCZ Guard"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "KB" = (
 /obj/structure/table/woodentable/walnut,
 /obj/item/paper_bin,
@@ -9717,20 +8089,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/isolation)
-"KR" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/saiga12/buckshot,
-/obj/item/ammo_magazine/scp/saiga12/buckshot,
-/obj/item/ammo_magazine/scp/saiga12/buckshot,
-/obj/item/ammo_magazine/scp/saiga12/buckshot,
-/obj/item/ammo_magazine/box/buckshot,
-/obj/item/ammo_magazine/box/buckshot,
-/obj/item/ammo_magazine/box/buckshot,
-/obj/item/ammo_magazine/box/buckshot,
-/obj/item/ammo_magazine/box/slug,
-/obj/item/ammo_magazine/box/slug,
-/turf/simulated/floor/tiled,
-/area/site53/uez/armory)
 "Lb" = (
 /obj/machinery/door/airlock/glass/mining{
 	name = "Helipad";
@@ -9759,18 +8117,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/tramhubhallwayentry)
-"Li" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "Lm" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -9793,17 +8139,6 @@
 "Lp" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/isolation)
-"Ls" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "Lv" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 1
@@ -9825,21 +8160,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/exam_room)
-"LE" = (
-/obj/machinery/button/alternate/door/bolts{
-	id_tag = "ezcell1";
-	name = "Cell 1 bolts";
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"LF" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "LG" = (
 /turf/unsimulated/mineral,
 /area/site53/medical/infirmary)
@@ -9849,17 +8169,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/repoffice/ethics)
-"LR" = (
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "EZ Security Shutter";
-	name = "EZ Security Shutter";
-	pixel_y = 34
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "LW" = (
 /obj/effect/floor_decal/corner/paleblue/half,
 /obj/structure/table/standard,
@@ -9889,12 +8198,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/hall)
-"Mh" = (
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "Mj" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/door/airlock/hatch/maintenance{
@@ -9910,10 +8213,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
-"Ml" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
 "Mo" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
@@ -9925,17 +8224,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/surgery/hall)
-"Mq" = (
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
-/area/site53/uez/equipmentroom)
-"Ms" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Mu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -9953,10 +8241,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"MA" = (
-/obj/structure/closet/secure_closet/guard/ez,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "ME" = (
 /obj/structure/table/woodentable/ebony,
 /turf/simulated/floor/tiled/techfloor,
@@ -9969,16 +8253,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/logistics/logistics)
-"MO" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
-"MQ" = (
-/obj/machinery/vending/hotfood{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "MR" = (
 /obj/effect/floor_decal/corner/paleblue/half,
 /obj/structure/table/standard,
@@ -10013,38 +8287,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"Ni" = (
-/obj/effect/floor_decal/corner/red/bordercee{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/power/apc{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensicsstairwell)
-"Nk" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"Ny" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/ionrifle,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "NA" = (
 /obj/effect/floor_decal/carpet/orange{
 	dir = 1
@@ -10058,11 +8300,6 @@
 	},
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"ND" = (
-/obj/structure/table/woodentable/ebony,
-/obj/machinery/photocopier,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "NE" = (
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/titanium,
@@ -10078,10 +8315,6 @@
 /obj/structure/barricade/spike,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"NM" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "NP" = (
 /obj/item/gun/energy/ionrifle,
 /turf/unsimulated/mineral,
@@ -10110,13 +8343,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/logistics/logistics)
-"Oe" = (
-/obj/machinery/door/airlock/glass/security{
-	name = "Sergeant Equipment";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "Of" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -10167,15 +8393,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"OE" = (
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/obj/machinery/light,
-/turf/simulated/open,
-/area/site53/zonecommanderoffice)
 "OK" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -10185,13 +8402,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"OU" = (
-/obj/structure/table/standard,
-/obj/item/device/tape,
-/obj/item/device/tape,
-/obj/item/device/taperecorder,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "OW" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
@@ -10245,30 +8455,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/surface/surface)
-"PA" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/armory)
-"PM" = (
-/obj/machinery/power/breakerbox/activated{
-	RCon_tag = "Self-Destruct Bypass"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
-"PR" = (
-/obj/structure/bed/chair/padded,
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
-"PS" = (
-/turf/simulated/floor/tiled,
-/area/site53/uez/armory)
 "PX" = (
 /obj/item/clothing/suit/storage/toggle/fr_jacket,
 /obj/item/clothing/suit/storage/toggle/fr_jacket/ems,
@@ -10289,13 +8475,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
-"PZ" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
-	},
-/obj/structure/closet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Qa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/mineral,
@@ -10377,18 +8556,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op1)
-"QG" = (
-/obj/structure/table/woodentable/ebony,
-/obj/item/stamp/scp/o5rep,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
-"QP" = (
-/obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "QQ" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/light/small{
@@ -10453,14 +8620,6 @@
 /obj/structure/ladder,
 /turf/simulated/open,
 /area/site53/maintenance/surfacewest)
-"Rw" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/red/half{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Rx" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -10487,15 +8646,6 @@
 /obj/structure/railing/mapped,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
-"RJ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "RK" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -10511,11 +8661,6 @@
 /obj/structure/sign/warning/nosmoking_1,
 /turf/simulated/wall/prepainted,
 /area/site53/medical/exam_room)
-"RR" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/mre/menu2,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "RS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/white,
@@ -10607,17 +8752,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Sz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "SC" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -10643,14 +8777,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/surface/surface)
-"SL" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "SN" = (
 /obj/effect/paint_stripe/green,
 /obj/effect/wallframe_spawn/reinforced/polarized/full,
@@ -10681,17 +8807,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/chemistry)
-"Td" = (
-/obj/structure/table/reinforced,
-/obj/item/material/ashtray/plastic,
-/obj/item/trash/cigbutt{
-	pixel_y = 7
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "Tg" = (
 /obj/effect/paint_stripe/gray,
 /obj/effect/wallframe_spawn/reinforced,
@@ -10708,13 +8823,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/lowertrams/restaurantkitchenarea)
-"Tn" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
-	},
-/obj/structure/closet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Tq" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 1
@@ -10735,21 +8843,6 @@
 /obj/structure/table/woodentable/ebony,
 /turf/simulated/floor/wood/walnut,
 /area/site53/surface/surface)
-"TG" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/floor_decal/corner/red/half{
-	dir = 4
-	},
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	pixel_x = 20
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "TI" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -10797,10 +8890,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
-"TR" = (
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "TU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10872,12 +8961,6 @@
 	},
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
-"Ux" = (
-/obj/structure/bed/chair/padded{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/equipmentroom)
 "UC" = (
 /obj/effect/floor_decal/corner/green/bordercorner{
 	dir = 1
@@ -10896,10 +8979,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op1)
-"UE" = (
-/obj/machinery/light,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "UF" = (
 /obj/effect/shuttle_landmark/heli/out,
 /turf/simulated/floor/reinforced,
@@ -10910,21 +8989,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"UM" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/button/blast_door{
-	dir = 1;
-	id_tag = "EZ Armoury Lockdown";
-	name = "EZ Armoury Lockdown";
-	pixel_y = -23;
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
 "UN" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -10938,18 +9002,6 @@
 /obj/item/device/scanner/spectrometer,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/medical/morgue)
-"UV" = (
-/obj/machinery/door/airlock/multi_tile/glass/security{
-	dir = 8;
-	icon_state = "closed";
-	name = "Guard Hallway";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"Va" = (
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensicsstairwell)
 "Vb" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -10960,30 +9012,12 @@
 /obj/effect/floor_decal/corner/orange/border,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"Vf" = (
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
 "Vi" = (
 /obj/structure/sign/warning/moving_parts{
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/logistics/logistics)
-"Vl" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/flashbangs,
-/obj/item/storage/box/teargas,
-/obj/item/storage/box/teargas,
-/obj/item/gun/launcher/grenade,
-/obj/item/storage/pill_bottle/amnesticsb,
-/obj/item/storage/pill_bottle/amnesticsb,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "Vm" = (
 /obj/effect/paint_stripe/green,
 /turf/simulated/wall/prepainted,
@@ -10994,13 +9028,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"Vr" = (
-/obj/machinery/vending/engineering{
-	dir = 1;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "Vu" = (
 /obj/effect/paint_stripe/white,
 /obj/structure/table/glass,
@@ -11087,14 +9114,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroomstairs)
-"Wm" = (
-/obj/machinery/door/airlock/glass/security{
-	id_tag = "ezcell1";
-	name = "Holding Cell 1";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Wo" = (
 /obj/effect/floor_decal/corner/paleblue/half,
 /obj/machinery/vending/medical{
@@ -11206,28 +9225,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Xq" = (
-/obj/machinery/light,
-/obj/effect/floor_decal/corner/red/border,
-/obj/structure/closet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"Xu" = (
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/senioragentoffice)
-"Xv" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "EZ Armoury Lockdown";
-	name = "EZ Armoury Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
 "Xy" = (
 /obj/structure/railing/mapped,
 /obj/structure/window/reinforced{
@@ -11242,13 +9239,6 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/goirepoffice)
-"XF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/hygiene/toilet,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "XH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -11278,25 +9268,6 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
-"XL" = (
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	pixel_x = 20
-	},
-/obj/structure/closet/secure_closet/guard/breachautomatics,
-/obj/item/ammo_magazine/box/a556,
-/obj/item/ammo_magazine/box/a556,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
-"XM" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
 "XN" = (
 /obj/structure/bed/chair,
 /obj/effect/floor_decal/corner/brown/half{
@@ -11322,25 +9293,6 @@
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
-"XW" = (
-/obj/structure/table/standard,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/zonecommanderoffice)
-"Yf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Yh" = (
 /obj/machinery/floodlight{
 	anchored = 1;
@@ -11367,11 +9319,6 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "Yo" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
 	},
@@ -11398,14 +9345,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
 /area/site53/medical/morgue)
-"YF" = (
-/obj/structure/lattice,
-/obj/structure/cable{
-	d1 = 32;
-	icon_state = "32-1"
-	},
-/turf/simulated/open,
-/area/site53/zonecommanderoffice)
 "YH" = (
 /obj/structure/morgue,
 /obj/machinery/light{
@@ -11435,46 +9374,6 @@
 /obj/effect/paint_stripe/white,
 /turf/simulated/wall/titanium,
 /area/site53/medical/infirmreception)
-"YR" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "facilitylockdown";
-	name = "Exterior Lockdown Blast Door"
-	},
-/obj/machinery/door/blast/shutters/open{
-	begins_closed = 1;
-	id_tag = "EZ Security Shutter";
-	name = "EZ Security Shutter"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/equipmentroom)
-"YT" = (
-/obj/machinery/button/alternate/door/bolts{
-	id_tag = "ezcell2";
-	name = "Cell 2 bolts";
-	pixel_x = -28
-	},
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
-"YU" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/shutters{
-	id_tag = "tribrep"
-	},
-/obj/machinery/door/blast/shutters{
-	id_tag = "tribrep"
-	},
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "facilitylockdown";
-	name = "Exterior Lockdown Blast Door"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "YV" = (
 /obj/effect/paint_stripe/white,
 /obj/structure/table/glass,
@@ -11495,9 +9394,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/repoffice/ethics)
-"Zn" = (
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/equipmentroom)
 "Zp" = (
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/titanium,
@@ -11533,27 +9429,10 @@
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
-"Zx" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/site53/zonecommanderoffice)
 "Zy" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/site53/logistics/logistics)
-"Zz" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/repoffice/internaltribunal)
 "ZG" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -14268,14 +12147,14 @@ dA
 dA
 dA
 dA
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -14525,14 +12404,14 @@ dA
 dA
 dA
 dA
-ty
-RR
-yk
-tB
-tB
-XW
-nh
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -14782,14 +12661,14 @@ dA
 dA
 dA
 dA
-ty
-Td
-Gx
-tB
-tB
-tB
-LF
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -15039,14 +12918,14 @@ dA
 dA
 dA
 dA
-ty
-XM
-tB
-we
-tB
-Ky
-Ac
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -15296,14 +13175,14 @@ dA
 dA
 dA
 dA
-ty
-nv
-tB
-tB
-tB
-Ky
-CF
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -15553,14 +13432,14 @@ dA
 dA
 dA
 dA
-ty
-zI
-tB
-tB
-tB
-tB
-tB
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -15806,24 +13685,24 @@ dA
 dA
 dA
 dA
-ty
-ty
-ty
-ty
-ty
-oZ
-oZ
-Oe
-Oe
-oZ
-oZ
-ty
-ty
-ty
-ty
-ty
-ty
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -16063,24 +13942,24 @@ dA
 dA
 dA
 dA
-ty
-sY
-BA
-MQ
-ty
-aQ
-aQ
-tK
-Jr
-aQ
-aQ
-OE
-ty
-td
-ti
-tn
-to
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -16320,24 +14199,24 @@ dA
 dA
 dA
 dA
-ty
-tB
-tB
-tB
-vK
-Mh
-Mh
-tB
-tB
-Mh
-Mh
-Mh
-QP
-kt
-tB
-rh
-tp
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -16577,24 +14456,24 @@ dA
 dA
 dA
 dA
-ty
-km
-sy
-Dz
-Dz
-Dz
-Li
-Li
-Li
-Li
-Li
-Li
-xn
-Sz
-Dz
-Jv
-tq
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -16832,26 +14711,26 @@ dA
 dA
 dA
 dA
-ty
-ty
-ty
-fV
-rh
-yW
-oZ
-oZ
-aQ
-aQ
-aQ
-aQ
-aQ
-qm
-ty
-te
-tj
-tB
-tr
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -17089,26 +14968,26 @@ dA
 dA
 dA
 dA
-ty
-dX
-sG
-tB
-rh
-tB
-tB
-oZ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-oZ
-tf
-tk
-we
-ts
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -17346,26 +15225,26 @@ dA
 dA
 dA
 dA
-ty
-gz
-sG
-tB
-rh
-tB
-tB
-oZ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-oZ
-tg
-tl
-tB
-tt
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -17603,26 +15482,26 @@ dA
 dA
 dA
 dA
-ty
-oK
-sG
-kR
-rh
-tB
-tB
-oZ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-oZ
-dV
-tB
-tB
-kI
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -17860,26 +15739,26 @@ dA
 dA
 dA
 dA
-ty
-ty
-ty
-ty
-dg
-ty
-ty
-ty
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-oZ
-th
-tm
-tm
-tu
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -18117,26 +15996,26 @@ dA
 dA
 dA
 dA
-ty
-xF
-PM
-gp
-Ls
-YF
-ty
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-oZ
-sQ
-sT
-FQ
-tv
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -18374,26 +16253,26 @@ dA
 dA
 dA
 dA
-ty
-Er
-ft
-Zx
-et
-cC
-ty
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-oZ
-sR
-sU
-sZ
-tw
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -18631,26 +16510,26 @@ dA
 dA
 dA
 dA
-ty
-fp
-eb
-eb
-eb
-mU
-ty
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-ty
-sS
-sV
-qo
-tx
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -18888,26 +16767,26 @@ dA
 dA
 dA
 dA
-ty
-eb
-eb
-eb
-eb
-zw
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -19145,13 +17024,13 @@ dA
 dA
 dA
 dA
-ty
-eb
-gf
-eb
-gf
-Vr
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -19402,13 +17281,13 @@ dA
 dA
 dA
 dA
-ty
-ty
-ty
-ty
-ty
-ty
-ty
+dA
+dA
+dA
+dA
+dA
+dA
+dA
 dA
 dA
 dA
@@ -40728,14 +38607,14 @@ dA
 Ce
 dw
 Ce
-ud
-ud
-Gi
-Gi
-Gi
-Gi
-Gi
-Gi
+oS
+oS
+oS
+oS
+oS
+oS
+oS
+oS
 tb
 Gg
 bk
@@ -40985,14 +38864,14 @@ Ce
 Ce
 dw
 Ce
-ud
-ud
-Gi
-XF
-Zn
-Gi
-XF
-Zn
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 tb
 di
 bk
@@ -41242,14 +39121,14 @@ bq
 GO
 XO
 Ce
-ud
-ud
-Gi
-Hf
-Zn
-Gi
-Hf
-Zn
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 tb
 Gg
 bk
@@ -41499,14 +39378,14 @@ Ce
 Ce
 Ce
 Ce
-Gi
-Gi
-Mq
-Gi
-Fi
-Gi
-Gi
-Wm
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 XJ
 dp
 hp
@@ -41751,19 +39630,19 @@ ed
 cp
 ES
 MX
-dA
-dA
-dA
-dA
-dA
-Gi
-Hq
-Hf
-Gi
-xK
-YT
-LE
-Zn
+oS
+oS
+oS
+oS
+oS
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 XJ
 dq
 dD
@@ -42013,14 +39892,14 @@ mk
 mk
 mk
 mk
-Gi
-Zn
-Zn
-Es
-Yf
-Zn
-Zn
-Yf
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 XJ
 dr
 dD
@@ -42270,14 +40149,14 @@ UI
 UI
 qA
 mk
-Gi
-Gi
-Gi
-Gi
-Gi
-Zn
-UV
-Gi
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 XJ
 dr
 dD
@@ -42527,14 +40406,14 @@ IG
 Vn
 XD
 mk
-Gi
-zP
-lA
-zP
-Am
-Zn
-Zn
-PZ
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 XJ
 dC
 dD
@@ -42784,14 +40663,14 @@ oq
 Gv
 vn
 mk
-Gi
-PR
-wz
-Ux
-Gi
-Bc
-Zn
-eK
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 db
 dD
 dD
@@ -43041,14 +40920,14 @@ Go
 QT
 Az
 mk
-px
-px
-px
-px
-Gi
-RJ
-EJ
-Xq
+oS
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 XJ
 dE
 dD
@@ -43298,14 +41177,14 @@ wJ
 xs
 BY
 mk
-IK
-Va
-Ni
-px
-xa
-Ms
-Zn
-eK
+oS
+oS
+oS
+oS
+rm
+rm
+rm
+oS
 XJ
 hp
 hp
@@ -43555,15 +41434,15 @@ IQ
 rt
 rt
 mk
-px
-px
 HG
-px
-Ak
-Zn
-Zn
-Tn
-Gi
+HG
+HG
+HG
+rm
+rm
+rm
+oS
+oS
 dA
 dA
 dA
@@ -43813,25 +41692,25 @@ lY
 lY
 lY
 lW
-BR
+lH
 mp
-Gi
-Gi
-Zn
-UV
-Gi
-Gi
-Gi
-Gi
-Gi
-Gi
-Gi
-kT
-kT
-kT
-kT
-kT
-kT
+dt
+rm
+rm
+rm
+rm
+oS
+oS
+oS
+oS
+oS
+oS
+oS
+oS
+oS
+oS
+oS
+oS
 dA
 dA
 fF
@@ -44066,29 +41945,29 @@ mz
 mo
 mo
 Yo
-mo
-mo
-mo
+uk
+uk
+uk
 uk
 mr
-mt
-Jt
-Nk
-tY
-tY
-Bf
-tV
-Gi
-Jx
-HL
-Ho
-zc
-kT
-zG
-xW
-Hj
-Vl
-kT
+mx
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 fF
@@ -44327,25 +42206,25 @@ Zv
 Zv
 Zv
 Zp
-ms
-mu
-Jt
-mQ
-mR
-Zn
-Zn
-Zn
-mS
-nA
-xg
-xg
-nA
-tz
-wO
-PS
-PS
-ct
-kT
+lo
+mx
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 fF
@@ -44584,25 +42463,25 @@ lP
 lP
 wj
 Zp
-ms
-mu
-Jt
-BQ
-Zn
-Zn
-uf
-Df
-Df
-nH
-yt
-yt
-nH
-Xv
-PA
-PS
-PS
-KR
-kT
+lo
+mx
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 dA
@@ -44841,25 +42720,25 @@ ok
 ok
 rF
 Zp
-ms
-mu
-Jt
-tL
-Zn
-EJ
-SL
-UE
-Gi
-MA
-mY
-mY
-ni
-kT
-fy
-PS
-PS
-PS
-kT
+lo
+mx
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 fF
 fF
@@ -45098,25 +42977,25 @@ ok
 ok
 rE
 Zp
-ms
-mv
-Gi
-LR
-tN
-tN
-SL
-lI
-Gi
-MA
-mY
-mY
-lS
-kT
-XL
-mf
-Ny
-Hz
-kT
+Uu
+mx
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 fF
 gq
@@ -45355,25 +43234,25 @@ Ga
 ok
 VF
 Zp
-ms
-mu
-tR
-Zn
-ak
-OU
-SL
-ui
-tS
-MA
-mY
-mY
-nt
-kT
-kT
-kT
-kT
-kT
-kT
+lo
+mx
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
+oS
+oS
+oS
+oS
+oS
 dA
 fF
 gq
@@ -45612,20 +43491,20 @@ Iy
 VA
 rC
 Zp
-mw
+lo
 mx
-Df
-uc
-pt
-tE
-SL
-uj
-lC
-tQ
-tQ
-tQ
-lC
-lC
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 dA
@@ -45871,18 +43750,18 @@ lP
 Zp
 tM
 tM
-Gi
-rK
-tU
-tU
-SL
-tX
-tQ
-tW
-Xu
-Xu
-nL
-lC
+dt
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 dA
@@ -46128,18 +44007,18 @@ rG
 Zp
 bS
 bm
-YR
-rJ
-Df
-Df
-ug
-TR
-tQ
-cU
-nu
-nI
-nM
-lC
+bm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 dA
@@ -46374,8 +44253,8 @@ dA
 dA
 dA
 rB
-rs
-ov
+rB
+rB
 rB
 rB
 rB
@@ -46385,18 +44264,18 @@ Zp
 NX
 bO
 ru
-YR
-tH
-Zn
-Zn
-SL
-nn
-tQ
-Vf
-nw
-nJ
-UM
-lC
+bO
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 dA
@@ -46630,30 +44509,30 @@ dA
 dA
 dA
 dA
-rB
-rn
-ng
-Zz
-mC
-mC
-bB
-rB
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+rm
 bm
 bm
 bO
+bO
 bm
-YR
-Rw
-mR
-Zn
-SL
-Zn
-tQ
-Xu
-Ml
-Xu
-ub
-lC
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
 dA
 dA
 oS
@@ -46887,30 +44766,30 @@ dA
 dA
 dA
 dA
-rB
-rn
-ny
-ny
-yI
-yI
-ga
-rB
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+rm
 bC
 bK
 bO
 bO
-YR
-ww
-Ck
-uh
-dP
-TG
-mW
-mZ
-nx
-nK
-nT
-lC
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
+oS
 oS
 oS
 oS
@@ -47144,30 +45023,30 @@ dA
 dA
 dA
 dA
-rB
-MO
-ny
-ny
-lF
-lF
-AR
-kb
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+rm
 bI
 bO
 bO
 bS
-Gi
-Gi
-Gi
-Gi
-eR
-Gi
-lC
-lC
-lC
-lC
-lC
-lC
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+oS
+oS
 oS
 DE
 DE
@@ -47401,28 +45280,28 @@ dA
 dA
 dA
 dA
-rB
-mF
-ny
-ny
-qb
-ny
-rn
-YU
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+rm
 bJ
 bO
 aK
 bO
 rm
-oS
-Gi
-zP
-zP
-zP
-Gi
-dA
-dA
-dA
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 oS
 oS
@@ -47658,28 +45537,28 @@ dA
 dA
 dA
 dA
-rB
-NM
-ny
-ny
-Dn
-ox
-QG
-rB
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+rm
 ru
 bI
 bX
 bO
 rm
-oS
-Gi
-dd
-zP
-fi
-Gi
-dA
-dA
-dA
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 oS
 oS
@@ -47915,28 +45794,28 @@ dA
 dA
 dA
 dA
-rB
-JR
-ny
-ny
-dc
-mE
-mD
-rB
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+rm
 bI
 rm
 bO
 bO
 rm
-oS
-Gi
-zP
-dv
-zP
-Gi
-dA
-dA
-dA
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 DE
 DE
@@ -48172,28 +46051,28 @@ dA
 dA
 dA
 dA
-rB
-ND
-rn
-rn
-od
-rn
-rn
-rB
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+rm
 rm
 rm
 rm
 bO
 rm
-oS
-Gi
-Gi
-Gi
-dW
-Gi
-dA
-dA
-dA
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 DE
 Io
@@ -48429,27 +46308,27 @@ dA
 dA
 dA
 dA
-rB
-rB
-rB
-rB
-rB
-rB
-rB
-mG
+dA
+dA
+dA
+dA
+dA
+dA
+oS
+oS
 oS
 rm
 rm
 rm
 rm
-oS
-Gi
-df
-dy
-zP
-Gi
-dA
-dA
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 oS
 DE
@@ -48699,14 +46578,14 @@ oS
 rm
 rm
 rm
-oS
-dk
-zP
-zP
-zP
-Gi
-dA
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 rm
 DE
@@ -48956,14 +46835,14 @@ oS
 rm
 rm
 rm
-oS
-Gi
-fo
-fs
-fA
-Gi
-oS
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 rm
 rm
 DE
@@ -49213,13 +47092,13 @@ oS
 oS
 rm
 rm
-oS
-Gi
-Gi
-Gi
-Gi
-Gi
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 rm
 rm
 GK
@@ -49470,13 +47349,13 @@ dA
 oS
 rm
 rm
-oS
-oS
-oS
-oS
-oS
-oS
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 rm
 bS
 jg

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -4556,6 +4556,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
+"lZ" = (
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/entrancezone/hallway)
 "ma" = (
 /obj/machinery/door/airlock/glass/civilian{
 	name = "Hub"
@@ -4655,7 +4661,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
 "mp" = (
-/obj/effect/floor_decal/corner/red/border{
+/obj/effect/floor_decal/corner/orange/border{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -4714,7 +4720,9 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/surface/surface)
 "mJ" = (
-/obj/effect/floor_decal/corner/orange/border,
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 6
+	},
 /obj/structure/cable/green{
 	icon_state = "2-8"
 	},
@@ -8520,6 +8528,12 @@
 "Qn" = (
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"Qp" = (
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/entrancezone/hallway)
 "Qq" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -43482,8 +43496,8 @@ Iy
 VA
 rC
 Zp
-lo
-mx
+lZ
+Qp
 dt
 rm
 rm
@@ -43987,7 +44001,7 @@ nY
 dA
 dA
 dt
-lo
+lZ
 mJ
 nr
 Zh

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -1997,7 +1997,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/site53/uez/commandpanicbunker)
 "fg" = (
 /obj/structure/bed/chair/comfy/blue{
@@ -4346,6 +4346,15 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
+"mL" = (
+/obj/item/clothing/gloves/latex/nitrile,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/clothing/suit/surgicalapron,
+/obj/item/clothing/mask/surgical,
+/obj/structure/table/rack,
+/obj/item/defibrillator/loaded,
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "mM" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
@@ -4375,6 +4384,9 @@
 /obj/item/deck/cards,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
+"mU" = (
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "mV" = (
 /obj/machinery/power/apc/hyper{
 	dir = 1
@@ -4653,6 +4665,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
+"pt" = (
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/trauma,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/toxin,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/machinery/camera/network/scp049{
+	dir = 4;
+	name = "SCP-049 Medical Storage"
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "pI" = (
 /obj/structure/table/rack,
 /obj/item/melee/baton/loaded,
@@ -4696,6 +4728,13 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
+"pM" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
 "pN" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -4861,13 +4900,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
 "qS" = (
-/obj/effect/paint_stripe/blue,
-/obj/machinery/button/blast_door{
-	id_tag = "PANIC SHIELD";
-	name = "PANIC SHIELD"
-	},
-/turf/simulated/wall/titanium,
-/area/site53/uez/commandpanicbunker)
+/obj/structure/table/standard,
+/obj/item/storage/box/freezer,
+/obj/item/storage/box/bodybags,
+/obj/item/device/radio,
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "ra" = (
 /obj/structure/bed/padded,
 /obj/structure/curtain/open/bed,
@@ -5066,6 +5104,10 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
+"sM" = (
+/obj/machinery/smartfridge/chemistry,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "sO" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -5716,6 +5758,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"yo" = (
+/obj/structure/iv_drip,
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "yq" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -5790,6 +5836,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
+"yR" = (
+/obj/machinery/chemical_dispenser/full,
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "yT" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -6054,6 +6104,12 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
+"AH" = (
+/obj/machinery/vending/medical{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "AL" = (
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/commandpanicbunker)
@@ -6227,6 +6283,13 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/site53/uez/equipmentroom)
+"Cn" = (
+/obj/machinery/reagentgrinder,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "Cq" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -6563,16 +6626,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
 "Ff" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/exoplanet/barren,
+/obj/effect/paint_stripe/blue,
+/obj/effect/paint_stripe/blue,
+/turf/simulated/wall/titanium,
 /area/site53/uez/commandpanicbunker)
 "Fo" = (
 /obj/structure/table/standard,
@@ -6904,7 +6960,7 @@
 	id_tag = "evacbunker";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white,
 /area/site53/uez/commandpanicbunker)
 "Ir" = (
 /obj/structure/cable/green{
@@ -7160,6 +7216,20 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
+"KH" = (
+/obj/structure/table/standard,
+/obj/machinery/reagent_temperature/cooler{
+	pixel_x = 7
+	},
+/obj/machinery/reagent_temperature{
+	pixel_x = -7
+	},
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/item/stack/material/phoron/ten,
+/obj/item/stack/material/phoron/ten,
+/obj/item/stack/material/phoron/ten,
+/turf/simulated/floor/tiled/monotile/white,
+/area/space)
 "KM" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -7314,7 +7384,15 @@
 /area/site53/logistics/logisticsbreak)
 "LP" = (
 /obj/structure/table/standard,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
 /obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
 /turf/simulated/floor/tiled/white,
 /area/site53/uez/commandpanicbunker)
 "LT" = (
@@ -7635,6 +7713,13 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uez/commandpanicbunker)
+"OR" = (
+/obj/machinery/organ_printer/flesh/mapped,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "OS" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/yellow/mono,
@@ -7698,8 +7783,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/button/blast_door{
 	dir = 4;
-	id_tag = "Panic Room Gate East";
-	name = "Panic Room Gate East";
+	id_tag = "Panic Room Gate West";
+	name = "Panic Room Gate West";
 	pixel_x = -6;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
@@ -7729,7 +7814,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/obj/item/storage/firstaid/surgery,
+/turf/simulated/floor/tiled/white,
 /area/site53/uez/commandpanicbunker)
 "Pl" = (
 /obj/structure/closet/crate/bin{
@@ -8767,9 +8853,24 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/uez/commandpanicbunker)
 "XG" = (
-/obj/structure/table/standard,
-/obj/item/roller,
-/turf/simulated/floor/tiled/white,
+/obj/structure/table/rack,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/trauma,
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/toxin,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/item/reagent_containers/ivbag/blood/OMinus,
+/obj/machinery/camera/network/scp049{
+	dir = 4;
+	name = "SCP-049 Medical Storage"
+	},
+/turf/simulated/floor/tiled/old_tile,
 /area/site53/uez/commandpanicbunker)
 "XJ" = (
 /obj/structure/table/standard,
@@ -8931,6 +9032,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
+"Zf" = (
+/obj/machinery/chem_master,
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "Zj" = (
 /obj/structure/table/standard,
 /obj/machinery/button/blast_door{
@@ -9044,6 +9149,25 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
+"ZK" = (
+/obj/structure/closet/secure_closet/freezer{
+	icon = 'icons/obj/closets/fridge.dmi';
+	name = "Secure Freezer"
+	},
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/lungs,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/liver,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/heart,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/obj/item/organ/internal/kidneys,
+/turf/simulated/floor/tiled/old_tile,
+/area/space)
 "ZM" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -29659,10 +29783,10 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
+OR
+mU
+AH
+pt
 hk
 hk
 hk
@@ -29916,10 +30040,10 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
+qS
+mU
+mU
+ZK
 hk
 hk
 hk
@@ -30173,10 +30297,10 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
+KH
+mU
+mU
+mL
 hk
 hk
 hk
@@ -30430,10 +30554,10 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
+sM
+yR
+Zf
+Cn
 hk
 hk
 hk
@@ -30691,7 +30815,7 @@ hk
 hk
 hk
 hk
-hk
+yo
 hk
 hk
 fo
@@ -30720,9 +30844,9 @@ fo
 fo
 fo
 fo
-hk
-hk
-hk
+fo
+fo
+fo
 hk
 hk
 hk
@@ -30973,13 +31097,13 @@ EC
 Bv
 cB
 EC
+EC
+EC
+EC
 CT
 qI
 fn
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -31227,16 +31351,16 @@ Gp
 UI
 sC
 EC
+EC
+EC
 VU
+EC
 EC
 EC
 mf
 ph
 fo
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -31483,17 +31607,17 @@ EC
 zH
 EC
 Kv
+EC
+EC
 xK
 eL
 VA
+EC
 EC
 AL
 nl
 fn
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -31740,17 +31864,17 @@ Ef
 fo
 AG
 Kv
+EC
+EC
 xK
 fu
 VA
+EC
 EC
 us
 Lw
 fo
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -31998,16 +32122,16 @@ fo
 SL
 Kv
 EC
+EC
+EC
 tE
+EC
 EC
 EC
 Od
 Gw
 fn
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -32258,13 +32382,13 @@ EC
 EC
 EC
 EC
+EC
+EC
+EC
 sj
 rD
 fo
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -32512,16 +32636,16 @@ Lq
 EJ
 Kv
 EC
+EC
+EC
 VU
+EC
 EC
 EC
 qj
 nR
 fn
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -32768,17 +32892,17 @@ AL
 uZ
 QU
 Kv
+EC
+EC
 xK
 fu
 VA
+EC
 EC
 TL
 tC
 fo
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -33025,17 +33149,17 @@ qm
 Ba
 Qy
 Ek
+EC
+EC
 xK
 BG
 VA
+EC
 EC
 Wp
 ne
 fn
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -33283,16 +33407,16 @@ Ls
 Ir
 WW
 EC
+EC
+EC
 tE
+EC
 EC
 EC
 Hp
 xq
 fo
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -33543,13 +33667,13 @@ EC
 EC
 EC
 EC
+EC
+EC
+EC
 QI
 RL
 fn
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -33800,13 +33924,13 @@ Vh
 oS
 Bc
 xu
+EC
+EC
+EC
 CL
 rN
 fo
 fo
-hk
-hk
-hk
 hk
 hk
 hk
@@ -34061,9 +34185,9 @@ fo
 fo
 fo
 fo
-hk
-hk
-hk
+fo
+fo
+fo
 hk
 hk
 hk
@@ -35855,9 +35979,9 @@ vq
 fo
 fo
 fo
-hk
-hk
-hk
+wX
+wX
+wX
 hk
 hk
 hk
@@ -36102,19 +36226,19 @@ ZO
 ZO
 mx
 cX
-hk
-hk
-hk
-hk
+wX
+Ff
+Ff
+fo
 fo
 fo
 vq
 fo
 fo
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+wX
 hk
 ac
 cl
@@ -36359,19 +36483,19 @@ ZO
 pI
 Ey
 cX
-hk
+wX
 fo
+OM
+OM
+pM
+OM
+Ta
+OM
+pM
+OM
+OM
 fo
-fo
-fo
-Zl
-ee
-Zl
-fo
-fo
-fo
-fo
-hk
+wX
 hk
 ac
 dd
@@ -36616,19 +36740,19 @@ ZO
 nr
 uS
 cX
-hk
+wX
 fo
 Th
 mN
-Ff
+mN
 mN
 lC
 mN
-Ff
+mN
 mN
 Ex
-qS
-hk
+fo
+wX
 hk
 ac
 Pr
@@ -36873,7 +36997,7 @@ ZO
 nr
 nh
 cX
-hk
+wX
 fo
 IG
 YI
@@ -36885,7 +37009,7 @@ OM
 YI
 qd
 fo
-hk
+wX
 hk
 ac
 AC
@@ -37130,7 +37254,7 @@ ht
 RF
 SA
 cX
-hk
+wX
 wX
 wX
 wX
@@ -37142,7 +37266,7 @@ CJ
 wX
 wX
 wX
-hk
+wX
 hk
 ac
 dg

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -1177,7 +1177,7 @@
 /area/site53/uez/hallway)
 "cX" = (
 /obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/prepainted,
 /area/site53/uez/equipmentroom)
 "cY" = (
 /obj/machinery/light{
@@ -1463,7 +1463,7 @@
 /area/site53/uez/commandpanicbunker)
 "dK" = (
 /obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/prepainted,
 /area/site53/uez/repoffice/internaltribunal)
 "dL" = (
 /obj/structure/cable/green{
@@ -1990,13 +1990,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
 "fd" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
 "fe" = (
 /obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/prepainted,
 /area/site53/entrancezone/forensics)
 "ff" = (
 /obj/structure/table/standard,
@@ -4190,7 +4190,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
 "lp" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/boombox,
 /obj/item/device/megaphone,
 /turf/simulated/floor/tiled/dark,
@@ -4317,7 +4317,7 @@
 "mr" = (
 /obj/effect/paint_stripe/red,
 /obj/machinery/status_display,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/prepainted,
 /area/site53/uez/equipmentroom)
 "ms" = (
 /obj/effect/floor_decal/corner/brown{
@@ -4354,15 +4354,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
-"mL" = (
-/obj/item/clothing/gloves/latex/nitrile,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/item/clothing/suit/surgicalapron,
-/obj/item/clothing/mask/surgical,
-/obj/structure/table/rack,
-/obj/item/defibrillator/loaded,
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "mM" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
@@ -4392,9 +4383,6 @@
 /obj/item/deck/cards,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
-"mU" = (
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "mV" = (
 /obj/machinery/power/apc/hyper{
 	dir = 1
@@ -4437,7 +4425,7 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/commandpanicbunker)
 "nk" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/photocopier,
 /obj/machinery/light{
 	dir = 4
@@ -4453,7 +4441,7 @@
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/commandpanicbunker)
 "np" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/photocopier,
 /obj/machinery/light{
 	dir = 8
@@ -4536,7 +4524,7 @@
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/commandpanicbunker)
 "nT" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/tape,
 /obj/item/device/tape,
 /obj/item/device/taperecorder,
@@ -4677,26 +4665,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
-"pt" = (
-/obj/structure/table/rack,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/trauma,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/o2,
-/obj/item/storage/firstaid/fire,
-/obj/item/storage/firstaid/toxin,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/item/reagent_containers/ivbag/blood/OMinus,
-/obj/machinery/camera/network/scp049{
-	dir = 4;
-	name = "SCP-049 Medical Storage"
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "pI" = (
 /obj/structure/table/rack,
 /obj/item/melee/baton/loaded,
@@ -4843,7 +4811,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "qE" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/button/blast_door{
 	dir = 4;
 	id_tag = "EZ Lobby Lockdown";
@@ -4875,7 +4843,7 @@
 	department = "Guard Commander's Office";
 	send_access = list("ACCESS_SECURITY_LEVEL5")
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/uez/equipmentroom)
 "qI" = (
@@ -4911,13 +4879,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
-"qS" = (
-/obj/structure/table/standard,
-/obj/item/storage/box/freezer,
-/obj/item/storage/box/bodybags,
-/obj/item/device/radio,
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "qZ" = (
 /obj/machinery/button/blast_door{
 	dir = 1;
@@ -5126,10 +5087,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
-"sM" = (
-/obj/machinery/smartfridge/chemistry,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "sO" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -5167,7 +5124,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
 "th" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/implanter,
 /obj/item/folder/yellow,
 /obj/item/implantcase/death_alarm,
@@ -5238,7 +5195,7 @@
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
 "ua" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -5490,7 +5447,7 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
 "vU" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -5532,7 +5489,7 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/uez/commandpanicbunker)
 "wi" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/tape,
 /obj/item/device/tape,
 /obj/item/device/tape,
@@ -5591,7 +5548,7 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
 "wP" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -5761,6 +5718,7 @@
 /obj/item/ammo_magazine/scp/mk9,
 /obj/item/gun/projectile/pistol/mk9,
 /obj/item/gun/projectile/pistol/mk9,
+/obj/item/gun/projectile/pistol/mk9,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "xX" = (
@@ -5783,10 +5741,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
-"yo" = (
-/obj/structure/iv_drip,
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "yq" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -5848,7 +5802,7 @@
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "yN" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/storage/mre/random,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
@@ -5861,10 +5815,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
-"yR" = (
-/obj/machinery/chemical_dispenser/full,
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "yT" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -6057,7 +6007,7 @@
 /area/site53/uez/commandpanicbunker)
 "Aa" = (
 /obj/item/device/flashlight/lamp,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
 "Ar" = (
@@ -6091,6 +6041,7 @@
 	pixel_y = -23;
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
+/obj/item/gun/projectile/pistol/usp45,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "Av" = (
@@ -6129,12 +6080,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
-"AH" = (
-/obj/machinery/vending/medical{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "AL" = (
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/commandpanicbunker)
@@ -6149,7 +6094,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "AO" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/door/window/brigdoor/westleft{
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
@@ -6187,7 +6132,7 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
 "AZ" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -6225,7 +6170,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "Bq" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/recharger,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
@@ -6314,13 +6259,6 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/site53/uez/equipmentroom)
-"Cn" = (
-/obj/machinery/reagentgrinder,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "Cq" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -6341,13 +6279,6 @@
 "Cy" = (
 /obj/structure/table/rack,
 /obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/ammo_magazine/box/a357,
-/obj/item/gun/projectile/revolver/rhino,
-/obj/item/gun/projectile/revolver/rhino,
 /obj/item/gun/projectile/revolver/rhino,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
@@ -6379,7 +6310,7 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
 "CG" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/implanter,
 /obj/item/folder/yellow,
 /obj/item/implantcase/death_alarm,
@@ -6416,7 +6347,7 @@
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/commandpanicbunker)
 "CR" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
 /obj/item/device/camera,
 /turf/simulated/floor/tiled/dark,
@@ -6425,7 +6356,7 @@
 /turf/simulated/floor/carpet/red,
 /area/site53/uez/commandpanicbunker)
 "De" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/storage/firstaid/combat,
 /obj/item/storage/firstaid/combat,
 /obj/item/storage/firstaid/combat,
@@ -6505,7 +6436,7 @@
 /area/site53/uez/maintenance)
 "Dy" = (
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/carpet/red,
 /area/site53/uez/equipmentroom)
 "DA" = (
@@ -7061,7 +6992,7 @@
 /area/site53/uez/equipmentroom)
 "IV" = (
 /obj/effect/paint_stripe/red,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/prepainted,
 /area/site53/uez/armory)
 "Je" = (
 /obj/structure/table/standard,
@@ -7069,7 +7000,7 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
 "Jl" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -7149,7 +7080,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
 "Ke" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -7158,7 +7089,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "Kg" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "Kk" = (
@@ -7253,20 +7184,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
-"KH" = (
-/obj/structure/table/standard,
-/obj/machinery/reagent_temperature/cooler{
-	pixel_x = 7
-	},
-/obj/machinery/reagent_temperature{
-	pixel_x = -7
-	},
-/obj/effect/floor_decal/corner/yellow/mono,
-/obj/item/stack/material/phoron/ten,
-/obj/item/stack/material/phoron/ten,
-/obj/item/stack/material/phoron/ten,
-/turf/simulated/floor/tiled/monotile/white,
-/area/space)
 "KM" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -7279,7 +7196,7 @@
 /area/site53/uez/commandpanicbunker)
 "KP" = (
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
 "KS" = (
@@ -7287,7 +7204,7 @@
 	department = "Guard Commander's Office";
 	send_access = list("ACCESS_SECURITY_LEVEL5")
 	},
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
 "KY" = (
@@ -7312,7 +7229,7 @@
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "Lo" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/photocopier,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
@@ -7456,7 +7373,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
 "Mm" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
@@ -7757,13 +7674,6 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uez/commandpanicbunker)
-"OR" = (
-/obj/machinery/organ_printer/flesh/mapped,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "OS" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/yellow/mono,
@@ -7789,7 +7699,7 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
 "OZ" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
@@ -7851,7 +7761,7 @@
 	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"));
 	name = "HCZCrematorium"
 	},
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/prepainted,
 /area/site53/uez/equipmentroom)
 "Pk" = (
 /obj/structure/table/standard,
@@ -7907,10 +7817,7 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/uez/commandpanicbunker)
 "PM" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
+/obj/structure/table/steel,
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/adv,
 /obj/item/storage/firstaid/adv,
@@ -7934,13 +7841,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
 "PT" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
 "PV" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/photocopier,
 /obj/machinery/light{
 	dir = 8
@@ -8457,7 +8364,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "TG" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -8574,7 +8481,7 @@
 /turf/simulated/floor,
 /area/site53/logistics/logisticsbreak)
 "UH" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/suit/straight_jacket,
@@ -8697,11 +8604,11 @@
 /area/site53/uez/commandpanicbunker)
 "VE" = (
 /obj/item/device/flashlight/lamp,
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/carpet/red,
 /area/site53/uez/equipmentroom)
 "VF" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/deck/cards,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
@@ -8805,7 +8712,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/equipmentroom)
 "WK" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/carpet/red,
@@ -8865,7 +8772,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
 "WZ" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -8917,7 +8824,7 @@
 /turf/simulated/floor/tiled/old_tile,
 /area/site53/uez/commandpanicbunker)
 "XJ" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/tiled/dark,
@@ -8987,7 +8894,7 @@
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/commandpanicbunker)
 "Yi" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/photocopier,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
@@ -9001,7 +8908,7 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/equipmentroom)
 "Yl" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/item/device/flashlight/lamp,
 /obj/item/device/taperecorder,
 /turf/simulated/floor/tiled/techfloor,
@@ -9069,19 +8976,15 @@
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
 "Zd" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/photocopier,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
-"Zf" = (
-/obj/machinery/chem_master,
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
 "Zj" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/button/blast_door{
 	dir = 4;
 	id_tag = "EZ Brig CR Windows";
@@ -9128,7 +9031,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "Zu" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /obj/machinery/button/blast_door{
 	dir = 4;
 	id_tag = "EZ Brig Iso Entry";
@@ -9190,28 +9093,13 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
 "ZJ" = (
-/obj/structure/table/standard,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
 "ZK" = (
-/obj/structure/closet/secure_closet/freezer{
-	icon = 'icons/obj/closets/fridge.dmi';
-	name = "Secure Freezer"
-	},
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/lungs,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/liver,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/heart,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/obj/item/organ/internal/kidneys,
-/turf/simulated/floor/tiled/old_tile,
-/area/space)
+/obj/effect/paint_stripe/blue,
+/turf/simulated/wall/prepainted,
+/area/site53/uez/hallway)
 "ZM" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -29827,10 +29715,10 @@ hk
 hk
 hk
 hk
-OR
-mU
-AH
-pt
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -30084,10 +29972,10 @@ hk
 hk
 hk
 hk
-qS
-mU
-mU
-ZK
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -30341,10 +30229,10 @@ hk
 hk
 hk
 hk
-KH
-mU
-mU
-mL
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -30598,10 +30486,10 @@ hk
 hk
 hk
 hk
-sM
-yR
-Zf
-Cn
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -30859,7 +30747,7 @@ hk
 hk
 hk
 hk
-yo
+hk
 hk
 hk
 fo
@@ -39869,7 +39757,7 @@ cX
 cX
 cX
 cX
-ac
+ZK
 hA
 vR
 zg

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -347,6 +347,11 @@
 	name = "Director Bodyguard Checkpoint";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "UEZ Checkpoint Access Point";
+	name = "UEZ Checkpoint Access Point";
+	begins_closed = 0
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
 "aT" = (
@@ -976,16 +981,11 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/substation)
 "cB" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/vending/wallmed1{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/exoplanet/barren,
+/turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
 "cC" = (
 /obj/structure/cable/green{
@@ -1933,6 +1933,12 @@
 /obj/structure/cable/green{
 	icon_state = "4-8"
 	},
+/obj/machinery/button/blast_door{
+	id_tag = "sitedirect";
+	name = "Panic Bunker Access";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
 "eV" = (
@@ -1952,6 +1958,12 @@
 	name = "EZ Bridge Windows Shutter";
 	pixel_y = 2;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "UEZ Checkpoint Access Point";
+	name = "UEZ Checkpoint Access Point";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
@@ -2047,11 +2059,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/hallway)
 "fq" = (
-/obj/structure/closet,
-/obj/item/reagent_containers/food/drinks/glass2/coffeecup,
-/obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/obj/item/storage/mre/random,
-/obj/item/storage/mre/random,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/uez/commandpanicbunker)
@@ -2520,11 +2527,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "gx" = (
@@ -2696,6 +2698,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
+"hw" = (
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
 "hA" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -4848,9 +4857,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
 "qS" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/site53/entrancezone/forensics)
+/obj/effect/paint_stripe/blue,
+/obj/machinery/button/blast_door{
+	id_tag = "PANIC SHIELD";
+	name = "PANIC SHIELD"
+	},
+/turf/simulated/wall/titanium,
+/area/site53/uez/commandpanicbunker)
 "ra" = (
 /obj/structure/bed/padded,
 /obj/structure/curtain/open/bed,
@@ -6026,16 +6039,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
-"AI" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/hyper{
-	dir = 1
-	},
-/turf/simulated/floor/lino,
-/area/site53/uez/hallway)
 "AL" = (
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/commandpanicbunker)
@@ -7260,6 +7263,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
+"LF" = (
+/obj/machinery/vending/wallmed1{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/hallway)
 "LL" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -7319,20 +7329,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
-"Md" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/exoplanet/barren,
-/area/site53/uez/commandpanicbunker)
 "Mm" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -7996,13 +7992,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/gloves/insulated,
-/obj/item/stack/cable_coil/green,
-/obj/item/stack/cable_coil/green,
-/obj/item/stack/cable_coil/green,
-/obj/item/wirecutters,
 /turf/simulated/floor/plating,
 /area/site53/uez/commandpanicbunker)
 "RK" = (
@@ -8234,6 +8223,10 @@
 	icon_state = "2-4"
 	},
 /obj/effect/catwalk_plated/dark,
+/obj/item/stack/cable_coil/green,
+/obj/item/clothing/gloves/insulated,
+/obj/item/crowbar,
+/obj/item/wirecutters,
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uez/commandpanicbunker)
 "Tk" = (
@@ -8336,6 +8329,13 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/commandpanicbunker)
+"TM" = (
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
+	pixel_y = 28
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "TO" = (
 /obj/structure/bed/chair/padded/black{
 	dir = 8
@@ -8753,11 +8753,8 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/commandpanicbunker)
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/hallway)
 "XB" = (
 /obj/machinery/vitals_monitor,
 /turf/simulated/floor/tiled/white,
@@ -8897,12 +8894,12 @@
 /area/site53/uez/equipmentroom)
 "YI" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/shieldwallgen/online,
+/obj/machinery/shieldwallgen/online{
+	max_range = 10;
+	req_access = list();
+	storedpower = 50000
+	},
 /turf/simulated/floor/plating,
 /area/site53/uez/commandpanicbunker)
 "YJ" = (
@@ -30967,7 +30964,7 @@ zA
 Vx
 EC
 Bv
-EC
+cB
 EC
 CT
 qI
@@ -31209,10 +31206,10 @@ EC
 EC
 Bv
 EC
-EC
+cB
 Bv
 EC
-Xj
+Bv
 EC
 EC
 Bv
@@ -35042,7 +35039,7 @@ hk
 hk
 hk
 cX
-ZO
+TM
 ZO
 AN
 mS
@@ -36602,7 +36599,7 @@ ZO
 pL
 Gn
 cX
-ZO
+TM
 dU
 YO
 cX
@@ -36615,15 +36612,15 @@ cX
 hk
 fo
 Th
-Md
+mN
 Ff
 mN
 lC
 mN
 Ff
-cB
+mN
 Ex
-fo
+qS
 hk
 hk
 ac
@@ -38915,7 +38912,7 @@ cX
 cX
 cX
 cX
-ZO
+TM
 dU
 zm
 zm
@@ -39192,7 +39189,7 @@ vR
 ac
 ov
 cm
-cd
+LF
 vj
 dk
 ac
@@ -40192,7 +40189,7 @@ fe
 ca
 Yl
 sa
-qS
+Nb
 XJ
 GR
 ws
@@ -40449,7 +40446,7 @@ fe
 Ht
 jF
 Ht
-qS
+Nb
 wi
 zt
 nk
@@ -40480,7 +40477,7 @@ cr
 cv
 Wq
 cY
-cg
+Xj
 dx
 ac
 bK
@@ -42008,7 +42005,7 @@ ac
 ac
 ac
 ac
-AI
+bK
 gw
 cH
 Ry
@@ -43281,7 +43278,7 @@ hk
 hk
 hk
 dF
-YJ
+hw
 gT
 hp
 hp

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -5052,6 +5052,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "EZ Security Secure Armoury";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "sC" = (
@@ -5184,17 +5188,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
-"uf" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "EZ Armoury Lockdown";
-	name = "EZ Armoury Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/armory)
-"uk" = (
-/turf/simulated/floor/tiled/dark,
-/area/site53/uez/armory)
 "ul" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/freezer,
@@ -5288,6 +5281,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "EZ Security Secure Armoury";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
@@ -8432,14 +8429,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
-"Uy" = (
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "EZ Armoury Lockdown";
-	name = "EZ Armoury Lockdown"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uez/armory)
 "UF" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
@@ -33537,7 +33526,7 @@ hk
 IV
 IV
 IV
-uf
+IV
 sy
 IV
 IV
@@ -33793,8 +33782,8 @@ cX
 hk
 hk
 hk
+hk
 IV
-uk
 KG
 IV
 hk
@@ -34051,7 +34040,7 @@ hk
 hk
 hk
 IV
-Uy
+IV
 vd
 IV
 hk

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -4517,11 +4517,6 @@
 	req_access = list("ACCESS_ADMIN_LEVEL3");
 	name = "Panic Chamber CR"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/plating,
 /area/site53/uez/commandpanicbunker)
 "nX" = (
@@ -5090,6 +5085,11 @@
 /area/site53/uez/commandpanicbunker)
 "tp" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/repoffice/internaltribunal)
 "tv" = (
@@ -5561,6 +5561,11 @@
 /obj/machinery/camera/autoname{
 	dir = 8;
 	network = list("Entrance Zone Network")
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
@@ -6781,14 +6786,13 @@
 /turf/simulated/wall/titanium,
 /area/site53/uez/commandpanicbunker)
 "Hv" = (
-/obj/effect/paint_stripe/yellow,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/prepainted,
-/area/site53/uez/maintenance)
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
 "Hy" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/teargas,
@@ -6884,19 +6888,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/uez/commandpanicbunker)
-"Ip" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
 "Ir" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7490,6 +7481,11 @@
 /obj/structure/bed/chair/padded/black{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/repoffice/internaltribunal)
 "Nt" = (
@@ -7796,7 +7792,7 @@
 "PR" = (
 /obj/machinery/door/airlock/command{
 	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4s")
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/senioragentoffice)
@@ -7925,8 +7921,8 @@
 /area/site53/uez/equipmentroom)
 "Rc" = (
 /obj/machinery/door/airlock/command{
-	name = "Zone Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL4s")
+	name = "Guard Commander Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
@@ -8003,6 +7999,10 @@
 /obj/item/crowbar,
 /obj/item/wrench,
 /obj/item/clothing/gloves/insulated,
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/green,
+/obj/item/stack/cable_coil/green,
+/obj/item/wirecutters,
 /turf/simulated/floor/plating,
 /area/site53/uez/commandpanicbunker)
 "RK" = (
@@ -8896,17 +8896,13 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/equipmentroom)
 "YI" = (
-/obj/machinery/shieldwallgen/online{
-	max_range = 10;
-	req_access = list();
-	storedpower = 50000
-	},
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
+/obj/machinery/shieldwallgen/online,
 /turf/simulated/floor/plating,
 /area/site53/uez/commandpanicbunker)
 "YJ" = (
@@ -40210,8 +40206,8 @@ JM
 Vp
 Nr
 tp
-nG
-nG
+Hv
+Hv
 Mo
 dK
 vR
@@ -41278,7 +41274,7 @@ dv
 dv
 dv
 dv
-Hv
+dv
 dv
 dv
 dv
@@ -41535,7 +41531,7 @@ fw
 fw
 fw
 fw
-Ip
+fw
 fP
 fw
 fw

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -3,10 +3,6 @@
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/upper_surface/maincontrolroom)
-"ab" = (
-/obj/effect/paint_stripe/blue,
-/turf/simulated/wall/titanium,
-/area/space)
 "ac" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/titanium,
@@ -170,7 +166,7 @@
 /area/site53/uez/bridge)
 "aw" = (
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
 "ax" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -313,6 +309,11 @@
 	id_tag = "sitedirect";
 	name = "Administrative Offices Lockdown"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
 "aQ" = (
@@ -358,7 +359,19 @@
 /turf/simulated/floor/tiled,
 /area/site53/upper_surface/maincontrolroom)
 "aV" = (
-/turf/simulated/floor/wood,
+/obj/machinery/camera/autoname{
+	network = list("Entrance Zone Network")
+	},
+/obj/structure/bed/chair/office/comfy,
+/obj/effect/landmark/start{
+	name = "Head of Personnel"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "aW" = (
 /obj/item/modular_computer/console/preset/cardslot/command{
@@ -456,7 +469,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "bm" = (
 /obj/effect/floor_decal/corner/blue/border,
@@ -476,18 +489,28 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/upper_surface/maincontrolroom)
 "bp" = (
-/obj/machinery/camera/autoname{
-	network = list("Entrance Zone Network")
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Lobby Outter Lockdown";
+	name = "EZ Lobby Outter Lockdown";
+	begins_closed = 0
 	},
-/turf/simulated/floor/carpet/brown,
-/area/site53/uez/hallway)
+/obj/machinery/door/airlock/multi_tile/glass/security{
+	dir = 8;
+	icon_state = "closed";
+	name = "EZ Security Center";
+	req_access = list("ACCESS_SECURITY_LEVEL1");
+	id_tag = "EZBrigLobbyEntry"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "bq" = (
 /obj/structure/table/woodentable,
 /obj/machinery/photocopier/faxmachine{
 	department = "Head of Personnel's Office";
 	send_access = list("ACCESS_ADMIN_LEVEL4")
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "br" = (
 /turf/simulated/floor/wood,
@@ -603,7 +626,7 @@
 "bF" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/exoplanet/grass,
-/area/space)
+/area/site53/uez/hallway)
 "bG" = (
 /obj/machinery/light{
 	dir = 4
@@ -612,13 +635,17 @@
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "bH" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/brown,
-/area/site53/uez/hallway)
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "bI" = (
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/filingcabinet,
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "bJ" = (
@@ -633,9 +660,14 @@
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "bL" = (
-/obj/structure/closet/crate/rcd,
-/turf/simulated/floor/plating,
-/area/site53/uez/hallway)
+/obj/machinery/button/alternate/door{
+	dir = 1;
+	id_tag = "EZBrigLobbyEntry";
+	name = "EZ Brig Entry Airlock";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "bM" = (
 /obj/structure/closet/crate/secure/biohazard{
 	req_access = list("ACCESS_SCIENCE_LEVEL1")
@@ -644,12 +676,12 @@
 /area/site53/uez/hallway)
 "bN" = (
 /obj/structure/filingcabinet,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "bO" = (
 /obj/structure/flora/bush,
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
 "bP" = (
 /obj/structure/bed/chair{
 	dir = 1
@@ -657,23 +689,20 @@
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
 "bQ" = (
-/obj/structure/table/woodentable,
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/turf/simulated/floor/carpet/brown,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
 "bR" = (
-/obj/effect/landmark/start{
-	name = "Head of Personnel"
-	},
-/obj/structure/bed/chair/office/comfy{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/brown,
-/area/site53/uez/hallway)
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed/chair/padded/black,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "bS" = (
-/obj/machinery/light/small/red,
-/turf/simulated/floor/plating,
-/area/site53/uez/hallway)
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
 "bT" = (
 /obj/machinery/light/small/red{
 	dir = 4;
@@ -686,13 +715,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "bV" = (
 /obj/structure/closet/secure_closet/hop{
 	req_access = list("ACCESS_ADMIN_LEVEL1")
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "bW" = (
 /obj/structure/table/woodentable,
@@ -706,9 +735,10 @@
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Office"
 	},
-/obj/machinery/door/blast/regular/open{
-	id_tag = "SD Office Outter Lockdown";
-	name = "SD Office Outter Lockdown"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
@@ -729,13 +759,15 @@
 	id_tag = "SD Office Outter Lockdown";
 	name = "SD Office Outter Lockdown"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
 "ca" = (
-/obj/structure/table/woodentable_reinforced/mahogany,
-/obj/item/boombox,
-/turf/simulated/floor/carpet/purple,
-/area/site53/uez/hallway)
+/obj/structure/bed/chair/padded,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/entrancezone/forensics)
 "cb" = (
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/woodentable_reinforced/mahogany,
@@ -851,6 +883,11 @@
 /area/site53/uez/hallway)
 "cs" = (
 /obj/machinery/papershredder,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
 "ct" = (
@@ -895,6 +932,12 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/photocopier,
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/hallway)
 "cy" = (
@@ -905,12 +948,18 @@
 	id_tag = "sitedirect";
 	name = "Administrative Offices Lockdown"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
 "cz" = (
 /obj/machinery/door/blast/regular/open{
 	id_tag = "sitedirect";
 	name = "Administrative Offices Lockdown"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
@@ -927,15 +976,17 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/substation)
 "cB" = (
-/obj/machinery/door/airlock/highsecurity{
-	req_access = list("ACCESS_ADMIN_LEVEL5")
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/blast/regular/open{
-	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown"
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood/mahogany,
-/area/site53/uez/hallway)
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
 "cC" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -954,6 +1005,25 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
+"cF" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
+/obj/machinery/camera/autoname{
+	dir = 3;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/commandpanicbunker)
 "cG" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier,
@@ -1051,6 +1121,9 @@
 	id_tag = "sitedirect";
 	name = "Administrative Offices Lockdown"
 	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
 "cT" = (
@@ -1062,6 +1135,9 @@
 /area/site53/uez/hallway)
 "cU" = (
 /obj/structure/bed/chair/office,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/hallway)
 "cV" = (
@@ -1070,6 +1146,14 @@
 	dir = 4;
 	id_tag = "sitedirect";
 	req_access = list("ACCESS_ADMIN_LEVEL5")
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/hallway)
@@ -1086,14 +1170,9 @@
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "cX" = (
-/obj/machinery/door/blast/regular{
-	id_tag = "sitedirect"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	req_access = list("ACCESS_ADMIN_LEVEL4")
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/hallway)
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/uez/equipmentroom)
 "cY" = (
 /obj/machinery/light{
 	dir = 8
@@ -1112,7 +1191,7 @@
 "cZ" = (
 /obj/structure/flora/tree/dead,
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
 "da" = (
 /obj/machinery/door/blast/regular/open{
 	id_tag = "Director Office Checkpoint Lower";
@@ -1147,11 +1226,17 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
 "df" = (
-/obj/structure/table/standard,
-/obj/item/stamp/rd,
-/obj/item/stamp/denied,
-/obj/item/stamp/approved,
-/turf/simulated/floor/carpet/purple,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "dg" = (
 /obj/machinery/camera/autoname{
@@ -1176,16 +1261,20 @@
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "dj" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Research Director's Office";
-	send_access = list("ACCESS_SCIENCE_LEVEL5")
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/random,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
 	},
-/obj/machinery/light{
-	dir = 1
+/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
 	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "dk" = (
 /obj/machinery/button/blast_door{
 	dir = 4;
@@ -1245,17 +1334,9 @@
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
 "ds" = (
-/obj/structure/closet/secure_closet/administration/facilityadmin,
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/item/folder,
-/obj/item/folder/blue,
-/obj/item/folder/red,
-/obj/item/folder/white,
-/obj/item/folder/yellow,
-/obj/item/implantcase/death_alarm,
-/obj/item/implanter,
-/turf/simulated/floor/tiled,
-/area/site53/uez/hallway)
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "dt" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -1360,50 +1441,43 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
 "dH" = (
-/obj/machinery/door/blast/regular/open{
-	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown"
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled,
+/area/site53/uez/conference)
 "dI" = (
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ECZ Security Lockdown";
-	name = "ECZ Security Lockdown"
+/obj/machinery/camera/network/entrance{
+	dir = 1
 	},
-/turf/simulated/floor/lino,
-/area/site53/uez/hallway)
+/obj/machinery/power/port_gen/pacman/mrs,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
 "dK" = (
-/obj/structure/closet/secure_closet/guard/guard_commander,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/folder,
-/obj/item/folder/blue,
-/obj/item/folder/red,
-/obj/item/folder/white,
-/turf/simulated/floor/tiled/techmaint,
-/area/site53/uez/hallway)
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/uez/repoffice/internaltribunal)
 "dL" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Guard Commander's Office";
-	send_access = list("ACCESS_SECURITY_LEVEL5")
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/techmaint,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled,
+/area/site53/uez/armory)
 "dM" = (
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/techmaint,
-/area/site53/uez/hallway)
-"dN" = (
-/obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"dN" = (
+/turf/simulated/floor/tiled,
+/area/site53/uez/armory)
 "dO" = (
 /obj/machinery/light,
 /obj/structure/filingcabinet,
@@ -1412,7 +1486,7 @@
 "dP" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
 "dQ" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1422,25 +1496,17 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/hallway)
 "dT" = (
-/obj/machinery/door/airlock/multi_tile/glass/research{
-	dir = 8;
-	icon_state = "closed";
-	name = "Research Director";
-	req_access = list("ACCESS_SCIENCE_LEVEL5")
-	},
-/obj/machinery/door/blast/regular/open{
-	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/uez/hallway)
+/obj/structure/curtain/medical,
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
 "dU" = (
-/obj/machinery/door/airlock/command{
-	name = "Security Commander's Office";
-	req_access = list("ACCESS_SECURITY_LEVEL5")
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "dV" = (
 /obj/effect/paint_stripe/blue,
 /obj/structure/sign/SecureArealv1mtf{
@@ -1490,7 +1556,7 @@
 "ea" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/exoplanet/grass,
-/area/space)
+/area/site53/uez/hallway)
 "eb" = (
 /obj/structure/table/standard,
 /obj/machinery/button/blast_door{
@@ -1517,25 +1583,30 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/hallway)
 "ed" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/site53/uez/senioragentoffice)
 "ee" = (
-/obj/structure/table/standard,
-/obj/item/implanter,
-/obj/item/folder/yellow,
-/obj/item/implantcase/death_alarm,
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
 "ef" = (
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/woodentable_reinforced/mahogany,
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
 "eg" = (
 /obj/structure/flora/grass/brown,
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
 "ei" = (
 /obj/structure/coatrack,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1617,7 +1688,7 @@
 "er" = (
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
 "es" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Main Control Room";
@@ -1641,7 +1712,7 @@
 "eu" = (
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/exoplanet/grass,
-/area/space)
+/area/site53/uez/hallway)
 "ev" = (
 /obj/machinery/light{
 	dir = 1
@@ -1649,10 +1720,14 @@
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "ew" = (
-/obj/machinery/status_display,
-/obj/effect/paint_stripe/blue,
-/turf/simulated/wall/titanium,
-/area/site53/uez/conference)
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/commandpanicbunker)
 "ex" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -1665,7 +1740,7 @@
 "ey" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
 "ez" = (
 /obj/structure/table/standard,
 /obj/item/folder,
@@ -1674,9 +1749,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
 "eA" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/plating,
-/area/site53/uez/conference)
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
 "eB" = (
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -1750,37 +1824,29 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
 "eK" = (
-/obj/machinery/door/airlock/multi_tile/glass/command{
-	name = "Conference Room A"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/conference)
+/obj/item/modular_computer/console/preset/cardslot/command,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "eL" = (
-/obj/machinery/power/apc/hyper{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/conference)
+/obj/structure/table/glass,
+/obj/item/paper,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/dice/d10,
+/obj/item/dice/d10,
+/obj/item/dice/d100,
+/obj/item/dice/d12,
+/obj/item/dice/d20,
+/obj/item/dice/d4,
+/obj/item/dice/d4,
+/obj/item/dice/d8,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "eM" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/modular_computer/console/preset/aislot/sysadmin{
+	dir = 8
 	},
-/turf/simulated/floor/tiled,
-/area/site53/uez/conference)
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/commandpanicbunker)
 "eN" = (
 /obj/structure/filingcabinet,
 /obj/effect/floor_decal/corner/blue/border{
@@ -1813,6 +1879,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
+"eP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
 "eQ" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "New Control Room";
@@ -1900,26 +1972,21 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
 "fd" = (
-/obj/structure/bed/chair{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/site53/uez/hallway)
-"fe" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/standard,
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"fe" = (
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/entrancezone/forensics)
 "ff" = (
-/obj/structure/bed/chair/comfy/red{
-	dir = 4;
-	name = "Guard Commander"
-	},
-/obj/effect/floor_decal/corner/red/half{
+/obj/structure/table/standard,
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/conference)
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
 "fg" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 8;
@@ -1941,21 +2008,21 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
 "fj" = (
-/obj/effect/landmark/start{
-	name = "Guard Commander"
+/obj/machinery/power/apc/hyper{
+	dir = 1
 	},
-/obj/structure/bed/chair/office/comfy{
-	dir = 8
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
 "fk" = (
-/obj/machinery/keycard_auth{
-	pixel_x = 28;
-	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
-	},
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
 "fl" = (
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/hallway)
@@ -1964,32 +2031,36 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/uez/hallway)
 "fn" = (
-/obj/item/device/flashlight/lamp,
-/obj/structure/table/standard,
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/obj/structure/closet,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "fo" = (
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("Entrance Zone Network")
-	},
-/turf/simulated/floor/carpet/red,
-/area/site53/uez/hallway)
+/obj/effect/paint_stripe/blue,
+/turf/simulated/wall/titanium,
+/area/site53/uez/commandpanicbunker)
 "fp" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/hallway)
 "fq" = (
-/obj/machinery/light{
+/obj/structure/closet,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"fr" = (
+/obj/structure/railing/mapped{
 	dir = 1
 	},
-/obj/machinery/requests_console{
-	department = "Administrative";
-	departmentType = 5;
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/conference)
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/hallway)
 "fs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -2010,16 +2081,18 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/substation)
 "fu" = (
-/obj/structure/closet/crate/bin{
-	anchored = 1;
-	name = "trash bin"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/conference)
+/obj/structure/table/glass,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "fv" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/uez/conference)
+/obj/machinery/door/airlock/multi_tile/glass/research{
+	dir = 8;
+	icon_state = "closed";
+	name = "Research Director";
+	req_access = list("ACCESS_SCIENCE_LEVEL5")
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/uez/hallway)
 "fw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2265,18 +2338,8 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
 "fV" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/lino,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/freezer,
+/area/site53/uez/commandpanicbunker)
 "fW" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -2382,14 +2445,11 @@
 /turf/simulated/floor/carpet/orange,
 /area/site53/uez/hallway)
 "gm" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/glass/command{
+	name = "Panic Bunker Shower"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/lino,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "gn" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -2459,6 +2519,11 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
@@ -2537,12 +2602,9 @@
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "gN" = (
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("Entrance Zone Network")
-	},
-/turf/simulated/floor/lino,
-/area/site53/uez/hallway)
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/commandpanicbunker)
 "gO" = (
 /obj/machinery/scp294,
 /turf/simulated/floor/tiled/monotile,
@@ -2556,6 +2618,20 @@
 "gT" = (
 /turf/simulated/floor/tiled,
 /area/site53/uez/conference)
+"gU" = (
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/site53/uez/commandpanicbunker)
 "gW" = (
 /obj/structure/table/standard,
 /obj/machinery/light,
@@ -2584,6 +2660,13 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
+"hf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
 "hj" = (
 /obj/machinery/light,
 /obj/structure/filingcabinet/chestdrawer,
@@ -2603,16 +2686,36 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/floor/plating,
 /area/site53/uez/bridge)
-"hC" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
+"ht" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"hv" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
+"hA" = (
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"hC" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "hE" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
@@ -3472,6 +3575,11 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"jD" = (
+/obj/structure/closet/secure_closet/guard/breachautomatics,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
 "jE" = (
 /obj/structure/flora/pottedplant/minitree,
 /obj/effect/floor_decal/corner/orange/borderfull,
@@ -3488,13 +3596,12 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
 "jF" = (
-/obj/effect/wallframe_spawn/reinforced/titanium,
-/obj/machinery/door/blast/shutters{
-	id_tag = "EZ Bridge Windows Shutter";
-	name = "EZ Bridge Windows Shutter"
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
 	},
-/turf/simulated/floor/plating,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/entrancezone/forensics)
 "jG" = (
 /obj/machinery/computer/station_alert/all{
 	dir = 1
@@ -4007,30 +4114,143 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"lr" = (
-/obj/machinery/light,
-/obj/structure/flora/pottedplant/minitree,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
+"lc" = (
+/obj/machinery/door/window/holowindoor{
+	req_access = list("ACCESS_ADMIN_LEVEL3");
 	dir = 4
 	},
-/obj/structure/railing/mapped,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"lg" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
+"lj" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/saiga12/buckshot,
+/obj/item/ammo_magazine/scp/saiga12/buckshot,
+/obj/item/ammo_magazine/scp/saiga12/buckshot,
+/obj/item/ammo_magazine/scp/saiga12/buckshot,
+/obj/item/ammo_magazine/box/buckshot,
+/obj/item/ammo_magazine/box/buckshot,
+/obj/item/ammo_magazine/box/buckshot,
+/obj/item/ammo_magazine/box/buckshot,
+/obj/item/ammo_magazine/box/slug,
+/obj/item/ammo_magazine/box/slug,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uez/conference)
+/area/site53/uez/armory)
+"lk" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"ll" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"lp" = (
+/obj/structure/table/standard,
+/obj/item/boombox,
+/obj/item/device/megaphone,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"lr" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"lA" = (
+/obj/structure/closet,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"lC" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
 "lE" = (
 /obj/machinery/chemical_dispenser/bar_coffee/full,
+/obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
+"lN" = (
+/obj/structure/bed/chair/padded/black{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"lR" = (
+/obj/machinery/door/airlock/civilian{
+	name = "Evacuation Bunker Living Compartment"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "lT" = (
-/obj/structure/table/standard,
-/obj/machinery/dnaforensics,
-/turf/simulated/floor/tiled/white,
-/area/site53/entrancezone/forensics)
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"lU" = (
+/obj/machinery/button/flasher{
+	id_tag = "EZBrigFlash";
+	pixel_x = 26;
+	pixel_y = 32;
+	name = "EZBrigFlash"
+	},
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"mf" = (
+/obj/structure/bed/chair/padded/black,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/commandpanicbunker)
 "mg" = (
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
@@ -4063,16 +4283,69 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"mp" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/hallway)
+"mr" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "EZ Secure Armoury";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/armory)
 "ms" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"mt" = (
+/obj/effect/paint_stripe/blue,
+/obj/machinery/button/blast_door{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/wall/titanium,
+/area/site53/uez/commandpanicbunker)
+"mx" = (
+/obj/structure/flora/pottedplant/minitree,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"my" = (
+/obj/structure/table/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/ionrifle,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "EZ Armoury Lockdown";
+	name = "EZ Armoury Lockdown";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
 "mM" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/uez/hallway)
+"mN" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
 "mQ" = (
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -4084,7 +4357,90 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"mS" = (
+/obj/structure/table/reinforced,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"mV" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"mX" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"mZ" = (
+/obj/structure/bed/chair/office/comfy{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
+"na" = (
+/obj/machinery/papershredder,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"ne" = (
+/obj/structure/bed,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/carpet/green,
+/area/site53/uez/commandpanicbunker)
+"nh" = (
+/obj/structure/closet/secure_closet/guard/ez,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"ni" = (
+/obj/machinery/button/blast_door{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown"
+	},
+/obj/effect/paint_stripe/blue,
+/turf/simulated/wall/titanium,
+/area/site53/uez/hallway)
+"nk" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
 "nl" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"np" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"nr" = (
+/obj/effect/landmark/start{
+	name = "EZ Junior Agent"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"nv" = (
+/obj/machinery/door/airlock/security{
+	name = "Evidence Storage";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/forensics)
 "nB" = (
@@ -4092,6 +4448,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
 "nD" = (
@@ -4101,6 +4458,20 @@
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"nF" = (
+/obj/machinery/door/airlock/glass/command{
+	name = "Meeting Room"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uez/hallway)
+"nG" = (
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
 "nI" = (
 /obj/structure/bed/chair/comfy/yellow{
 	name = "Containment Engineer"
@@ -4111,34 +4482,212 @@
 "nJ" = (
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/exoplanet/snow,
-/area/space)
+/area/site53/uez/hallway)
+"nN" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/hallway)
+"nQ" = (
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/glass/bucket,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
 "nR" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
-"nV" = (
+/obj/structure/bed,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/commandpanicbunker)
+"nT" = (
 /obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 1
+/obj/item/device/tape,
+/obj/item/device/tape,
+/obj/item/device/taperecorder,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"nV" = (
+/obj/machinery/door/airlock/highsecurity{
+	req_access = list("ACCESS_ADMIN_LEVEL3");
+	name = "Panic Chamber CR"
 	},
-/turf/simulated/floor/tiled/white,
-/area/site53/entrancezone/forensics)
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
+"nX" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/machinery/camera/network/entrance{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"oa" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"on" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/machinery/photocopier/faxmachine{
+	department = "Site Director's Office";
+	send_access = list("ACCESS_ADMIN_LEVEL5")
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
 "ov" = (
 /obj/structure/table/woodentable_reinforced/mahogany,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
-"po" = (
+"oA" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"oD" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uez/conference)
+"oH" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"oS" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light{
 	dir = 4
 	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"pb" = (
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("Entrance Zone Network")
+	},
 /obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/folder/envelope/nuke_instructions,
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
+"pg" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"ph" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/commandpanicbunker)
+"pj" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"po" = (
+/obj/item/storage/secure/briefcase/nukedisk,
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/site53/uez/hallway)
+"pr" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"pI" = (
+/obj/structure/table/rack,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"pJ" = (
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"pL" = (
+/obj/structure/table/steel,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "pN" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -4150,50 +4699,261 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/bridge)
+"pP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"pX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"qd" = (
+/obj/machinery/power/port_gen/pacman/mrs,
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"qf" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"qj" = (
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/commandpanicbunker)
 "ql" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"qm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"qr" = (
+/obj/structure/table/woodentable/ebony,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "tribrep";
+	name = "Shutters";
+	pixel_x = -6;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
 "qs" = (
 /obj/machinery/vending/hydronutrients,
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
 "qt" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"qu" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/corner/red/bordercorner{
+/turf/simulated/floor/tiled,
+/area/site53/uez/armory)
+"qx" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"qE" = (
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "EZ Lobby Lockdown";
+	name = "EZ Lobby Lockdown";
+	pixel_x = -6;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "EZ Lobby Outter Lockdown";
+	name = "EZ Lobby Outter Lockdown";
+	pixel_x = 4;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "EZ Lobby Windows";
+	name = "EZ Lobby Windows";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"qF" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "Guard Commander's Office";
+	send_access = list("ACCESS_SECURITY_LEVEL5")
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"qI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed,
+/obj/structure/curtain/open/bed,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/commandpanicbunker)
+"qK" = (
+/obj/machinery/camera/autoname{
+	network = list("Entrance Zone Network");
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
-"qx" = (
-/obj/structure/bed/chair/office/dark{
-	dir = 8
+/area/site53/uez/repoffice/internaltribunal)
+"qR" = (
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "EZ Armoury Lockdown";
+	name = "EZ Armoury Lockdown";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
-/turf/simulated/floor/tiled/white,
-/area/site53/entrancezone/forensics)
-"qK" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/table/steel,
-/obj/item/taperoll/police,
-/obj/item/taperoll/police,
-/obj/item/taperoll/police,
-/obj/item/hand_labeler,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/armory)
+"qS" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
 /area/site53/entrancezone/forensics)
+"ra" = (
+/obj/structure/bed/padded,
+/obj/structure/curtain/open/bed,
+/obj/item/bedsheet,
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
 "rc" = (
-/obj/item/storage/secure/briefcase/nukedisk,
-/obj/structure/table/woodentable_reinforced/mahogany,
-/turf/simulated/floor/wood/mahogany,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"rf" = (
+/obj/machinery/door/airlock/glass/command{
+	name = "Meeting Room"
+	},
+/turf/simulated/floor/tiled,
 /area/site53/uez/hallway)
+"rm" = (
+/obj/structure/bed/chair/padded/black,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"rs" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Brig CR Windows";
+	name = "EZ Brig CR Windows"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"rv" = (
+/obj/machinery/light/small/red{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"rC" = (
+/obj/machinery/door/airlock/command{
+	name = "EZ Brig Control Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Brig CR Access";
+	name = "EZ Brig CR Access";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"rD" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 1;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/carpet/orange,
+/area/site53/uez/commandpanicbunker)
+"rF" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/saiga12/rubbershot,
+/obj/item/ammo_magazine/scp/saiga12/rubbershot,
+/obj/item/ammo_magazine/scp/saiga12/rubbershot,
+/obj/item/ammo_magazine/scp/saiga12/rubbershot,
+/obj/item/ammo_magazine/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/scp/saiga12/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/beanbag,
+/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/rubbershot,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
 "rG" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/white,
+/obj/machinery/door/airlock/command{
+	name = "EZ Security Gear Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
 "rI" = (
 /obj/effect/floor_decal/corner/orange/border{
@@ -4204,20 +4964,60 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"rP" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
+"rN" = (
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/commandpanicbunker)
+"rO" = (
+/obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/area/site53/uez/repoffice/internaltribunal)
+"rP" = (
+/obj/machinery/light,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/hallway)
 "rX" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
+"rZ" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"sa" = (
+/obj/structure/bed/chair/padded{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/entrancezone/forensics)
+"sb" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/bed/chair/shuttle{
+	name = "Reeducation Chair";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/uez/equipmentroom)
+"se" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"sj" = (
+/obj/structure/bed/chair/padded/black,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/orange,
+/area/site53/uez/commandpanicbunker)
 "sr" = (
 /obj/structure/bed/chair/comfy/yellow{
 	name = "Chief Engineer"
@@ -4225,6 +5025,35 @@
 /obj/effect/floor_decal/corner/orange/half,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"ss" = (
+/obj/item/modular_computer/console/preset/aislot/research,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"sy" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Armoury Lockdown";
+	name = "EZ Armoury Lockdown"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
+"sC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"sO" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
 "sY" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -4238,76 +5067,183 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"th" = (
+/obj/structure/table/standard,
+/obj/item/implanter,
+/obj/item/folder/yellow,
+/obj/item/implantcase/death_alarm,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"tj" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"tm" = (
+/obj/structure/closet,
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
+"tp" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
 "tv" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"tC" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/commandpanicbunker)
 "tD" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/logistics/logisticsofficer)
+"tE" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"tO" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "tS" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/site53/uez/hallway)
+"ua" = (
 /obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/white,
-/area/site53/entrancezone/forensics)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/device/flashlight/lamp,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"ue" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
+"uf" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Armoury Lockdown";
+	name = "EZ Armoury Lockdown"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
+"uk" = (
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/armory)
+"ul" = (
+/obj/machinery/light,
+/turf/simulated/floor/tiled/freezer,
+/area/site53/uez/commandpanicbunker)
+"us" = (
+/obj/structure/bed/chair/padded/black,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
 "ux" = (
 /obj/effect/floor_decal/corner/red,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
-"uX" = (
+"uy" = (
+/obj/item/paper,
+/obj/item/storage/pill_bottle/dice,
+/obj/item/dice/d10,
+/obj/item/dice/d10,
+/obj/item/dice/d100,
+/obj/item/dice/d12,
+/obj/item/dice/d20,
+/obj/item/dice/d4,
+/obj/item/dice/d4,
+/obj/item/dice/d8,
 /obj/structure/table/standard,
-/obj/item/folder/blue,
-/obj/item/folder/red,
-/obj/item/folder/white,
-/obj/item/folder/yellow,
-/obj/item/folder,
-/turf/simulated/floor/tiled/white,
-/area/site53/entrancezone/forensics)
-"uZ" = (
-/obj/structure/table/woodentable_reinforced/mahogany,
-/obj/item/folder/envelope/nuke_instructions,
-/turf/simulated/floor/wood/mahogany,
-/area/site53/uez/hallway)
-"vh" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/orange/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/upper_surface/commstower)
-"vG" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/uez/hallway)
-"vN" = (
-/obj/structure/table/woodentable_reinforced/mahogany,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"uH" = (
+/obj/effect/paint_stripe/blue,
 /obj/machinery/button/blast_door{
 	id_tag = "sitedirect";
 	name = "Administrative Offices Lockdown"
 	},
+/turf/simulated/wall/titanium,
+/area/site53/uez/commandpanicbunker)
+"uM" = (
+/obj/structure/table/standard,
+/obj/item/stamp/rd,
+/obj/item/stamp/denied,
+/obj/item/stamp/approved,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
-"wj" = (
-/obj/effect/floor_decal/corner/brown/half{
+"uS" = (
+/obj/structure/closet/secure_closet/guard/ez,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"uX" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/logistics/logisticsbreak)
-"wz" = (
-/obj/structure/railing/mapped,
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
+"uZ" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/woodentable_reinforced/mahogany,
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"va" = (
 /obj/structure/railing/mapped{
-	dir = 8
+	dir = 1
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
-"wS" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"vb" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/gloves{
 	pixel_y = 6
@@ -4316,39 +5252,434 @@
 /obj/item/clothing/gloves/forensic,
 /obj/item/clothing/gloves/forensic,
 /obj/item/clothing/gloves/forensic,
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
-"wX" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood/mahogany,
-/area/site53/uez/hallway)
-"xa" = (
-/obj/effect/floor_decal/corner/red/bordercee{
-	dir = 8
-	},
-/obj/item/storage/briefcase/crimekit{
-	pixel_y = 12
-	},
-/obj/item/storage/briefcase/crimekit{
-	pixel_y = 6
-	},
-/obj/item/storage/briefcase/crimekit,
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
-"xn" = (
-/obj/effect/floor_decal/corner/red/bordercee{
-	dir = 8
-	},
-/obj/machinery/power/apc{
+"vd" = (
+/obj/machinery/door/blast/regular{
 	dir = 4;
-	name = "east bump";
-	pixel_x = 24
+	id_tag = "EZ Armoury Lockdown";
+	name = "EZ Armoury Lockdown"
 	},
-/obj/structure/cable{
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/armory)
+"vh" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/orange/border{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/upper_surface/commstower)
+"vi" = (
+/obj/machinery/power/smes/buildable/preset/ds90/substation_full{
+	RCon_tag = "Evacuation Bunker Substation"
+	},
+/obj/structure/cable/green{
+	d2 = 4;
 	icon_state = "0-4"
 	},
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
+"vj" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/site53/uez/hallway)
+"vn" = (
+/obj/structure/window/reinforced,
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"vp" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/random,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
+	},
+/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/commandpanicbunker)
+"vq" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "Panic Room Gate East";
+	name = "Panic Room Gate East"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
+"vF" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"vG" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/uez/hallway)
+"vH" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/hallway)
+"vK" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 0
+	},
+/obj/machinery/button/flasher{
+	id_tag = "EZBrigFlash";
+	pixel_x = 26;
+	pixel_y = 32;
+	name = "EZBrigFlash"
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Brig CR Windows";
+	name = "EZ Brig CR Windows"
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"vM" = (
+/obj/machinery/optable,
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"vN" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/machinery/button/blast_door{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/hallway)
+"vR" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"vU" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"vX" = (
+/obj/structure/bed/roller,
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"vY" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "Panic Room Gate East";
+	name = "Panic Room Gate East";
+	pixel_x = -6;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "Panic Room Gate East";
+	name = "Panic Room Gate East";
+	pixel_x = 4;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"wh" = (
+/obj/machinery/vending/medical,
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"wi" = (
+/obj/structure/table/standard,
+/obj/item/device/tape,
+/obj/item/device/tape,
+/obj/item/device/tape,
+/obj/item/device/tape,
+/obj/item/device/tape,
+/obj/item/device/taperecorder,
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"wj" = (
+/obj/effect/floor_decal/corner/brown/half{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
+/area/site53/logistics/logisticsbreak)
+"wn" = (
+/obj/structure/table/woodentable/ebony,
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
+"ws" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"wv" = (
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/structure/table/woodentable/ebony,
+/obj/item/stamp/scp/o5rep,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"wz" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"wI" = (
+/obj/machinery/door/airlock/security{
+	name = "Termination";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"wM" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/red{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"wP" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Brig CR Windows";
+	name = "EZ Brig CR Windows"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"wS" = (
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"wX" = (
+/turf/unsimulated/mineral,
+/area/site53/uez/commandpanicbunker)
+"wZ" = (
+/obj/machinery/door/airlock/command{
+	name = "EZ Security Gear Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"xa" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"xj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"xm" = (
+/obj/structure/bed/chair/padded/black{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"xn" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"xq" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/green,
+/area/site53/uez/commandpanicbunker)
+"xu" = (
+/obj/structure/table/standard,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"xw" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
+"xx" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"xC" = (
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"xG" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"xK" = (
+/obj/structure/bed/chair,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"xM" = (
+/obj/effect/catwalk_plated/dark,
+/obj/effect/floor_decal/industrial/warning,
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/machinery/camera/network/hcz{
+	dir = 1;
+	name = "HCZ Guard Office"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"xQ" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Lobby Windows";
+	name = "EZ Lobby Windows";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"xR" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/box/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/ammo_magazine/scp/mk9,
+/obj/item/gun/projectile/pistol/mk9,
+/obj/item/gun/projectile/pistol/mk9,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
+"xX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
 "yb" = (
 /obj/effect/floor_decal/corner/green/half{
@@ -4359,12 +5690,58 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"yq" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Lobby Outter Lockdown";
+	name = "EZ Lobby Outter Lockdown";
+	begins_closed = 0
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"yt" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"yx" = (
+/obj/structure/hygiene/toilet{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/site53/uez/commandpanicbunker)
 "yB" = (
 /obj/structure/bed/chair/office/comfy{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/upper_surface/commstower)
+"yC" = (
+/obj/structure/closet,
+/obj/effect/catwalk_plated/dark,
+/obj/item/stack/material/tritium/fifty,
+/obj/item/stack/material/tritium/fifty,
+/obj/item/stack/material/tritium/fifty,
+/obj/item/stack/material/tritium/fifty,
+/obj/machinery/camera/autoname{
+	network = list("Entrance Zone Network");
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
+"yE" = (
+/obj/machinery/sleeper{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
 "yK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4373,6 +5750,65 @@
 	},
 /turf/simulated/floor/lino,
 /area/site53/uez/hallway)
+"yN" = (
+/obj/structure/table/standard,
+/obj/item/storage/mre/random,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"yO" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Brig Iso Exit";
+	name = "EZ Brig Iso Exit";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"yT" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"yY" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"zf" = (
+/obj/machinery/door/airlock/command{
+	name = "EZ Brig Control Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Brig CR Access Outter";
+	name = "EZ Brig CR Access Outter";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"zg" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"zm" = (
+/obj/structure/bed/chair/padded/black{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "zp" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/shutters{
@@ -4382,17 +5818,91 @@
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
+"zq" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/machinery/light/small/red{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"zt" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"zA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/mre/random,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
+	},
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"zC" = (
+/obj/machinery/photocopier,
+/obj/structure/table/woodentable/ebony,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
 "zE" = (
+/obj/structure/railing/mapped{
+	dir = 1
+	},
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"zG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/camera/network/entrance{
+	dir = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/hallway)
+"zH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "zJ" = (
 /obj/structure/table/standard,
 /obj/machinery/microscope,
 /turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
+"zN" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/hallway)
 "zO" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -4403,6 +5913,31 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
+"zQ" = (
+/obj/machinery/vending/security,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"zR" = (
+/obj/machinery/computer/cryopod{
+	pixel_x = -32
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"zU" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
 "zW" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8;
@@ -4414,20 +5949,125 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
 "zX" = (
-/obj/structure/window/reinforced,
-/obj/structure/filingcabinet/filingcabinet{
-	pixel_x = -9
+/obj/machinery/door/airlock/glass/command{
+	name = "Panic Bunker Toilets"
 	},
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_x = 6
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Aa" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"Ar" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
-/area/site53/entrancezone/forensics)
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
+"As" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/usp45,
+/obj/item/ammo_magazine/scp/usp45,
+/obj/item/ammo_magazine/scp/usp45,
+/obj/item/ammo_magazine/scp/usp45,
+/obj/item/ammo_magazine/scp/usp45,
+/obj/item/ammo_magazine/scp/usp45,
+/obj/item/ammo_magazine/box/a45,
+/obj/item/ammo_magazine/box/a45,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/gun/projectile/pistol/usp45,
+/obj/item/gun/projectile/pistol/usp45,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
 "Av" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
+"AC" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier{
+	pixel_y = 3
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/hallway)
+"AF" = (
+/obj/structure/bed/chair/comfy/red{
+	dir = 4;
+	name = "Guard Commander"
+	},
+/obj/effect/floor_decal/corner/red/half{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"AG" = (
+/obj/machinery/chemical_dispenser/bar_coffee/full,
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/machinery/camera/autoname{
+	dir = 3;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"AI" = (
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
+"AL" = (
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"AN" = (
+/obj/structure/bed/chair/padded/black,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"AO" = (
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor/westleft{
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Brig CR Windows";
+	name = "EZ Brig CR Windows"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/equipmentroom)
+"AQ" = (
+/obj/structure/closet/secure_closet/guard/guard_commander,
+/obj/item/folder/white,
+/obj/item/folder/red,
+/obj/item/folder/blue,
+/obj/item/folder,
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"AV" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/boombox,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
 "AY" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
@@ -4436,30 +6076,82 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"Ba" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 6
-	},
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
-"Bv" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 8
-	},
-/obj/structure/table/steel,
+"AZ" = (
+/obj/structure/table/standard,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/device/camera,
-/obj/item/device/camera,
-/obj/item/device/camera_film,
-/obj/item/device/camera_film,
-/turf/simulated/floor/tiled/monotile,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "EZ Interrogation shutters";
+	name = "EZ Interrogation shutters";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
+"Ba" = (
+/obj/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"Bc" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 28;
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Bl" = (
+/obj/structure/bed/chair/office/comfy{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Bq" = (
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Bv" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Bz" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 0
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Lobby Windows";
+	name = "EZ Lobby Windows";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"BC" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"BG" = (
+/obj/structure/table/glass,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "BL" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -4468,11 +6160,50 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
+"BP" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"BS" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"BV" = (
+/obj/machinery/door/airlock/highsecurity{
+	req_access = list("ACCESS_ADMIN_LEVEL3")
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"BZ" = (
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
 "Cj" = (
-/obj/effect/paint_stripe/red,
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/prepainted,
-/area/site53/entrancezone/forensics)
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
 "Cq" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -4490,6 +6221,56 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"Cy" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/ammo_magazine/box/a357,
+/obj/item/gun/projectile/revolver/rhino,
+/obj/item/gun/projectile/revolver/rhino,
+/obj/item/gun/projectile/revolver/rhino,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
+"Cz" = (
+/obj/machinery/door/airlock/highsecurity{
+	req_access = list("ACCESS_ADMIN_LEVEL3")
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"CC" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"CD" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/camera/autoname{
+	network = list("Entrance Zone Network");
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"CF" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"CG" = (
+/obj/structure/table/standard,
+/obj/item/implanter,
+/obj/item/folder/yellow,
+/obj/item/implantcase/death_alarm,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
 "CH" = (
 /obj/structure/table/standard,
 /obj/item/folder/red,
@@ -4497,6 +6278,70 @@
 /obj/item/folder/red,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"CJ" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"CK" = (
+/obj/machinery/door/airlock/security{
+	name = "Forensics Laboratory";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"CL" = (
+/obj/structure/bed/chair/padded/black,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/commandpanicbunker)
+"CR" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/device/camera,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"CT" = (
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/commandpanicbunker)
+"De" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Dg" = (
+/obj/item/storage/briefcase/crimekit{
+	pixel_y = 12
+	},
+/obj/item/storage/briefcase/crimekit{
+	pixel_y = 6
+	},
+/obj/item/storage/briefcase/crimekit,
+/obj/structure/table/rack,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"Dl" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/machinery/door/airlock/engineering,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
 "Dm" = (
 /obj/machinery/camera/autoname{
 	dir = 1;
@@ -4504,6 +6349,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
+"Dn" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
+"Do" = (
+/obj/structure/table/standard,
+/obj/item/device/taperecorder,
+/obj/item/device/tape/random,
+/obj/item/device/tape/random,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
 "Ds" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -4524,16 +6386,33 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
+"Dy" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/standard,
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"DA" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
 "DB" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 10
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/obj/effect/floor_decal/industrial/warning/full,
+/obj/machinery/door/blast/regular{
+	begins_closed = 0;
+	id_tag = "Panic Room Gate West";
+	name = "Panic Room Gate West"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
 "DC" = (
 /obj/machinery/light{
 	dir = 8;
@@ -4551,21 +6430,93 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
 "DJ" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 5
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
 	},
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"DO" = (
+/obj/machinery/door/airlock/glass/security{
+	id_tag = "evaccell";
+	name = "Bunker Brig Cell";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Ee" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/area/site53/uez/commandpanicbunker)
+"Ef" = (
+/obj/machinery/vending/snack{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Ei" = (
+/obj/machinery/button/blast_door{
+	id_tag = "EZ Brig CR Access";
+	name = "EZ Brig CR Access";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Ek" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Eq" = (
+/obj/machinery/keycard_auth{
+	pixel_x = 28;
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"Et" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small/red{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"Ev" = (
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
+"Ex" = (
+/obj/structure/cable/green{
+	icon_state = "1-4"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"Ey" = (
+/obj/structure/table/rack,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/obj/item/melee/baton/loaded,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "EA" = (
 /obj/structure/bed/chair/office/comfy{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/upper_surface/commstower)
+"EC" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "EH" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
@@ -4577,11 +6528,46 @@
 /obj/item/material/kitchen/rollingpin,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"EI" = (
+/obj/structure/closet,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"EJ" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Ff" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
 "Fo" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"Fu" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/morgue{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"Fx" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "Fz" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -4591,24 +6577,209 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"FW" = (
-/obj/structure/bed/chair/comfy/yellow{
-	name = "LCZ Commander"
+"FH" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/light/small/red{
+	dir = 8
 	},
-/obj/effect/floor_decal/corner/yellow/half,
+/obj/structure/hygiene/toilet{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"FI" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"FQ" = (
+/obj/structure/closet/secure_closet/guard/ez/sergeant,
+/obj/effect/landmark/start{
+	name = "EZ Senior Agent"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"FT" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table/woodentable/ebony,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/uez/conference)
+/area/site53/uez/repoffice/internaltribunal)
+"FW" = (
+/obj/structure/hygiene/shower,
+/obj/structure/curtain/open/shower,
+/turf/simulated/floor/tiled/freezer,
+/area/site53/uez/commandpanicbunker)
 "Ga" = (
 /obj/structure/table/woodentable,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
+"Gl" = (
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"Gn" = (
+/obj/structure/table/steel,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Gp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Gu" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"Gw" = (
+/obj/structure/bed,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/carpet/orange,
+/area/site53/uez/commandpanicbunker)
+"GB" = (
+/obj/machinery/door/airlock/glass/command{
+	name = "Panic Bunker Access"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
+"GE" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "GL" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop/preset/custom_loadout/standard,
 /turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
+"GP" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
+"GR" = (
+/obj/structure/bed/chair/office/comfy{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"GS" = (
+/obj/structure/closet/secure_closet{
+	name = "secure evidence locker";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"GU" = (
+/obj/structure/table/standard,
+/obj/item/auto_cpr,
+/obj/item/defibrillator/loaded,
+/obj/machinery/cell_charger,
+/obj/item/screwdriver,
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"GV" = (
+/obj/machinery/door/blast/regular{
+	id_tag = "sitedirect";
+	name = "Administrative Offices Lockdown"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"GW" = (
+/obj/structure/table/steel,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/device/camera,
+/obj/item/device/camera,
+/obj/item/device/camera_film,
+/obj/item/device/camera_film,
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"Hb" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"Hc" = (
+/obj/structure/table/woodentable/ebony,
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
+"He" = (
+/obj/item/modular_computer/console/preset/cardslot/command_sec{
+	dir = 4
+	},
+/obj/machinery/camera/network/entrance{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/commandpanicbunker)
+"Hp" = (
+/obj/structure/bed/chair/padded/black,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/green,
+/area/site53/uez/commandpanicbunker)
+"Ht" = (
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/entrancezone/forensics)
+"Hu" = (
+/obj/effect/paint_stripe/blue,
+/obj/item/storage/mirror,
+/turf/simulated/wall/titanium,
+/area/site53/uez/commandpanicbunker)
 "Hv" = (
 /obj/effect/paint_stripe/yellow,
 /obj/structure/cable{
@@ -4618,6 +6789,29 @@
 	},
 /turf/simulated/wall/prepainted,
 /area/site53/uez/maintenance)
+"Hy" = (
+/obj/structure/table/standard,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/flashbangs,
+/obj/item/storage/box/teargas,
+/obj/item/storage/box/teargas,
+/obj/item/gun/launcher/grenade,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/item/storage/pill_bottle/amnesticsb,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
+"HE" = (
+/obj/machinery/door/airlock/command{
+	name = "EZ Security Gear Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
 "HF" = (
 /obj/effect/paint_stripe/blue,
 /obj/machinery/button/windowtint{
@@ -4627,6 +6821,29 @@
 	},
 /turf/simulated/wall/titanium,
 /area/site53/uez/hallway)
+"HH" = (
+/obj/structure/closet,
+/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
+/obj/item/gun/projectile/automatic/scp/saiga12/buckshot,
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
+"HN" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
 "HP" = (
 /obj/structure/table/standard,
 /obj/item/folder/blue,
@@ -4651,6 +6868,22 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
+"If" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uez/conference)
+"In" = (
+/obj/structure/table/standard,
+/obj/machinery/button/holosign{
+	id_tag = "evacbunker";
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
 "Ip" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4665,24 +6898,125 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
 "Ir" = (
-/obj/effect/paint_stripe/red,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall/prepainted,
-/area/site53/entrancezone/forensics)
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Ix" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	id_tag = "tribrep";
+	begins_closed = 0
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/repoffice/internaltribunal)
 "Iy" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/carpet/purple,
-/area/site53/uez/hallway)
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/hologram/holopad,
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"IA" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"IG" = (
+/obj/machinery/power/port_gen/pacman/mrs,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"IJ" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"IO" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Lobby Lockdown";
+	name = "EZ Lobby Lockdown";
+	begins_closed = 0
+	},
+/obj/machinery/door/airlock/multi_tile/glass/security{
+	dir = 8;
+	icon_state = "closed";
+	name = "EZ Security Center";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "IV" = (
-/obj/effect/paint_stripe/white,
-/turf/simulated/wall/prepainted,
+/obj/effect/paint_stripe/red,
+/turf/simulated/wall/titanium,
+/area/site53/uez/armory)
+"Je" = (
+/obj/structure/table/standard,
+/obj/machinery/dnaforensics,
+/turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
+"Jl" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Jp" = (
+/obj/machinery/cryopod,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"JE" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small/red{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"JG" = (
+/obj/item/mop,
+/obj/structure/mopbucket,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
+"JM" = (
+/obj/machinery/door/airlock/glass/command{
+	name = "Internal Tribunal Department Representitive"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
 "JN" = (
 /obj/structure/table/standard,
 /obj/item/stamp/approved,
@@ -4690,14 +7024,160 @@
 /obj/item/stamp/cargo,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
+"JS" = (
+/obj/machinery/door/airlock/civilian{
+	name = "Evacuation Bunker Living Compartment"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
 "JT" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/titanium,
 /area/site53/uez/maintenance)
+"JY" = (
+/obj/structure/bed,
+/obj/structure/curtain/open/bed,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
 "Ka" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
+"Ke" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Kg" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Kk" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Kn" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
+"Ko" = (
+/obj/effect/landmark/start{
+	name = "EZ Junior Agent"
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Kq" = (
+/obj/structure/table/steel,
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
+/obj/item/hand_labeler,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"Ku" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/red{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Kv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Ky" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/stack/material/tritium/fifty,
+/obj/item/stack/material/tritium/fifty,
+/obj/item/stack/material/tritium/fifty,
+/obj/item/stack/material/tritium/fifty,
+/obj/structure/closet,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
+"KB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"KG" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "EZ Secure Armoury";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/armory)
+"KM" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
+"KP" = (
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"KS" = (
+/obj/machinery/photocopier/faxmachine{
+	department = "Guard Commander's Office";
+	send_access = list("ACCESS_SECURITY_LEVEL5")
+	},
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
 "KY" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -4708,6 +7188,106 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/bridge)
+"Ld" = (
+/turf/unsimulated/mineral,
+/area/site53/uez/equipmentroom)
+"Lj" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/hallway)
+"Lo" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Lq" = (
+/obj/structure/window/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup,
+/obj/item/deck/cards,
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"Lr" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/commandpanicbunker)
+"Ls" = (
+/obj/machinery/door/window/holowindoor{
+	id_tag = "sitedirect";
+	req_access = list("ACCESS_ADMIN_LEVEL5")
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"Lv" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"Lw" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"LA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/filingcabinet,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"LD" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"LL" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/obj/item/handcuffs,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/commandpanicbunker)
 "LM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4720,14 +7300,73 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
+"LP" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/adv,
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
 "LT" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
+/obj/structure/table/woodentable,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
-"Mm" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/prepainted,
+"LU" = (
+/obj/effect/floor_decal/corner/black/full,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"LX" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
+"Md" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"Mm" = (
+/obj/structure/table/standard,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Mn" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"Mo" = (
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable/green,
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"Mp" = (
+/obj/structure/closet/secure_closet/guard/zone_commander,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
 "MG" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 1;
@@ -4738,22 +7377,129 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
-"MX" = (
-/obj/structure/table/standard,
-/obj/item/device/taperecorder,
-/obj/item/device/tape/random,
-/obj/item/device/tape/random,
-/turf/simulated/floor/tiled/white,
-/area/site53/entrancezone/forensics)
-"Nk" = (
-/obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("Entrance Zone Network")
+"MI" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/structure/railing/mapped{
+	dir = 1
 	},
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/structure/railing/mapped,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"MK" = (
+/obj/structure/bed/chair/office/dark,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"ML" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "Panic Room CR Window";
+	name = "Panic Room CR Window";
+	pixel_x = -6;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/wrench,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"MS" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/commandpanicbunker)
+"MU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/entrancezone/forensics)
+"MX" = (
+/obj/structure/closet/secure_closet/administration/facilityadmin,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/item/folder,
+/obj/item/folder/blue,
+/obj/item/folder/red,
+/obj/item/folder/white,
+/obj/item/folder/yellow,
+/obj/item/implantcase/death_alarm,
+/obj/item/implanter,
+/turf/simulated/floor/wood/mahogany,
+/area/site53/uez/hallway)
+"MZ" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/equipmentroom)
+"Nb" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Interrogation shutters";
+	name = "EZ Interrogation shutters";
+	begins_closed = 0
+	},
+/turf/simulated/floor/plating,
+/area/site53/entrancezone/forensics)
+"Nd" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/boombox,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/hallway)
+"Nk" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"No" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small/red,
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"Nr" = (
+/obj/structure/bed/chair/padded/black{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/repoffice/internaltribunal)
+"Nt" = (
+/obj/effect/wallframe_spawn/reinforced/titanium,
+/obj/machinery/door/blast/regular/open{
+	id_tag = "Panic Room CR Window";
+	name = "Panic Room CR Window"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
 "Nv" = (
 /obj/effect/floor_decal/corner/blue/mono,
 /obj/structure/bed/chair/comfy/blue{
@@ -4771,6 +7517,16 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"NF" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/yellow/mono,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
 "NJ" = (
 /obj/structure/bed/chair/comfy/blue{
 	dir = 1;
@@ -4781,6 +7537,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"NL" = (
+/obj/machinery/body_scanconsole{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
 "Oc" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -4792,10 +7554,50 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
 "Od" = (
-/obj/structure/window/reinforced,
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/carpet/orange,
+/area/site53/uez/commandpanicbunker)
+"Og" = (
+/obj/machinery/button/alternate/door/bolts{
+	dir = 4;
+	id_tag = "evaccell";
+	name = "Bunker Brig Cell bolt button";
+	pixel_x = -25;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Op" = (
+/obj/machinery/door/airlock/command{
+	name = "Command Security Compartment"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Ot" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
+"OC" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"OD" = (
+/obj/structure/railing/mapped,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/hallway)
+"OE" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/hygiene/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "OG" = (
 /obj/machinery/vending/hotfood,
 /obj/machinery/light{
@@ -4804,11 +7606,32 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
-"OM" = (
-/obj/effect/floor_decal/corner/red/border,
-/obj/machinery/light,
+"OI" = (
+/obj/structure/bed/chair/comfy/captain{
+	dir = 1;
+	name = "director's chair"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"OJ" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/structure/bed/chair/padded/black,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/commandpanicbunker)
+"OL" = (
+/obj/machinery/holosign/surgery{
+	dir = 4;
+	id_tag = "evacbunker"
+	},
+/obj/machinery/door/airlock/medical{
+	name = "Bunker Medical"
+	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/area/site53/uez/commandpanicbunker)
+"OM" = (
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
 "OS" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/yellow/mono,
@@ -4833,16 +7656,233 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"OZ" = (
+/obj/structure/table/standard,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/effect/floor_decal/corner/red/border{
+	dir = 1
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/item/storage/box/bodybags,
+/obj/machinery/light/small/red{
+	dir = 4;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"Ph" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "Panic Room Gate East";
+	name = "Panic Room Gate East";
+	pixel_x = -6;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "Panic Room Gate East";
+	name = "Panic Room Gate East";
+	pixel_x = 4;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/camera/network/entrance{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Pj" = (
+/obj/effect/paint_stripe/red,
+/obj/machinery/button/crematorium{
+	id_tag = "HCZCrematorium";
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_MEDICAL_LEVEL2"));
+	name = "HCZCrematorium"
+	},
+/turf/simulated/wall/titanium,
+/area/site53/uez/equipmentroom)
+"Pk" = (
+/obj/structure/table/standard,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"Pl" = (
+/obj/structure/closet/crate/bin{
+	anchored = 1;
+	name = "trash bin"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"Pp" = (
+/obj/machinery/door/airlock/command{
+	name = "EZ Security Gear Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/entrancezone/forensics)
+"Pr" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier/faxmachine{
+	department = "Research Director's Office";
+	send_access = list("ACCESS_SCIENCE_LEVEL5")
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/hallway)
+"Pt" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/site53/uez/hallway)
+"Pv" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/morgue,
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
 "PE" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"PH" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"PM" = (
+/obj/structure/table/standard,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/combat,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/firstaid/adv,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	pixel_y = -23
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"PR" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4s")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"PT" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"PV" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"PY" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"Ql" = (
+/obj/structure/table/standard,
+/obj/effect/floor_decal/corner/red/mono,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"Qu" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
 "Qv" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/purple/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"Qy" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/machinery/photocopier,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"QA" = (
+/obj/structure/table/standard,
+/obj/item/folder/blue,
+/obj/item/folder/red,
+/obj/item/folder/white,
+/obj/item/folder/yellow,
+/obj/item/folder,
+/obj/structure/window/reinforced,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"QE" = (
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"QF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
 "QG" = (
 /obj/structure/table/standard,
 /obj/item/pen,
@@ -4850,10 +7890,46 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"QI" = (
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/commandpanicbunker)
+"QN" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -30
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "QP" = (
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
+"QU" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"QZ" = (
+/obj/structure/bed/chair/office/comfy{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Rb" = (
+/obj/structure/bed/chair/office/comfy{
+	dir = 4
+	},
+/obj/effect/landmark/start{
+	name = "Guard Commander"
+	},
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"Rc" = (
+/obj/machinery/door/airlock/command{
+	name = "Zone Commander's Office";
+	req_access = list("ACCESS_SECURITY_LEVEL4s")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "Rd" = (
 /obj/structure/table/woodentable_reinforced/mahogany,
 /obj/item/stamp/denied,
@@ -4861,6 +7937,18 @@
 /obj/item/stamp/scp/facdir,
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
+"Rv" = (
+/obj/structure/closet,
+/obj/item/reagent_containers/food/drinks/cans/waterbottle,
+/obj/item/storage/mre/random,
+/obj/item/storage/mre/random,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
 "Rw" = (
 /obj/structure/bed/chair/comfy/green{
 	dir = 4;
@@ -4871,23 +7959,72 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"Ry" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/multi_tile/glass/security{
+	name = "Corridor"
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
+"RB" = (
+/obj/machinery/papershredder,
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"RE" = (
+/obj/machinery/camera/network/entrance{
+	dir = 4
+	},
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"RF" = (
+/obj/effect/landmark/start{
+	name = "EZ Junior Agent"
+	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"RG" = (
+/obj/structure/closet,
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/crowbar,
+/obj/item/wrench,
+/obj/item/clothing/gloves/insulated,
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
 "RK" = (
 /obj/effect/floor_decal/corner/brown/half,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
 "RL" = (
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/bordercorner{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red/bordercorner,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/obj/structure/bed,
+/obj/structure/curtain/open/bed,
+/turf/simulated/floor/carpet/brown,
+/area/site53/uez/commandpanicbunker)
 "RR" = (
 /obj/effect/floor_decal/corner/red/half,
 /obj/structure/bed/chair/comfy,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"RS" = (
+/obj/machinery/requests_console{
+	department = "Administrative";
+	departmentType = 5;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
 "RU" = (
@@ -4917,22 +8054,170 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"RV" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Brig Iso Entry";
+	name = "EZ Brig Iso Entry"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Sb" = (
+/obj/machinery/door/airlock/command{
+	name = "EZ Security Gear Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Sf" = (
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_x = 6
+	},
+/obj/structure/filingcabinet/filingcabinet{
+	pixel_x = -9
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
 "Sh" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
+"Si" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled,
+/area/site53/uez/armory)
+"Sj" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"Sl" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"St" = (
+/obj/machinery/camera/network/entrance{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "Sv" = (
 /obj/structure/bed/chair/office{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"SA" = (
+/obj/structure/closet/secure_closet/guard/ez,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"SB" = (
+/obj/structure/flora/pottedplant/minitree,
+/obj/structure/railing/mapped,
+/obj/structure/railing/mapped{
+	dir = 8
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/commandpanicbunker)
+"SD" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/light/small/red{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
 "SG" = (
 /obj/machinery/light,
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
+"SI" = (
+/obj/structure/table/woodentable/ebony,
+/obj/machinery/photocopier/faxmachine{
+	department = "Tribunal Officer's Fax"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"SL" = (
+/obj/machinery/chemical_dispenser/bar_alc/full,
+/obj/structure/table/woodentable_reinforced/mahogany,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"SW" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/senioragentoffice)
+"SY" = (
+/obj/structure/curtain/open/privacy{
+	name = "plastic curtain"
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"Ta" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"Tb" = (
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"Tf" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "Lobby";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "Tg" = (
 /obj/effect/floor_decal/corner/orange/border,
 /obj/structure/closet/crate/bin{
@@ -4942,9 +8227,23 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"Th" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/exoplanet/barren,
+/area/site53/uez/commandpanicbunker)
+"Tk" = (
+/obj/structure/coatrack,
+/obj/item/clothing/suit/storage/toggle/labcoat,
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
 "To" = (
 /turf/simulated/floor/exoplanet/grass,
-/area/space)
+/area/site53/uez/hallway)
 "Tp" = (
 /obj/structure/bed/chair/comfy/red{
 	dir = 1;
@@ -4955,6 +8254,10 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"Tq" = (
+/obj/structure/closet,
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
 "Ts" = (
 /obj/machinery/door/airlock/command{
 	name = "Communications Tower";
@@ -4962,34 +8265,209 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"Tw" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red/border{
+"Tt" = (
+/obj/machinery/camera/network/entrance{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security{
-	name = "Evidence Storage";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"Tv" = (
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/monotile,
+/turf/simulated/floor/tiled/white,
 /area/site53/entrancezone/forensics)
+"Tw" = (
+/obj/machinery/light/small/red{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"Ty" = (
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"TB" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"TC" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"TG" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"TL" = (
+/obj/structure/bed/chair/padded/black,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/commandpanicbunker)
+"TO" = (
+/obj/structure/bed/chair/padded/black{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "TP" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"TR" = (
+/obj/machinery/cryopod,
+/obj/structure/railing/mapped{
+	dir = 4
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
 "TT" = (
 /obj/structure/table/standard,
 /obj/item/pen,
 /obj/item/paper_bin,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
+"TV" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Uh" = (
+/obj/machinery/light,
+/obj/structure/table/standard,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/gloves/insulated,
+/obj/item/crowbar,
+/obj/item/wrench,
+/turf/simulated/floor,
+/area/site53/uez/commandpanicbunker)
+"Uj" = (
+/obj/structure/bed/chair/office/comfy{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"Um" = (
+/obj/structure/cryofeed,
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"Up" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"Ur" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"Uy" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Armoury Lockdown";
+	name = "EZ Armoury Lockdown"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/armory)
+"UF" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small/red,
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
 "UG" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor,
 /area/site53/logistics/logisticsbreak)
+"UH" = (
+/obj/structure/table/standard,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/head/helmet/facecover,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/glasses/blindfold,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"UI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "UU" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
@@ -4997,10 +8475,68 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"UX" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/woodentable/ebony,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
+"Vf" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/wood/mahogany,
+/area/site53/uez/hallway)
+"Vh" = (
+/obj/structure/table/standard,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/reagent_temperature,
+/obj/machinery/camera/network/entrance{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Vj" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"Vl" = (
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"Vp" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
 "Vq" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
+"Vv" = (
+/obj/machinery/bodyscanner{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"Vx" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
 "Vy" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
@@ -5008,19 +8544,78 @@
 	},
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
-"VU" = (
-/obj/structure/cable/green{
-	d1 = 4;
+"VA" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"VC" = (
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/door/blast/regular{
-	begins_closed = 0;
-	id_tag = "ECZ Security Lockdown";
-	name = "ECZ Security Lockdown"
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"VE" = (
+/obj/item/device/flashlight/lamp,
+/obj/structure/table/standard,
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"VF" = (
+/obj/structure/table/standard,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"VK" = (
+/obj/machinery/door/airlock/glass/security{
+	name = "EZ Brig Cell";
+	req_access = list("ACCESS_SECURITY_LEVEL3");
+	id_tag = "EZBrig"
 	},
-/turf/simulated/floor/lino,
-/area/site53/uez/hallway)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"VS" = (
+/obj/structure/filingcabinet,
+/turf/simulated/floor/tiled/techmaint,
+/area/site53/uez/equipmentroom)
+"VT" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"VU" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"VX" = (
+/obj/structure/bed/chair/comfy/yellow{
+	name = "LCZ Commander"
+	},
+/obj/effect/floor_decal/corner/yellow/half,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"Wi" = (
+/obj/structure/hygiene/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/freezer,
+/area/site53/uez/commandpanicbunker)
 "Wk" = (
 /obj/effect/landmark/start{
 	name = "Communications Officer"
@@ -5030,14 +8625,237 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/upper_surface/commstower)
+"Wm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/network/entrance{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"Wp" = (
+/turf/simulated/floor/carpet/green,
+/area/site53/uez/commandpanicbunker)
+"Wq" = (
+/obj/structure/cable/green{
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/blue,
+/area/site53/uez/hallway)
+"Wu" = (
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"WA" = (
+/obj/structure/window/reinforced,
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"WD" = (
+/obj/structure/table/standard,
+/obj/machinery/door/window/brigdoor/westleft{
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/window/brigdoor/eastright{
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Lobby Windows";
+	name = "EZ Lobby Windows";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/equipmentroom)
+"WK" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/carpet/red,
+/area/site53/uez/equipmentroom)
+"WL" = (
+/obj/machinery/vending/snack,
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
+"WP" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/door/blast/shutters{
+	id_tag = "EZ Lobby Windows";
+	name = "EZ Lobby Windows";
+	begins_closed = 0
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "WQ" = (
 /turf/simulated/mineral,
 /area/site53/surface/surface)
-"WW" = (
-/obj/effect/floor_decal/corner/red/border{
+"WR" = (
+/obj/structure/cryofeed,
+/obj/machinery/camera/network/entrance{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"WV" = (
+/obj/structure/bed/chair/padded/black{
+	dir = 8
+	},
+/obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"WW" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"WZ" = (
+/obj/structure/table/standard,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Xa" = (
+/turf/simulated/floor/tiled/white,
+/area/site53/entrancezone/forensics)
+"Xb" = (
+/obj/structure/bed/padded,
+/obj/structure/curtain/open/bed,
+/obj/item/bedsheet,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/monotile,
+/area/site53/uez/commandpanicbunker)
+"Xj" = (
+/obj/machinery/vending/wallmed1{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"XB" = (
+/obj/machinery/vitals_monitor,
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"XG" = (
+/obj/structure/table/standard,
+/obj/item/roller,
+/turf/simulated/floor/tiled/white,
+/area/site53/uez/commandpanicbunker)
+"XJ" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/simulated/floor/tiled/dark,
+/area/site53/entrancezone/forensics)
+"XR" = (
+/obj/structure/table/steel,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/under/scp/dclass,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/item/clothing/shoes/orange,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"XS" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"XV" = (
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
+/area/site53/uez/conference)
+"Yb" = (
+/obj/effect/floor_decal/corner/black/full,
+/obj/machinery/light/small/red{
+	dir = 8
+	},
+/obj/structure/hygiene/toilet{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/commandpanicbunker)
+"Yd" = (
+/obj/structure/table/woodentable_reinforced/mahogany,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/machinery/keycard_auth{
+	pixel_y = 28;
+	req_access = list("ACCESS_SCIENCE_LEVEL4","ACCESS_ENGINEERING_LEVEL4")
+	},
+/turf/simulated/floor/carpet/purple,
+/area/site53/uez/commandpanicbunker)
+"Yi" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Yk" = (
+/obj/effect/catwalk_plated/dark,
+/obj/machinery/light/small/red{
+	dir = 1;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"Yl" = (
+/obj/structure/table/standard,
+/obj/item/device/flashlight/lamp,
+/obj/item/device/taperecorder,
+/turf/simulated/floor/tiled/techfloor,
 /area/site53/entrancezone/forensics)
 "Yo" = (
 /obj/machinery/light{
@@ -5056,40 +8874,193 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"YA" = (
+/obj/machinery/door/airlock/command{
+	name = "EZ Security Gear Room";
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"YD" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/crematorium{
+	dir = 1;
+	name = "HCZCrematorium";
+	id = "HCZCrematorium"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/equipmentroom)
+"YI" = (
+/obj/machinery/shieldwallgen/online{
+	max_range = 10;
+	req_access = list();
+	storedpower = 50000
+	},
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
 "YJ" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/conference)
+"YO" = (
+/obj/machinery/recharger/wallcharger{
+	dir = 1;
+	pixel_y = -23
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "YW" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
-"Zl" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
+"Zd" = (
+/obj/structure/table/standard,
+/obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/coatrack,
-/obj/item/clothing/suit/storage/toggle/labcoat,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Zj" = (
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "EZ Brig CR Windows";
+	name = "EZ Brig CR Windows";
+	pixel_x = -6;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/blast_door{
+	id_tag = "EZ Brig CR Access Outter";
+	name = "EZ Brig CR Access Outter";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Zl" = (
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
 "Zm" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
 "Zn" = (
-/obj/effect/floor_decal/corner/red/border{
-	dir = 9
+/obj/structure/railing/mapped{
+	dir = 8
 	},
-/obj/structure/closet/secure_closet{
-	name = "secure evidence locker";
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"Zo" = (
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Lobby Lockdown";
+	name = "EZ Lobby Lockdown";
+	begins_closed = 0
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Zu" = (
+/obj/structure/table/standard,
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "EZ Brig Iso Entry";
+	name = "EZ Brig Iso Entry";
+	pixel_x = -6;
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/entrancezone/forensics)
+/obj/machinery/button/blast_door{
+	dir = 4;
+	id_tag = "EZ Brig Iso Exit";
+	name = "EZ Brig Iso Exit";
+	pixel_x = 4;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
+	},
+/obj/machinery/button/alternate/door{
+	dir = 1;
+	id_tag = "EZBrig";
+	name = "EZ Brig Cells";
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"Zz" = (
+/obj/machinery/flasher{
+	id_tag = "EZBrigFlash";
+	name = "EZBrigFlash"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	network = list("Entrance Zone Network");
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "ZB" = (
 /obj/effect/wallframe_spawn/reinforced/polarized/full{
 	id = "sitedirect"
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
+"ZD" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/uez/hallway)
+"ZE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
+"ZF" = (
+/obj/machinery/vending/cola{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/commandpanicbunker)
+"ZJ" = (
+/obj/structure/table/standard,
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/senioragentoffice)
+"ZM" = (
+/obj/effect/catwalk_plated/dark,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/hallway)
+"ZO" = (
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "ZZ" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/brown/half,
@@ -21843,13 +25814,13 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+fo
+fo
+fo
 hk
 hk
 hk
@@ -22100,13 +26071,13 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+ew
+Yb
+fo
+ew
+Yb
+fo
 hk
 hk
 hk
@@ -22357,13 +26328,13 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+OJ
+vp
+fo
+OJ
+vp
+fo
 hk
 hk
 hk
@@ -22614,13 +26585,13 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+gN
+Lr
+fo
+gN
+Lr
+fo
 hk
 hk
 hk
@@ -22866,18 +26837,18 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+fo
+fo
+DO
+Ee
+fo
+DO
+Ee
+fo
 hk
 hk
 hk
@@ -23123,18 +27094,18 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+cF
+He
+LL
+Og
+DO
+EC
+EC
+Bv
+EC
+rc
+fo
 hk
 hk
 hk
@@ -23380,18 +27351,18 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+eK
+tE
+EC
+EC
+BZ
+EC
+EC
+EC
+VU
+EC
+fo
 hk
 hk
 hk
@@ -23637,23 +27608,23 @@ hk
 hk
 hk
 hk
+fo
+ss
+VU
+CC
+EC
+BZ
+EC
+EC
+xK
+uy
+VA
+fo
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
 hk
 hk
 hk
@@ -23894,23 +27865,23 @@ hk
 hk
 hk
 hk
+fo
+SB
+eM
+MS
+EC
+BZ
+EC
+EC
+Wm
+tE
+rc
+fo
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+FW
+FW
+fo
 hk
 hk
 hk
@@ -24151,23 +28122,23 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+Op
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fV
+ul
+fo
 hk
 hk
 hk
@@ -24410,25 +28381,25 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+fo
+Xb
+lr
+ra
+lr
+ra
+lr
+ra
+fo
+gm
+fo
+fo
+fo
+Hu
+fo
+fo
 hk
 hk
 hk
@@ -24667,25 +28638,25 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+rc
+fo
+eA
+eA
+eA
+eA
+eA
+eA
+fq
+fo
+Up
+eA
+zR
+fo
+gU
+yx
+fo
 hk
 hk
 hk
@@ -24924,25 +28895,25 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+lR
+eA
+eA
+eA
+eA
+eA
+eA
+eA
+JS
+eA
+eA
+eA
+zX
+fV
+fV
+fo
 hk
 hk
 hk
@@ -25181,25 +29152,25 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+rc
+fo
+eA
+eA
+eA
+eA
+eA
+eA
+fq
+fo
+Jp
+TR
+TR
+fo
+fo
+fo
+fo
 hk
 hk
 hk
@@ -25438,22 +29409,22 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+fo
+Xb
+lr
+ra
+nX
+ra
+lr
+ra
+fo
+Um
+WR
+Um
+fo
 hk
 hk
 hk
@@ -25695,22 +29666,22 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
 hk
 hk
 hk
@@ -25952,31 +29923,31 @@ hk
 hk
 hk
 hk
+fo
+EC
+EC
+fo
+GU
+Vl
+PH
+Vl
+dT
+RE
+Pk
+fo
+vi
+KM
+Ev
+fo
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+Hu
+fo
+fo
+fo
+fo
+fo
+fo
 hk
 hk
 hk
@@ -26209,31 +30180,31 @@ hk
 hk
 hk
 hk
+fo
+EC
+EC
+fo
+XG
+vX
+Vv
+NL
+SY
+Vl
+XB
+fo
+Ky
+QF
+Uh
+fo
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+Wi
+yx
+fo
+FW
+fo
+FW
+fo
 hk
 hk
 hk
@@ -26466,31 +30437,31 @@ hk
 hk
 hk
 hk
+fo
+EC
+EC
+fo
+LP
+vX
+yE
+Vl
+SY
+Vl
+vM
+fo
+Ar
+QF
+dI
+fo
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fV
+fV
+fo
+fV
+fV
+fV
+fo
 hk
 hk
 hk
@@ -26723,32 +30694,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+fo
+wh
+Tt
+xj
+Vl
+dT
+In
+ff
+fo
+nQ
+QF
+JG
+fo
+fo
+fo
+zX
+fo
+fo
+gm
+fo
+fo
+fo
+fo
 hk
 hk
 hk
@@ -26980,32 +30951,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+fo
+fo
+fo
+fo
+OL
+fo
+fo
+fo
+fo
+fo
+Dl
+fo
+fo
+zA
+Vx
+EC
+Bv
+EC
+EC
+CT
+qI
+fn
+fo
 hk
 hk
 hk
@@ -27237,32 +31208,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+Bv
+EC
+EC
+Bv
+EC
+Xj
+EC
+EC
+Bv
+EC
+VC
+UI
+Gp
+UI
+sC
+EC
+VU
+EC
+EC
+mf
+ph
+fo
+fo
 hk
 hk
 hk
@@ -27494,32 +31465,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+EC
+zH
+EC
+EC
+zH
+EC
+zH
+EC
+EC
+zH
+St
+EC
+EC
+zH
+EC
+Kv
+xK
+eL
+VA
+EC
+AL
+nl
+fn
+fo
 hk
 hk
 hk
@@ -27751,32 +31722,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+ZF
+Ef
+fo
+AG
+Kv
+xK
+fu
+VA
+EC
+us
+Lw
+fo
+fo
 hk
 hk
 hk
@@ -28020,20 +31991,20 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+SL
+Kv
+EC
+tE
+EC
+EC
+Od
+Gw
+fn
+fo
 hk
 hk
 hk
@@ -28260,37 +32231,37 @@ hk
 hk
 hk
 hk
+cX
+cX
+cX
+cX
+cX
+cX
+hk
+hk
+IV
+IV
+IV
+IV
+IV
+IV
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+qt
+Kv
+EC
+EC
+EC
+EC
+sj
+rD
+fo
+fo
 hk
 hk
 hk
@@ -28517,37 +32488,37 @@ hk
 hk
 hk
 hk
+cX
+Et
+sb
+Et
+cX
+cX
+hk
+IV
+IV
+Hy
+xR
+Cy
+As
+IV
+IV
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+uH
+JY
+AL
+Lq
+EJ
+Kv
+EC
+VU
+EC
+EC
+qj
+nR
+fn
+fo
 hk
 hk
 hk
@@ -28774,37 +32745,37 @@ hk
 hk
 hk
 hk
+cX
+Cj
+Cj
+Cj
+Pv
+cX
+hk
+IV
+HH
+dL
+dL
+Si
+dN
+jD
+IV
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+AV
+AL
+uZ
+QU
+Kv
+xK
+fu
+VA
+EC
+TL
+tC
+fo
+fo
 hk
 hk
 hk
@@ -29031,37 +33002,37 @@ hk
 hk
 hk
 hk
+cX
+Cj
+Cj
+Cj
+CD
+cX
+hk
+IV
+lj
+dN
+dN
+qu
+dN
+ue
+IV
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+Rv
+qm
+Ba
+Qy
+Ek
+xK
+BG
+VA
+EC
+Wp
+ne
+fn
+fo
 hk
 hk
 hk
@@ -29276,49 +33247,49 @@ hk
 hk
 hk
 hk
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+Yk
+Cj
+Cj
+No
+cX
+hk
+IV
+rF
+eP
+dN
+qu
+eP
+my
+IV
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fj
+qf
+Ls
+Ir
+WW
+EC
+tE
+EC
+EC
+Hp
+xq
+fo
+fo
 hk
 hk
 hk
@@ -29533,49 +33504,49 @@ hk
 hk
 hk
 hk
+cX
+pg
+FH
+cX
+pg
+FH
+cX
+pg
+FH
+cX
+pg
+FH
+cX
+Cj
+Cj
+Cj
+Fu
+cX
+hk
+IV
+IV
+IV
+uf
+sy
+IV
+IV
+IV
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+Yd
+AL
+on
+rZ
+LD
+EC
+EC
+EC
+EC
+QI
+RL
+fn
+fo
 hk
 hk
 hk
@@ -29790,49 +33761,49 @@ hk
 hk
 hk
 hk
+cX
+bR
+dj
+cX
+bR
+dj
+cX
+bR
+dj
+cX
+bR
+dj
+cX
+xM
+Cj
+Cj
+Pj
+cX
+hk
+hk
+hk
+IV
+mr
+KG
+IV
 hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+ef
+OI
+vY
+IA
+LD
+Vh
+oS
+Bc
+xu
+CL
+rN
+fo
+fo
 hk
 hk
 hk
@@ -30047,49 +34018,49 @@ hk
 hk
 hk
 hk
+cX
+LU
+Fx
+cX
+LU
+Fx
+cX
+LU
+Fx
+cX
+LU
+Fx
+cX
+OZ
+Cj
+JE
+YD
+cX
+hk
+hk
+hk
+IV
+Uy
+vd
+IV
 hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+fo
+GB
+fo
+fo
+fo
+fo
+fo
+fo
+fo
+fo
 hk
 hk
 hk
@@ -30303,44 +34274,44 @@ hk
 hk
 hk
 hk
+cX
+cX
+VK
+MZ
+cX
+VK
+MZ
+cX
+VK
+MZ
+cX
+VK
+MZ
+cX
+cX
+wI
+cX
+cX
+cX
+cX
+cX
+cX
+IV
+uk
+qR
+IV
+cX
+cX
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+Bv
+nV
+Dn
+ee
+Dn
+fo
 hk
 hk
 hk
@@ -30560,44 +34531,44 @@ hk
 hk
 hk
 hk
+cX
+DJ
+ZO
+ZO
+Zz
+ZO
+ZO
+DJ
+ZO
+ZO
+DJ
+ZO
+mx
+cX
+ZE
+ZO
+EI
+cX
+CG
+Mp
+Mn
+PV
+ed
+ZO
+dU
+Jl
+Bl
+FQ
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+fo
+fo
+fo
+DB
+fo
+fo
 hk
 hk
 hk
@@ -30817,45 +34788,45 @@ hk
 hk
 hk
 hk
+cX
+ZO
+ZO
+ZO
+zm
+ZO
+ZO
+ZO
+zm
+ZO
+ZO
+ZO
+ZO
+RV
+ZO
+ZO
+lA
+cX
+ZJ
+fk
+Uj
+PT
+ed
+ZO
+dU
+TC
+lc
+WZ
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+nV
+fo
+fo
+fo
+DB
+fo
+fo
+fo
 hk
 hk
 hk
@@ -31074,45 +35045,45 @@ hk
 hk
 hk
 hk
+cX
+ZO
+ZO
+AN
+mS
+AN
+ZO
+AN
+mS
+AN
+ZO
+ZO
+ZO
+RV
+ZO
+ZO
+UH
+cX
+KS
+fk
+KP
+Aa
+ed
+ZO
+dU
+ZO
+ZO
+Kk
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+EC
+ML
+fo
+uX
+ee
+Zl
+tm
+fo
 hk
 hk
 hk
@@ -31331,45 +35302,45 @@ hk
 hk
 hk
 hk
+cX
+ZO
+ZO
+ZO
+TO
+ZO
+ZO
+ZO
+ZO
+OC
+lU
+ZO
+ZO
+cX
+ZO
+ZO
+Gn
+cX
+Tb
+Ur
+IJ
+Ur
+SW
+qx
+Sl
+xG
+xG
+xG
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+mt
+EC
+rm
+Nt
+Zl
+ee
+Zl
+yC
+fo
 hk
 hk
 hk
@@ -31588,45 +35559,45 @@ hk
 hk
 hk
 hk
+cX
+pJ
+ZO
+ZO
+Ty
+ZO
+ZO
+pJ
+ds
+cX
+rC
+wP
+AO
+cX
+ZO
+ZO
+XR
+cX
+LA
+fk
+fk
+fk
+PR
+ZO
+dU
+Jl
+QZ
+FQ
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+GE
+Ph
+fo
+uX
+ee
+Zl
+RG
+fo
 hk
 hk
 hk
@@ -31845,45 +35816,45 @@ hk
 hk
 hk
 hk
+cX
+cX
+VK
+MZ
+cX
+VK
+MZ
+cX
+cX
+cX
+Ei
+ZO
+xn
+rs
+ZO
+ZO
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+BP
+Sl
+TC
+lc
+ua
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+fo
+vq
+fo
+fo
+fo
 hk
 hk
 hk
@@ -32103,55 +36074,55 @@ hk
 hk
 hk
 hk
+cX
+LU
+Fx
+cX
+LU
+Fx
+cX
+hk
+cX
+Zj
+ZO
+Zu
+vK
+ZO
+ds
+cX
+Ld
+cX
+yT
+QN
+zQ
+cX
+ZO
+dU
+ZO
+ZO
+mx
+cX
+hk
+hk
+hk
+hk
+fo
+fo
+vq
+fo
+fo
 hk
 hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+ac
+cl
+ac
+ac
+ac
+ac
+ac
 hk
 hk
 hk
@@ -32360,55 +36331,55 @@ hk
 hk
 hk
 hk
+cX
+bR
+dj
+cX
+bR
+dj
+cX
 hk
+cX
+cX
+zf
+cX
+cX
+yO
+yO
+cX
+cX
+cX
+ZO
+wz
+qx
+YA
+qx
+dM
+ZO
+pI
+Ey
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+fo
+fo
+fo
+Zl
+ee
+Zl
+fo
+fo
+fo
+fo
 hk
 hk
 ac
-cl
+dd
+dl
+cd
+dh
+dO
 ac
-ac
-ac
-ac
-ac
-hk
-hk
 hk
 hk
 hk
@@ -32617,55 +36588,55 @@ hk
 hk
 hk
 hk
+cX
+OE
+Ku
+cX
+OE
+Ku
+cX
 hk
+cX
+lA
+ZO
+ZO
+ZE
+ZO
+ZO
+pL
+Gn
+cX
+ZO
+dU
+YO
+cX
+nh
+nr
+ZO
+nr
+uS
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+Th
+Md
+Ff
+mN
+lC
+mN
+Ff
+cB
+Ex
+fo
 hk
 hk
 ac
-dd
-dl
-cd
+Pr
+dm
+dD
 dh
-dO
+gt
 ac
-hk
-hk
 hk
 hk
 hk
@@ -32874,55 +36845,55 @@ hk
 hk
 hk
 hk
+cX
+cX
+cX
+cX
+cX
+cX
+cX
 hk
+cX
+lA
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+Sb
+ZO
+dU
+De
+cX
+nh
+nr
+ZO
+nr
+nh
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fo
+IG
+YI
+OM
+OM
+Ta
+OM
+OM
+YI
+qd
+fo
 hk
 hk
 ac
-cd
-dm
-dD
+AC
+dn
+uM
 dh
-gt
+dQ
 ac
-hk
-hk
 hk
 hk
 hk
@@ -33139,47 +37110,47 @@ hk
 hk
 hk
 hk
+cX
+bH
+ZO
+pP
+tO
+lA
+lA
+bH
+lA
+cX
+pP
+dU
+PM
+cX
+SA
+Ko
+ht
+RF
+SA
+cX
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+wX
+wX
+wX
+CJ
+QE
+Ta
+zE
+CJ
+wX
+wX
+wX
 hk
 hk
 ac
-Iy
-dn
-df
+dg
+dp
+vG
 dh
-dQ
+dE
 ac
-hk
-hk
 hk
 hk
 hk
@@ -33388,55 +37359,55 @@ hk
 hk
 hk
 hk
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+cX
+Sb
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+wZ
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+ac
+zG
+OD
+zN
+fr
+rP
+ac
 hk
 hk
 hk
 hk
 ac
-ac
-ac
-ac
-hk
-ac
-ac
-ac
-ac
-dg
-dp
-vG
+ZD
 dh
 dh
+dh
+dS
 ac
-hk
-hk
 hk
 hk
 hk
@@ -33645,55 +37616,55 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-ac
-bL
-aM
-ac
-ac
-ac
-aM
-aM
+fe
+GS
+ll
+GS
+fe
+Dg
+Xa
+Kq
+fe
+Ot
+Gl
+ll
 cX
-dh
-dh
-dh
-dh
-dh
+th
+AQ
+RB
+np
+lT
+VT
+dU
+ZE
+Mm
+vU
+BC
+Kg
+Ke
+na
+Kg
+cX
+hk
+hk
+ac
+ac
+Zn
+vR
+Zn
+Zn
+ac
+ac
 ac
 hk
 hk
+ac
+ac
+dh
+dh
+ac
+ac
+ac
 hk
 hk
 hk
@@ -33902,52 +37873,52 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+GS
+Gl
+GS
+fe
+vb
+Xa
+Tq
+fe
+Gl
+Gl
+Gl
+cX
+Iy
+wS
+Rb
+WK
+lT
+mX
+dU
+ZO
+Kg
+Jl
+QZ
+Lo
+Jl
+QZ
+Yi
+cX
 hk
 hk
 ac
 bM
 aM
-aM
-aM
-aM
-bT
-aM
+vF
+TB
+TB
+rv
+pr
+ni
+hk
+hk
+hk
 ac
-dj
-dq
-dE
 dh
-dS
+dh
 ac
 hk
 hk
@@ -34159,42 +38130,41 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+GS
+Gl
+GS
+fe
+GW
+Xa
+Tq
+fe
+Gl
+Gl
+Gl
+cX
+qF
+wS
+Dy
+VE
+lT
+Bq
+dU
+ZO
+Kg
+BS
+lc
+TG
+TC
+lc
+TG
+cX
 hk
 hk
 ac
 ac
-bS
-ac
+aM
+UF
 ac
 ac
 ac
@@ -34202,9 +38172,10 @@ cy
 ac
 ac
 ac
+hk
 ac
-dH
-dT
+dh
+fv
 ac
 ac
 ac
@@ -34416,51 +38387,51 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+fe
+nv
+fe
+fe
+Tv
+Xa
+Tk
+fe
+KB
+Gl
+hv
+cX
+VS
+xC
+lk
+xC
+lT
+lp
+dU
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+mx
+cX
 hk
 hk
 hk
 ac
 aM
+vR
 ac
 bY
 vN
+Vf
 cs
-ci
-ci
-cd
 dr
 ac
-ev
+hk
+ac
+bK
 bK
 dX
 dh
@@ -34673,51 +38644,51 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+Sf
+Xa
+CF
+oH
+WA
+Xa
+FI
+fe
+Gl
+Gl
+Gl
+cX
+hf
+Eq
+bS
+se
+Rc
+ZO
+dU
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+ZO
+cX
 hk
 hk
 hk
 ac
 aM
+vR
 ac
 cb
 ck
 ct
-ci
-ct
-cd
-ca
+vj
+Nd
 ac
-bK
+hk
+ac
+ev
 bK
 ac
 ei
@@ -34930,41 +38901,41 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+Gu
+Xa
+Xa
+Xa
+QP
+Xa
+Xa
+fe
+Gl
+Gl
+Gl
+cX
+cX
+cX
+cX
+cX
+cX
+ZO
+dU
+zm
+zm
+ZO
+zm
+zm
+ZO
+ZO
+Kk
+cX
+ac
+ac
+ac
 ac
 aM
+vR
 ac
 ac
 cl
@@ -34972,7 +38943,7 @@ ac
 cz
 ac
 ac
-ac
+hk
 ac
 eB
 bK
@@ -35187,49 +39158,49 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-ac
-aM
+fe
+Je
+Xa
+Xa
+Xa
+vn
+Xa
+Xa
+CK
+Gl
+Gl
+Gl
+ll
+Gl
+Gl
+HE
+ZO
+ZE
+wz
+dM
+VF
+yN
+ZO
+CR
+nT
+ZO
+ZO
+ZO
+Cz
+Tw
+Wu
+Wu
+Tw
+Wu
+vR
 ac
 ov
 cm
-ac
-cB
-ac
+cd
+vj
 dk
-ds
+ac
+hk
 ac
 bK
 bK
@@ -35444,49 +39415,49 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+Hb
+zJ
+GL
+Do
+QA
+Xa
+yt
+fe
+mV
+xX
+LX
+LX
+LX
+xX
+rG
+qx
+XS
+TV
+qx
+WV
+xm
+qx
+lN
+lN
+XS
+qx
+qx
+BV
+TB
+TB
+ZM
+TB
+TB
+oA
 ac
-aM
+cd
+cd
+cd
+vj
+MX
 ac
-cd
-cd
-cd
-ci
-ci
-ci
-ci
+hk
 ac
 bK
 bK
@@ -35701,49 +39672,49 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+Pp
+fe
+fe
+HE
+fe
+cX
+cX
+Tf
+cX
+Zo
+IO
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
+cX
 ac
-ac
-ac
-ac
-aM
+hA
+vR
+zg
+Zn
+Zn
 HF
 cd
 co
 Rd
-ci
-wX
-ci
-dt
+Pt
+pb
+ac
+hk
 ac
 bK
 bK
@@ -35964,43 +39935,43 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-ac
-aM
-aM
+fe
+Ht
+MU
+Ht
+Nb
+fd
+Gl
+AZ
+cX
+Zd
+ZO
+cX
+pX
+ZO
+Ix
+Sj
+bQ
+bQ
+bQ
+MK
+UX
+dK
+SD
+zU
+rv
+Qu
+va
 aM
 bT
 ac
 ce
 cq
 cu
-ci
+vj
 po
-uZ
-rc
+ac
+hk
 ac
 ev
 bK
@@ -36017,20 +39988,20 @@ ai
 ai
 ai
 hk
-IV
-IV
-IV
-IV
-IV
-Mm
-Mm
-Mm
-Mm
-Mm
-Mm
-Mm
-Mm
-Mm
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 ai
@@ -36221,30 +40192,30 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+ca
+Yl
+sa
+qS
+XJ
+GR
+ws
+cX
+Mm
+bL
+Bz
+hC
+qx
+JM
+Vp
+Nr
+tp
+nG
+nG
+Mo
+dK
+vR
+ac
 ac
 aP
 ac
@@ -36256,8 +40227,8 @@ ZB
 ac
 cS
 ac
-ZB
-ZB
+ac
+ac
 ac
 bK
 bK
@@ -36274,20 +40245,20 @@ hk
 hk
 hk
 hk
-IV
-lT
-GL
-tS
-zX
-Zl
-Bv
-wS
-qK
-Mm
-Zn
-rP
-DB
-Mm
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 ai
@@ -36478,40 +40449,40 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+Ht
+jF
+Ht
+qS
+wi
+zt
+nk
+cX
+qE
+xn
+xQ
+xa
+ZO
+Ix
+wv
+wn
+qr
+Hc
+nG
+qK
+dK
+vR
+zq
 ac
-aV
+vH
 bq
 bN
 bU
-bb
+xx
 cf
 cr
 cv
-cg
+Wq
 cY
 cg
 dx
@@ -36531,20 +40502,20 @@ hk
 hk
 hk
 hk
-IV
-nV
-qx
-rG
-QP
-nR
-WW
-WW
-RL
-Tw
-qt
-nl
-OM
-Mm
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 ai
@@ -36735,36 +40706,36 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+fe
+cX
+WP
+WD
+cX
+yq
+bp
+dK
+FT
+mZ
+nG
+nG
+nG
+sO
+dK
+wM
+yY
 ac
 aV
-aV
-aV
-aV
-bb
+Ga
+bn
+bn
+xx
 cg
 cg
 cw
@@ -36788,20 +40759,20 @@ hk
 hk
 hk
 hk
-IV
-zJ
-MX
-uX
-Od
-xn
-zE
-wz
-xa
-Mm
-DJ
-hC
-Ba
-Mm
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 ai
@@ -37000,30 +40971,30 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
 ac
-aV
+WL
+bK
+DA
+fT
+bK
+Ix
+zC
+PY
+rO
+SI
+bQ
+Pl
+dK
+pj
+Wu
+ac
+nN
 LT
-aV
-aV
+Lj
+Lj
 bX
-ci
-ci
+tS
+tS
 cx
 cV
 db
@@ -37045,20 +41016,20 @@ hk
 hk
 hk
 hk
-IV
-IV
-IV
-IV
-IV
-Ir
-Mm
-Mm
-Mm
-Mm
-Mm
-Mm
-Mm
-Cj
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 ai
@@ -37257,38 +41228,38 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+ac
+xw
+bK
+bK
+fT
+bK
+Ix
+Ix
+Ix
+Ix
+Ix
+Ix
+Ix
+dK
+oa
+GV
 ac
 bl
-aV
-aV
+bn
+bn
 bV
-bb
+xx
 ci
 ci
 ci
-wX
+Pt
 ci
 ci
 dt
 ac
-dI
-dI
+bK
+bK
 ac
 ac
 ac
@@ -37514,32 +41485,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+ac
+bK
+bK
+bK
+GP
+cH
+cH
+cH
+cH
+cH
+cH
+cH
+cH
+Kn
+df
+bK
 cl
+mp
+bI
 bn
-bH
-bQ
 bW
-bb
+xx
 cj
 cj
 ct
-ci
+vj
 ct
 cj
 cj
@@ -37771,26 +41742,26 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
 ac
-bp
-Ga
-bR
+bK
+bK
+bK
+fT
+bK
+eo
+bK
+bK
+gQ
+bK
+bK
+bK
+bK
+fT
+bK
+ac
+ac
+ac
+ac
 ac
 ac
 bb
@@ -38028,38 +41999,38 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
 ac
-bn
-bH
-bn
-bb
-cC
+xx
+xx
+ac
+nF
+rf
+ac
+xx
+xx
+ac
+ac
+ac
+ac
+AI
+gw
+cH
+Ry
+cH
 cH
 cH
 cH
 di
+cH
+cH
+cH
+lg
 ch
 cH
 cH
 cW
 cH
-fV
+yK
 bK
 bK
 ac
@@ -38285,27 +42256,27 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+Vj
+gT
+gT
+dH
+gT
+gT
+gT
+PE
+dF
 hk
 hk
 ac
-bn
-bI
-bn
-bb
+bK
+eo
+bK
+bK
+gQ
+bK
+bK
+bK
 fT
 bK
 bK
@@ -38316,7 +42287,7 @@ bK
 bK
 da
 bK
-fT
+bK
 gQ
 bK
 ac
@@ -38542,22 +42513,22 @@ hk
 hk
 hk
 hk
+dF
+eD
+gT
+ux
+AF
+Rw
+tv
+gT
+eq
+dF
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-cD
-cD
-cD
-cD
-cD
-cD
-cD
+ac
+ac
+ac
+ac
 ac
 ac
 ac
@@ -38572,8 +42543,8 @@ zp
 cc
 cQ
 be
-dI
-VU
+bK
+bK
 ac
 ac
 ac
@@ -38799,21 +42770,21 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+fc
+gT
+RR
+Ql
+TP
+yb
+gT
+Nk
+dF
 hk
 hk
 hk
 cD
 OG
-br
-br
-br
-br
 DC
 br
 zO
@@ -38830,17 +42801,17 @@ cE
 eb
 be
 bK
-gm
-dF
-dF
-dF
-ew
-dF
-dF
-dF
-dF
-dF
-dF
+gL
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -39056,21 +43027,21 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+HN
+If
+VX
+NF
+fb
+MG
+gT
+QG
+dF
 hk
 hk
 hk
 cD
 qs
-br
-br
-br
-br
 br
 br
 br
@@ -39087,17 +43058,17 @@ bs
 cT
 be
 bK
-fT
-eA
-fv
-gT
-gT
-gT
-gT
-gT
-gT
-PE
-dF
+bK
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -39313,21 +43284,21 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+YJ
+gT
+hp
+hp
+fh
+fh
+gT
+YJ
+dF
 hk
 hk
 hk
 cD
 fY
-br
-rX
-aF
-bP
 br
 rX
 aF
@@ -39343,18 +43314,18 @@ bC
 cG
 gW
 aI
-bK
-fT
-eA
-eD
-gT
-ux
-ff
-Rw
-tv
-gT
-eq
-dF
+ac
+ac
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -39570,21 +43541,21 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+tj
+gT
+Nv
+hp
+fh
+tc
+ml
+XV
+dF
 hk
 hk
 hk
 cD
 Vy
-br
-rX
-aF
-bP
 br
 rX
 aF
@@ -39600,18 +43571,18 @@ be
 be
 be
 aI
-bK
-fT
-eA
-fc
-gT
-RR
-fb
-TP
-yb
-gT
-Nk
-dF
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -39827,21 +43798,21 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+RS
+gT
+hp
+hp
+fh
+fh
+gT
+YJ
+dF
 hk
 hk
 hk
 cD
 YW
-br
-br
-br
-br
 br
 br
 br
@@ -39857,18 +43828,18 @@ ky
 hd
 hj
 ac
-bK
-gm
-dF
-eL
-gT
-FW
-OS
-fb
-MG
-gT
-QG
-dF
+ac
+ac
+ac
+ac
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -40084,21 +44055,21 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+mg
+gT
+sr
+fi
+Fo
+NJ
+gT
+ez
+dF
 hk
 hk
 hk
 cD
 lE
-br
-rX
-aF
-bP
 br
 rX
 aF
@@ -40113,19 +44084,19 @@ eS
 hb
 eS
 kA
-jF
-bK
-gw
-eK
-eM
-gT
-hp
-hp
-fh
-fh
-gT
-YJ
-dF
+fW
+aw
+er
+To
+ea
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -40341,21 +44312,21 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
+dF
+gs
+gT
+nI
+OS
+Qv
+Tp
+gT
+HP
+dF
 hk
 hk
 hk
 cD
 nB
-br
-rX
-aF
-bP
 Yo
 rX
 aF
@@ -40370,19 +44341,19 @@ ha
 eS
 gX
 kC
-jF
-bK
-bK
-gT
-gT
-gT
-Nv
-hp
-fh
-tc
-ml
-YJ
-dF
+fW
+aw
+To
+To
+To
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -40598,19 +44569,19 @@ hk
 hk
 hk
 hk
+dF
+UU
+gT
+ql
+fg
+zW
+ms
+gT
+CH
+dF
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-cD
-cD
-cD
-cD
 cD
 cD
 cD
@@ -40628,18 +44599,18 @@ eS
 eS
 kE
 ac
-bK
-gL
-dF
-fq
-gT
-hp
-hp
-fh
-fh
-gT
-YJ
-dF
+cZ
+aw
+aw
+aw
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -40855,22 +44826,22 @@ hk
 hk
 hk
 hk
+dF
+Lv
+gT
+gT
+oD
+gT
+gT
+gT
+MI
+dF
 hk
 hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-ab
+ac
 aw
 aw
 aw
@@ -40884,19 +44855,19 @@ eS
 eS
 eS
 kJ
-jF
-bK
-gN
-eA
-mg
-gT
-sr
-fi
-Fo
-NJ
-gT
-ez
-dF
+fW
+To
+aw
+eg
+aw
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -41112,22 +45083,22 @@ hk
 hk
 hk
 hk
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
+dF
 hk
 hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-ab
+ac
 cZ
 To
 eg
@@ -41141,19 +45112,19 @@ ha
 eS
 gX
 kL
-jF
-bK
-bK
-eA
-gs
-gT
-nI
-OS
-Qv
-Tp
-gT
-HP
-dF
+fW
+aw
+aw
+aw
+To
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -41384,7 +45355,7 @@ hk
 hk
 hk
 hk
-ab
+ac
 aw
 To
 To
@@ -41399,18 +45370,18 @@ eS
 eS
 kM
 ac
-bK
-bK
-eA
-UU
-gT
-ql
-fg
-zW
-ms
-gT
-CH
-dF
+ea
+To
+eg
+aw
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -41641,8 +45612,8 @@ hk
 hk
 hk
 hk
-ab
-To
+ac
+bF
 To
 aw
 To
@@ -41656,18 +45627,18 @@ kv
 kz
 hU
 ac
-bK
-bK
-eA
-fu
-gT
-gT
-gT
-gT
-gT
-gT
-lr
-dF
+aw
+To
+To
+To
+ac
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -41898,7 +45869,7 @@ hk
 hk
 hk
 hk
-ab
+ac
 To
 dP
 aw
@@ -41913,18 +45884,18 @@ fW
 fW
 fW
 ac
+To
+To
+cZ
+To
 ac
-dU
-ac
-ac
-ac
-cl
-dF
-dF
-dF
-dF
-dF
-dF
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -42155,7 +46126,7 @@ hk
 hk
 hk
 hk
-ab
+ac
 To
 aw
 To
@@ -42169,13 +46140,13 @@ aw
 nJ
 aw
 cZ
+To
+To
+aw
+To
+To
 ac
-dK
-dW
-dW
-fd
-fm
-ac
+hk
 hk
 hk
 hk
@@ -42412,7 +46383,7 @@ hk
 hk
 hk
 hk
-ab
+ac
 To
 nJ
 To
@@ -42426,13 +46397,13 @@ To
 aw
 er
 aw
+nJ
+To
+nJ
+To
+aw
 ac
-dL
-mM
-ed
-fe
-fn
-ac
+hk
 hk
 hk
 hk
@@ -42669,7 +46640,7 @@ hk
 hk
 hk
 hk
-ab
+ac
 To
 aw
 To
@@ -42683,13 +46654,13 @@ To
 To
 aw
 nJ
+bF
+To
+aw
+To
+To
 ac
-dM
-dW
-ee
-fj
-fo
-ac
+hk
 hk
 hk
 hk
@@ -42926,7 +46897,7 @@ hk
 hk
 hk
 hk
-ab
+ac
 aw
 aw
 To
@@ -42940,13 +46911,13 @@ cZ
 To
 bO
 aw
+aw
+aw
+aw
+To
+bF
 ac
-dN
-dW
-ef
-fk
-ef
-ac
+hk
 hk
 hk
 hk
@@ -43183,27 +47154,27 @@ hk
 hk
 hk
 hk
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
-ab
 ac
 ac
 ac
-cl
 ac
 ac
 ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+hk
 hk
 hk
 hk

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -504,7 +504,7 @@
 	dir = 8;
 	icon_state = "closed";
 	name = "EZ Security Center";
-	req_access = list("ACCESS_SECURITY_LEVEL1");
+	req_access = list("ACCESS_SECURITY_LEVEL2");
 	id_tag = "EZBrigLobbyEntry"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -754,6 +754,12 @@
 	name = "SD Office Outter Lockdown";
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
+/obj/machinery/button/blast_door{
+	id_tag = "sitedirect";
+	name = "Panic Bunker Access";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
 "bZ" = (
@@ -960,8 +966,8 @@
 /area/site53/uez/hallway)
 "cz" = (
 /obj/machinery/door/blast/regular/open{
-	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown"
+	id_tag = "sitedirect2";
+	name = "inner SD lockdown"
 	},
 /obj/structure/cable/green{
 	icon_state = "4-8"
@@ -2710,6 +2716,12 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
+/obj/machinery/button/blast_door{
+	id_tag = "sitedirect";
+	name = "Panic Bunker Access";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
 "hC" = (
@@ -4315,13 +4327,9 @@
 /area/site53/uez/conference)
 "mt" = (
 /obj/effect/paint_stripe/blue,
-/obj/machinery/button/blast_door{
-	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown";
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
+/obj/machinery/status_display,
 /turf/simulated/wall/titanium,
-/area/site53/uez/commandpanicbunker)
+/area/site53/uez/hallway)
 "mx" = (
 /obj/structure/flora/pottedplant/minitree,
 /turf/simulated/floor/tiled/dark,
@@ -4424,13 +4432,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "ni" = (
-/obj/machinery/button/blast_door{
-	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown"
-	},
-/obj/effect/paint_stripe/blue,
-/turf/simulated/wall/titanium,
-/area/site53/uez/hallway)
+/obj/effect/catwalk_plated/dark,
+/obj/structure/bed/chair/padded/black,
+/turf/simulated/floor/plating,
+/area/site53/uez/commandpanicbunker)
 "nk" = (
 /obj/structure/table/standard,
 /obj/machinery/photocopier,
@@ -4662,6 +4667,13 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "sitedirect";
+	name = "Panic Bunker Access";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
@@ -4906,6 +4918,16 @@
 /obj/item/device/radio,
 /turf/simulated/floor/tiled/old_tile,
 /area/space)
+"qZ" = (
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "sitedirect";
+	name = "Panic Bunker Access";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
+/turf/simulated/floor/lino,
+/area/site53/uez/hallway)
 "ra" = (
 /obj/structure/bed/padded,
 /obj/structure/curtain/open/bed,
@@ -5263,13 +5285,15 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
 "uH" = (
-/obj/effect/paint_stripe/blue,
 /obj/machinery/button/blast_door{
+	dir = 1;
 	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown"
+	name = "Panic Bunker Access";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
-/turf/simulated/wall/titanium,
-/area/site53/uez/commandpanicbunker)
+/turf/simulated/floor/tiled/dark,
+/area/site53/uez/equipmentroom)
 "uM" = (
 /obj/structure/table/standard,
 /obj/item/stamp/rd,
@@ -5289,6 +5313,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/bed/chair/padded/black,
 /turf/simulated/floor/plating,
 /area/site53/uez/commandpanicbunker)
 "uZ" = (
@@ -5450,8 +5475,8 @@
 "vN" = (
 /obj/structure/table/woodentable_reinforced/mahogany,
 /obj/machinery/button/blast_door{
-	id_tag = "sitedirect";
-	name = "Administrative Offices Lockdown"
+	id_tag = "sitedirect2";
+	name = "Inner Lockdown SD"
 	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
@@ -6113,6 +6138,12 @@
 "AL" = (
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/commandpanicbunker)
+"AM" = (
+/obj/machinery/door/airlock/glass/command{
+	name = "Internal Tribunal Department Representitive"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/repoffice/internaltribunal)
 "AN" = (
 /obj/structure/bed/chair/padded/black,
 /turf/simulated/floor/tiled/dark,
@@ -7105,6 +7136,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/button/blast_door{
+	id_tag = "sitedirect";
+	name = "Panic Bunker Access";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL3"))
+	},
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/commandpanicbunker)
 "Ka" = (
@@ -7484,6 +7521,13 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/wrench,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "sitedirect";
+	name = "Panic Bunker Access";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL4")
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
 "MS" = (
@@ -32629,7 +32673,7 @@ IV
 IV
 IV
 hk
-uH
+fo
 JY
 AL
 Lq
@@ -35456,11 +35500,11 @@ xG
 xG
 mr
 hk
-mt
+fo
 EC
 rm
 Nt
-Zl
+ni
 ee
 Zl
 yC
@@ -37770,9 +37814,9 @@ na
 Kg
 cX
 hk
-hk
 ac
 ac
+Zn
 Zn
 vR
 Zn
@@ -38027,16 +38071,16 @@ QZ
 Yi
 cX
 hk
-hk
 ac
 bM
+aM
 aM
 vF
 TB
 TB
 rv
 pr
-ni
+ac
 hk
 hk
 hk
@@ -38284,9 +38328,9 @@ lc
 TG
 cX
 hk
-hk
 ac
 ac
+aM
 aM
 UF
 ac
@@ -38539,11 +38583,11 @@ ZO
 ZO
 ZO
 mx
-cX
-hk
+mr
 hk
 hk
 ac
+aM
 aM
 vR
 ac
@@ -38795,12 +38839,12 @@ ZO
 ZO
 ZO
 ZO
-ZO
-mr
-hk
+Kk
+cX
 hk
 hk
 ac
+aM
 aM
 vR
 ac
@@ -39052,12 +39096,12 @@ zm
 zm
 ZO
 ZO
-Kk
+uH
 cX
 ac
 ac
 ac
-ac
+aM
 aM
 vR
 ac
@@ -39313,8 +39357,8 @@ ZO
 Cz
 Tw
 Wu
-Wu
 Tw
+Wu
 Wu
 vR
 ac
@@ -41363,7 +41407,7 @@ Ix
 Ix
 Ix
 Ix
-Ix
+AM
 Ix
 dK
 oa
@@ -41624,8 +41668,8 @@ cH
 cH
 Kn
 df
-bK
-cl
+qZ
+ac
 mp
 bI
 bn
@@ -41883,7 +41927,7 @@ bK
 fT
 bK
 ac
-ac
+mt
 ac
 ac
 ac

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -3585,8 +3585,11 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
 "jD" = (
-/obj/structure/closet/secure_closet/guard/breachautomatics,
-/obj/machinery/light,
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EZ Rifle Locker";
+	name = "EZ Rifle Locker"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "jE" = (
@@ -4300,12 +4303,10 @@
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
 "mr" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "EZ Secure Armoury";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/uez/armory)
+/obj/effect/paint_stripe/red,
+/obj/machinery/status_display,
+/turf/simulated/wall/titanium,
+/area/site53/uez/equipmentroom)
 "ms" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 1
@@ -4326,19 +4327,22 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "my" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /obj/structure/table/rack,
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/ionrifle,
+/obj/machinery/camera/autoname{
+	dir = 8;
+	network = list("Entrance Zone Network")
+	},
 /obj/machinery/button/blast_door{
 	dir = 1;
 	id_tag = "EZ Armoury Lockdown";
 	name = "EZ Armoury Lockdown";
 	pixel_y = -23;
 	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
-/obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("Entrance Zone Network")
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
@@ -5068,6 +5072,25 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet/green,
 /area/site53/uez/hallway)
+"sZ" = (
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/ammo_magazine/scp/p90_mag/ap,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/item/gun/projectile/automatic/scp/p90,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
 "tc" = (
 /obj/effect/floor_decal/corner/black/mono,
 /obj/structure/bed/chair/comfy/black{
@@ -5156,22 +5179,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "ue" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/ammo_magazine/scp/p90_mag/ap,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/obj/item/gun/projectile/automatic/scp/p90,
-/turf/simulated/floor/tiled/monotile,
+/obj/structure/sign/goldenplaque/security{
+	pixel_y = 30
+	},
+/turf/simulated/floor/tiled/dark,
 /area/site53/uez/armory)
 "uf" = (
 /obj/machinery/door/blast/regular{
@@ -6001,6 +6012,13 @@
 	},
 /obj/item/gun/projectile/pistol/usp45,
 /obj/item/gun/projectile/pistol/usp45,
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "EZ Rifle Locker";
+	name = "EZ Rifle Locker";
+	pixel_y = -23;
+	req_access = list("ACCESS_SECURITY_LEVEL3")
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/armory)
 "Av" = (
@@ -7138,10 +7156,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/entrancezone/forensics)
 "KG" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "EZ Secure Armoury";
-	req_access = list("ACCESS_SECURITY_LEVEL3")
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -8229,6 +8243,10 @@
 /obj/item/wirecutters,
 /turf/simulated/floor/exoplanet/barren,
 /area/site53/uez/commandpanicbunker)
+"Ti" = (
+/obj/structure/closet/secure_closet/guard/breachautomatics,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/armory)
 "Tk" = (
 /obj/structure/coatrack,
 /obj/item/clothing/suit/storage/toggle/labcoat,
@@ -32496,7 +32514,7 @@ Cy
 As
 IV
 IV
-hk
+IV
 hk
 uH
 JY
@@ -32752,8 +32770,8 @@ dL
 Si
 dN
 jD
+Ti
 IV
-hk
 hk
 fo
 AV
@@ -33007,10 +33025,10 @@ lj
 dN
 dN
 qu
-dN
-ue
+sZ
 IV
-hk
+IV
+IV
 hk
 fo
 Rv
@@ -33264,9 +33282,9 @@ rF
 eP
 dN
 qu
-eP
 my
 IV
+hk
 hk
 hk
 fo
@@ -33523,7 +33541,7 @@ uf
 sy
 IV
 IV
-IV
+hk
 hk
 hk
 fo
@@ -33776,7 +33794,7 @@ hk
 hk
 hk
 IV
-mr
+uk
 KG
 IV
 hk
@@ -34290,7 +34308,7 @@ cX
 cX
 cX
 IV
-uk
+ue
 qR
 IV
 cX
@@ -35308,7 +35326,7 @@ OC
 lU
 ZO
 ZO
-cX
+mr
 ZO
 ZO
 Gn
@@ -35323,7 +35341,7 @@ Sl
 xG
 xG
 xG
-cX
+mr
 hk
 mt
 EC
@@ -38135,7 +38153,7 @@ fe
 Gl
 Gl
 Gl
-cX
+mr
 qF
 wS
 Dy
@@ -38665,7 +38683,7 @@ ZO
 ZO
 ZO
 ZO
-cX
+mr
 hk
 hk
 hk
@@ -39687,7 +39705,7 @@ Zo
 IO
 cX
 cX
-cX
+mr
 cX
 cX
 cX

--- a/maps/site53/site53areas.dm
+++ b/maps/site53/site53areas.dm
@@ -548,6 +548,12 @@
 	area_flags = AREA_FLAG_RAD_SHIELDED
 	icon_state = "head_quarters"
 
+/area/site53/uez/commandpanicbunker
+	name = "\improper Admin Panic Bunker"
+	sound_env = MEDIUM_SOFTFLOOR
+	area_flags = AREA_FLAG_RAD_SHIELDED
+	icon_state = "head_quarters"
+
 /area/site53/uez/hallway
 	name = "\improper Upper Entrance Zone"
 	area_flags = AREA_FLAG_RAD_SHIELDED
@@ -935,11 +941,6 @@
 
 /area/site53/entrancezone/forensics
 	name = "\improper Forensics Laboratory"
-	icon_state = "detective"
-	area_flags = AREA_FLAG_RAD_SHIELDED
-
-/area/site53/entrancezone/forensicsstairwell
-	name = "\improper Forensics Laboratory Stairwell"
 	icon_state = "detective"
 	area_flags = AREA_FLAG_RAD_SHIELDED
 


### PR DESCRIPTION
## About the Pull Request
Create a new EZ Security section above the SD's office. LCZ Security offices are moved near the entry checkpoint of LCZ and reorganized. Level 4 Command section has been reorganized, a few offices were moved around and a new panic bunker has been created (more protective than the one on the surface). 

## Why It's Good For The Game
EZ Office was scrawny and awkward to use especially to process prisoners. Now they are closer to the SD's office and larger, with a proper detention center. 
LCZ office is closer to the checkpoint for ease of accessibility.
Panic Bunker allows command staff to flee to safety in the event of an SCP's breach. Field generator can keep SCPs away for so long as the bunker is powered (PACMANs generators with tritium fuel can help if the wire is cut). 

close #1121
close #1122

## Changelog

:cl:
add: Panic bunker on level 4 (under SD office) with multiple accesses within the floor.
add: EZ Security Office moved and expanded at Level 4 near the SD's office. 
add: LCZ security office moved and expanded near the LCZ entry checkpoint
add: ITD office and meeting room were moved around. ITD office is now near EZ Security office on level 4. 
/:cl:

