### PR TITLE
Fix show today server log

### DIFF
--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -91,11 +91,10 @@
 	if(!check_rights(R_ADMIN|R_MOD, TRUE))
 		return
 
-	var/path = "data/logs/[time2text(world.realtime,"YYYY/MM/DD")].log"
-	if( fexists(path) )
-		to_target(src, run(file(path)))
+	if( diary )
+		to_target(src, run(diary))
 	else
-		to_chat(src, FONT_COLORED("red","Error: view_txt_log(): File not found/Invalid path([path])."))
+		to_chat(src, FONT_COLORED("red","Error: view_txt_log(): diary global is null."))
 		return
 	return
 


### PR DESCRIPTION
## About the Pull Request

there is an issue where if its past 12am GMT (the live server's timezone) while the current round is running, show today's server log will fail and nobody will be able to get current round log past this time

this changes it to use diary, which is the current day's log defined for the current round that's ongoing, the next day's won't exist until the next round

## Why It's Good For The Game

this is so annoying when staffing the server at 4pm my time on 40 players

## Changelog

:cl:
admin: Show today server log works correctly after a current round passes 12am server timezone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
