### PR TITLE
R_MOD changes, again

### DIFF
--- a/code/game/jobs/access/_access.dm
+++ b/code/game/jobs/access/_access.dm
@@ -238,7 +238,7 @@
 	var/static/obj/item/card/id/all_access/ghost_all_access
 
 /mob/observer/ghost/GetIdCard()
-	if(!is_admin(src))
+	if(!check_rights(R_ADMIN, 0, src))
 		return
 
 	if(!ghost_all_access)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -306,7 +306,8 @@ var/list/admin_verbs_mod = list(
 	/client/proc/cmd_admin_say,
 	/client/proc/investigate_show,
 	/datum/admins/proc/view_txt_log,
-	/client/proc/game_panel
+	/client/proc/game_panel,
+	/client/proc/free_slot_crew
 )
 var/list/admin_verbs_mentors = list(
 	/client/proc/cmd_mentor_say,

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -305,7 +305,8 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/paralyze_mob, // right-click paralyze ,
 	/client/proc/cmd_admin_say,
 	/client/proc/investigate_show,
-	/datum/admins/proc/view_txt_log
+	/datum/admins/proc/view_txt_log,
+	/client/proc/game_panel
 )
 var/list/admin_verbs_mentors = list(
 	/client/proc/cmd_mentor_say,

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -482,7 +482,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 0
 
 /mob/observer/ghost/can_admin_interact()
-	return check_rights(R_ADMIN, 0, src)
+	return check_rights(R_ADMIN|R_MOD, 0, src)
 
 /mob/observer/ghost/verb/toggle_ghostsee()
 	set name = "Toggle Ghost Vision"

--- a/code/modules/nano/interaction/admin.dm
+++ b/code/modules/nano/interaction/admin.dm
@@ -4,4 +4,4 @@
 GLOBAL_DATUM_INIT(admin_state, /datum/topic_state/admin_state, new)
 
 /datum/topic_state/admin_state/can_use_topic(src_object, mob/user)
-	return check_rights(R_ADMIN, 0, user) ? STATUS_INTERACTIVE : STATUS_CLOSE
+	return check_rights(R_ADMIN|R_MOD, 0, user) ? STATUS_INTERACTIVE : STATUS_CLOSE


### PR DESCRIPTION
## About the Pull Request

moderator ranks have +SPAWN on the live server but not game panel
we can spawn any atom already, it's just really really annoying to do so
rest of the game panel other than spawning is already R_ADMIN | R_SERVER checked so this gives no extra permissions, just makes it easier to use current permissions

freeing job slots is common sense, if you ban someone whos playing you want to free the job slot lol

ai interacting is obvious for fixing grief

## Why It's Good For The Game

why don't mods have this

## Changelog

:cl:
admin: Mods get game panel access.
admin: The skill panel no longer does nothing for mods.
admin: Mods can now AI interact as ghost.
admin: Mods can now free job slots in the crew.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
