### PR TITLE
Makes 173 AI active in low-pop, but prevents 173 from self-breaching in lowpop

### DIFF
--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -158,8 +158,6 @@ GLOBAL_LIST_EMPTY(scp173s)
 
 /mob/living/scp_173/Life()
 	. = ..()
-	if(length(GLOB.clients) <= 30 && !client)
-		return
 	//In case we are caged, we must see if our cage is being looked at rather than us
 	var/list/our_view = dview(7, istype(loc, /obj/structure/scp173_cage) ? loc : src)
 	for(var/mob/living/carbon/human/H in next_blinks)
@@ -284,6 +282,9 @@ GLOBAL_LIST_EMPTY(scp173s)
 		UnarmedAttack(target)
 
 /mob/living/scp_173/proc/Defecate()
+	var/feces_amount = CheckFeces()
+	if(feces_amount >= 30 && length(GLOB.clients) <= 30 && !client) //If we're lowpop we cant breach ourselves
+		return
 	if(!isobj(loc) && world.time > defecation_cooldown)
 		defecation_cooldown = world.time + defecation_cooldown_time
 		var/feces = pick(defecation_types)
@@ -294,7 +295,6 @@ GLOBAL_LIST_EMPTY(scp173s)
 			if(Tdir && !IsBeingWatched())
 				SelfMove(Tdir)
 	// Breach check
-	var/feces_amount = CheckFeces()
 	if(feces_amount >= 60) // Breach, gonna take ~45 minutes
 		if(breach_cooldown > world.time)
 			return


### PR DESCRIPTION
## About the Pull Request
Instead of 173 being catatonic when low pop (under 30 players), it just cant breach itself, and you can still interact with 173.

Also only AI can control 173 in low-pop.
## Why It's Good For The Game

SCPs are kind of our whole selling point, it seems absurdly stupid to disable one entirely.

The real issue is 173 self-breaching on low pop and massacring everyone, so instead of just disabling him, we should prevent it from self-breaching.

## Dependencies
This should be merged **BEFORE** #1116, but only with #1116 being test merged right after.
## Changelog

:cl:
balance: 173 is now active in low-pop but AI only and cannot self-breach.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
