### PR TITLE
Change joined round as to use alt title, fix notes player age

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -100,7 +100,7 @@ var/global/floorIsLava = 0
 		if(C.ckey == key)
 			p_age = C.player_age
 			break
-	dat += "<b>Player age: [p_age]</b><br><ul id='notes'>"
+	dat += "<b>Player age: [p_age ? p_age : get_player_age(key)]</b><br><ul id='notes'>"
 
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -172,7 +172,7 @@
 			AnnounceArrival(character, job, spawnpoint.msg)
 		else
 			AnnounceCyborg(character, job, spawnpoint.msg)
-	log_and_message_staff("has joined the round as [character.mind.role_alt_title].", character)
+	log_and_message_staff("has joined the round as [character.mind.assigned_role == character.mind.role_alt_title ? character.mind.assigned_role : "[character.mind.assigned_role] ([character.mind.role_alt_title])"].", character)
 
 	if(character.needs_wheelchair())
 		equip_wheelchair(character)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -172,7 +172,7 @@
 			AnnounceArrival(character, job, spawnpoint.msg)
 		else
 			AnnounceCyborg(character, job, spawnpoint.msg)
-	log_and_message_staff("has joined the round as [character.mind.assigned_role == character.mind.role_alt_title ? character.mind.assigned_role : "[character.mind.assigned_role] ([character.mind.role_alt_title])"].", character)
+	log_and_message_staff("has joined the round as [character.mind.assigned_role][character.mind.role_alt_title == character.mind.assigned_role ? "" : " ([character.mind.role_alt_title])"].", character)
 
 	if(character.needs_wheelchair())
 		equip_wheelchair(character)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -172,7 +172,7 @@
 			AnnounceArrival(character, job, spawnpoint.msg)
 		else
 			AnnounceCyborg(character, job, spawnpoint.msg)
-	log_and_message_staff("has joined the round as [character.mind.assigned_role].", character)
+	log_and_message_staff("has joined the round as [character.mind.role_alt_title].", character)
 
 	if(character.needs_wheelchair())
 		equip_wheelchair(character)


### PR DESCRIPTION
## About the Pull Request

[player] has joined the round as Global Occult Coalition Representative
(they are actually the mcd liaison)

## Why It's Good For The Game

bro more specific logs is better

## Changelog

:cl:
admin: Player joined round log now uses alt job title
admin: Show player info now gets player age from db if client is not connected, meaning admins can see disconnected clients' player ages
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
