### PR TITLE
LCZ Armoury Riot Shotgun -> Saiga 12 / P90 Full Auto Re-Enabled / MTF ERT Alpha 1 Beret Armoured / Slight LCZ Armoury mapping

### DIFF
--- a/code/game/objects/items/weapons/SCP/guns.dm
+++ b/code/game/objects/items/weapons/SCP/guns.dm
@@ -15,7 +15,7 @@
 	//Assault rifle, burst fire degrades quicker than SMG, worse one-handing penalty, slightly increased move delay
 	firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null),
-		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=4,    one_hand_penalty=4, burst_accuracy=list(0,-1,-1,-1,-2), dispersion=list(0.5, 0.5, 0.7, 0.9, 1.0)),
+		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    one_hand_penalty=3, burst_accuracy=list(0,-1,-1), dispersion=list(0.0, 0.5, 0.8)),
 		list(mode_name="full auto",      burst=1, fire_delay=0, burst_delay=1, one_hand_penalty=4, burst_accuracy=list(0,-1,-2), dispersion=list(0.1, 0.7, 1.1), autofire_enabled=1),
 		)
 

--- a/code/game/objects/items/weapons/SCP/guns.dm
+++ b/code/game/objects/items/weapons/SCP/guns.dm
@@ -15,8 +15,8 @@
 	//Assault rifle, burst fire degrades quicker than SMG, worse one-handing penalty, slightly increased move delay
 	firemodes = list(
 		list(mode_name="semiauto",       burst=1, fire_delay=0,    move_delay=null, one_hand_penalty=2, burst_accuracy=null, dispersion=null),
-		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=4,    one_hand_penalty=3, burst_accuracy=list(0,-1,-1),       dispersion=list(0.0, 0.5, 0.7)),
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=4,    one_hand_penalty=4, burst_accuracy=list(0,-1,-1,-1,-2), dispersion=list(0.5, 0.5, 0.7, 0.9, 1.0)),
+		list(mode_name="full auto",      burst=1, fire_delay=0, burst_delay=1, one_hand_penalty=4, burst_accuracy=list(0,-1,-2), dispersion=list(0.1, 0.7, 1.1), autofire_enabled=1),
 		)
 
 /obj/item/gun/projectile/automatic/scp/p90/update_icon()
@@ -35,7 +35,7 @@
 	toggle_scope(usr, 1.0)
 */
 /obj/item/gun/projectile/automatic/scp/p90
-	magazine_type = /obj/item/ammo_magazine/scp/p90_mag/rubber
+	magazine_type = /obj/item/ammo_magazine/scp/p90_mag
 
 /obj/item/gun/projectile/automatic/scp/m16
 	name = "M16"

--- a/maps/site53/items/clothing/solgov-head.dm
+++ b/maps/site53/items/clothing/solgov-head.dm
@@ -363,6 +363,8 @@
 	desc = "A dark red beret worn by members of the 'Red Right Hand' MTF unit, it feels kind of heavy for a beret."
 	icon_state = "alpha-beret"
 	item_state = "alpha-beret"
+	body_parts_covered = HEAD
+	armor = list(melee = 90, bullet = 90, laser = 90, energy = 95, bomb = 90, bio = 90, rad = 0)
 
 //GOC
 /obj/item/clothing/head/helmet/scp/goc

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -11542,6 +11542,7 @@
 /obj/structure/table/rack,
 /obj/item/gun/energy/ionrifle,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "aEz" = (
@@ -16118,9 +16119,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/checkequip)
 "aUL" = (
@@ -16145,14 +16143,23 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
 "aUQ" = (
-/obj/structure/table/standard,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/saiga12/stunshell,
+/obj/item/ammo_magazine/scp/saiga12/stunshell,
+/obj/item/ammo_magazine/scp/saiga12/stunshell,
+/obj/item/ammo_magazine/scp/saiga12/stunshell,
+/obj/item/ammo_magazine/box/stunshell,
+/obj/item/ammo_magazine/box/stunshell,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/power/apc/hyper{
+	dir = 8
 	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "aUR" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/donut,
@@ -16370,15 +16377,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "aVM" = (
-/obj/machinery/power/apc/hyper{
-	dir = 8
+/obj/machinery/button/blast_door{
+	dir = 8;
+	id_tag = "ULCZ Lethal Armoury";
+	name = "ULCZ Lethal Armoury";
+	pixel_x = 22;
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/closet/secure_closet/guard/specialistshotgun,
-/obj/effect/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "aVN" = (
@@ -18741,14 +18746,12 @@
 /turf/simulated/floor/plating,
 /area/site53/uhcz/scp247observation)
 "bde" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/scp/saiga12/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "ULCZ Specialist Non Lethal Armoury";
+	name = "ULCZ Specialist Non Lethal Armoury"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "bdf" = (
@@ -19862,13 +19865,26 @@
 /area/site53/ulcz/hallways)
 "bhm" = (
 /obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/saiga12/stunshell,
-/obj/item/ammo_magazine/scp/saiga12/stunshell,
-/obj/item/ammo_magazine/scp/saiga12/stunshell,
-/obj/item/ammo_magazine/scp/saiga12/stunshell,
-/obj/item/ammo_magazine/box/stunshell,
-/obj/item/ammo_magazine/box/stunshell,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/machinery/light,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "bho" = (
@@ -19900,16 +19916,14 @@
 /area/site53/ulcz/hallways)
 "bhr" = (
 /obj/structure/table/rack,
-/obj/machinery/light,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/gun/projectile/shotgun/pump,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
-/obj/item/clothing/accessory/storage/bandolier,
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/item/reagent_containers/spray/chemsprayer,
+/obj/item/reagent_containers/spray/chemsprayer,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/light,
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
+	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bhu" = (
@@ -21323,15 +21337,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
 "bQp" = (
-/obj/structure/table/rack,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/item/ammo_magazine/box/beanbag,
-/obj/effect/floor_decal/industrial/hatch/red,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bQJ" = (
@@ -21497,6 +21508,11 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
+"bWy" = (
+/obj/structure/closet/secure_closet/guard/lethalshotgunammunitionbuckshot,
+/obj/effect/floor_decal/industrial/hatch/red,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "bWR" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -22126,6 +22142,15 @@
 /obj/effect/paint_stripe/red,
 /turf/simulated/wall/prepainted,
 /area/site53/engineering/primaryhallway)
+"cJw" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "cKH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -22759,6 +22784,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
+"duo" = (
+/obj/machinery/camera/network/lcz,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "dvt" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23135,6 +23164,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
+"dSN" = (
+/obj/machinery/button/blast_door{
+	id_tag = "ULCZ Specialist Non Lethal Armoury";
+	name = "ULCZ Specialist Non Lethal Armoury";
+	pixel_y = 25;
+	req_access = list(list("ACCESS_SECURITY_LEVEL2","ACCESS_SCIENCE_LEVEL2"))
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "dTW" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -24510,13 +24553,26 @@
 /turf/simulated/floor/wood,
 /area/site53/llcz/entrance_checkpoint)
 "fCD" = (
-/obj/machinery/button/blast_door{
-	dir = 8;
-	id_tag = "ULCZ Secure Armoury";
-	name = "ULCZ Secure Armoury";
-	pixel_x = 22;
-	req_access = list("ACCESS_SECURITY_LEVEL2")
-	},
+/obj/structure/table/rack,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/item/ammo_magazine/scp/p90_mag/rubber,
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/item/ammo_magazine/box/a57/rubber,
+/obj/item/ammo_magazine/box/a57/rubber,
+/obj/item/ammo_magazine/box/a57/rubber,
+/obj/item/ammo_magazine/box/a57/rubber,
+/obj/item/ammo_magazine/box/a57/rubber,
+/obj/item/ammo_magazine/box/a57/rubber,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "fDv" = (
@@ -25554,16 +25610,9 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
 "gNi" = (
-/obj/structure/table/rack,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/obj/item/ammo_magazine/box/flash,
-/obj/item/ammo_magazine/box/flash,
-/obj/item/ammo_magazine/box/flash,
-/obj/item/ammo_magazine/box/flash,
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/monotile/white,
+/obj/effect/paint_stripe/red,
+/obj/structure/reagent_dispensers/peppertank,
+/turf/simulated/wall/titanium,
 /area/site53/llcz/checkequip)
 "gNK" = (
 /obj/structure/table/reinforced,
@@ -25859,22 +25908,10 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/engineering/primaryhallway)
 "hbm" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
-/obj/item/ammo_magazine/scp/p90_mag/rubber,
 /obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
+/obj/structure/closet/secure_closet/guard/riotshotguns,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "hbt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25923,17 +25960,28 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/scp012)
 "hed" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
 /obj/structure/table/rack,
-/obj/item/ammo_magazine/box/rubbershot,
-/obj/item/ammo_magazine/box/rubbershot,
-/obj/item/ammo_magazine/box/rubbershot,
-/obj/item/ammo_magazine/box/rubbershot,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/box/a57,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
 /obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/obj/item/ammo_magazine/scp/p90_mag,
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "heA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -28789,11 +28837,11 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
 "kcw" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 32
 	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "kcV" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start{
@@ -30532,7 +30580,6 @@
 /area/site53/uhcz/generalpurpose3)
 "maZ" = (
 /obj/structure/table/rack,
-/obj/machinery/light,
 /obj/item/ammo_magazine/box/a357,
 /obj/item/ammo_magazine/box/a357,
 /obj/item/ammo_magazine/box/a357,
@@ -31583,18 +31630,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aicobservation)
 "naI" = (
-/obj/structure/table/standard,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/adv,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/storage/firstaid/combat,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/item/device/scanner/health,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
+/obj/machinery/door/airlock/highsecurity{
+	name = "LCZ Shotgun Storage";
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
@@ -32089,6 +32127,17 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)
+"nDL" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "nFS" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
@@ -32203,6 +32252,20 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp457containment)
+"nKy" = (
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "ULCZ Specialist Non Lethal Armoury";
+	name = "ULCZ Specialist Non Lethal Armoury"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "nLc" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/chef,
@@ -32474,11 +32537,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
 "nZl" = (
-/obj/structure/table/rack,
-/obj/item/gun/energy/ionrifle,
-/obj/effect/floor_decal/industrial/hatch/red,
-/turf/simulated/floor/tiled/dark,
-/area/site53/llcz/dclass/armory)
+/obj/structure/table/standard,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "oau" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34559,6 +34623,12 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
+"qBE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "qCb" = (
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/science/seniorresearcherb)
@@ -35497,6 +35567,14 @@
 /obj/item/storage/box/donut,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/office)
+"rGF" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/closet/secure_closet/guard/riotshotguns,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "rHa" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -37822,6 +37900,12 @@
 /obj/structure/flora/pottedplant/deskfern,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/scp151)
+"uty" = (
+/obj/effect/floor_decal/industrial/hatch/red,
+/obj/structure/closet/secure_closet/guard/riotshotguns,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile/white,
+/area/site53/llcz/checkequip)
 "utJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -38401,10 +38485,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/generalpurpose3)
 "vgG" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/scp/saiga12/rubbershot,
-/obj/item/gun/projectile/automatic/scp/saiga12/rubbershot,
+/obj/structure/closet/secure_closet/guard/lethalshotgunammunitionbuckshot,
 /obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "vhB" = (
@@ -39335,6 +39418,18 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/science/aiccore)
+"weF" = (
+/obj/structure/closet/secure_closet/guard/specialistshotgun,
+/obj/effect/floor_decal/industrial/outline/red,
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/site53/llcz/dclass/armory)
 "wfL" = (
 /obj/structure/closet/crate/secure/biohazard,
 /obj/machinery/light/small{
@@ -40330,9 +40425,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "xfS" = (
@@ -40941,21 +41033,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/checkequip)
 "xSs" = (
-/obj/structure/table/rack,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/machinery/light,
-/obj/effect/floor_decal/industrial/hatch/red,
+/obj/machinery/door/blast/regular/open{
+	begins_closed = 1;
+	icon_state = "pdoor0";
+	id_tag = "ULCZ Lethal Armoury";
+	name = "ULCZ Lethal Armoury"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "xSP" = (
@@ -57095,12 +57178,12 @@ wVD
 uJG
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+aMC
+aMC
+aMC
+aMC
+aMC
+aMC
 azA
 azA
 azA
@@ -57352,12 +57435,12 @@ qzE
 uJG
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+aMC
+weF
+aUQ
+wsM
+icU
+qSc
 azA
 azA
 azA
@@ -57609,14 +57692,14 @@ oNG
 uJG
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+aMC
+nKy
+bde
+bde
+bde
+aMC
+aMC
+aMC
 azA
 azA
 azA
@@ -57867,13 +57950,13 @@ uJG
 azA
 azA
 aMC
+dSN
+aXh
+aXh
+aXh
+xSs
+bWy
 aMC
-aMC
-aMC
-aMC
-aMC
-azA
-azA
 azA
 azA
 azA
@@ -58122,15 +58205,15 @@ qwF
 vXy
 uJG
 azA
-aMC
-aMC
-aVM
-vgG
-vgG
-aXh
-qSc
-aMC
 azA
+aMC
+nDL
+aXh
+aXh
+aXh
+xSs
+vgG
+aMC
 azA
 azA
 azA
@@ -58379,15 +58462,15 @@ aTq
 wVD
 uJG
 azA
-aMC
-kcw
-aVL
-aXh
-aXh
-aXh
-maZ
-aMC
 azA
+aMC
+cJw
+aXh
+aXh
+aXh
+xSs
+iQI
+aMC
 azA
 azA
 azA
@@ -58637,14 +58720,14 @@ jrM
 uJG
 azA
 aMC
-nZl
-aVL
-bde
-icU
-aXh
-iQI
 aMC
-azA
+aVL
+aXh
+aXh
+aXh
+xSs
+maZ
+aMC
 azA
 azA
 azA
@@ -58896,12 +58979,12 @@ azA
 aMC
 eiL
 aVL
-wsM
-bhm
 aXh
-hbm
+aXh
+aXh
+xSs
+hed
 aMC
-azA
 azA
 azA
 azA
@@ -59157,8 +59240,8 @@ aXh
 aXh
 aXh
 xSs
+bhm
 aMC
-azA
 azA
 azA
 azA
@@ -59410,12 +59493,12 @@ azA
 aMC
 fCD
 aVL
+qBE
 aXh
-aXh
-aXh
+aVM
+xSs
 tPi
 aMC
-azA
 azA
 azA
 azA
@@ -59672,7 +59755,7 @@ aMC
 aMC
 aMC
 qSc
-azA
+qSc
 azA
 azA
 azA
@@ -60439,7 +60522,7 @@ aTI
 wlv
 wVj
 aUa
-aVD
+gNi
 azA
 azA
 azA
@@ -60696,7 +60779,7 @@ wVj
 aMS
 wVj
 bTG
-aVD
+gNi
 azA
 azA
 azA
@@ -60946,14 +61029,14 @@ aMS
 aMS
 aMS
 akH
-akH
+nZl
 aVD
 aKa
 wVj
 aMS
 wVj
 cta
-aVD
+gNi
 azA
 azA
 azA
@@ -61210,7 +61293,7 @@ oni
 dMS
 aUu
 kDr
-aVD
+gNi
 azA
 azA
 azA
@@ -61462,12 +61545,12 @@ aMS
 aMS
 aNs
 aVD
-lbi
+bQp
+kcw
 aMS
-aMS
-aMS
+kcw
 bhr
-aVD
+gNi
 azA
 azA
 azA
@@ -61719,11 +61802,11 @@ aMS
 aMS
 aVr
 aVD
-aUQ
+aVD
+aVD
 naI
-hed
-gNi
-bQp
+aVD
+aVD
 aVD
 azA
 azA
@@ -61976,11 +62059,11 @@ aMS
 aMS
 blL
 aVD
-aVD
-aVD
-aVD
-aVD
-aVD
+lbi
+aMS
+aMS
+aMS
+aNs
 aVD
 azA
 azA
@@ -62233,12 +62316,12 @@ gci
 jnd
 gci
 aVD
-azA
-azA
-azA
-azA
-azA
-azA
+duo
+aMS
+aMS
+aMS
+aMS
+aVD
 azA
 azA
 azA
@@ -62490,12 +62573,12 @@ gci
 jnd
 gci
 aVD
-azA
-azA
-azA
-azA
-azA
-azA
+rGF
+hbm
+hbm
+hbm
+uty
+aVD
 azA
 azA
 azA
@@ -62747,12 +62830,12 @@ gci
 jnd
 wCH
 aVD
-azA
-azA
-azA
-azA
-azA
-azA
+aVD
+aVD
+aVD
+aVD
+aVD
+aVD
 azA
 azA
 azA

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -16151,13 +16151,6 @@
 /obj/item/ammo_magazine/box/stunshell,
 /obj/item/ammo_magazine/box/stunshell,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/machinery/power/apc/hyper{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "aUR" = (

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -19861,9 +19861,6 @@
 /obj/item/ammo_magazine/box/a57,
 /obj/item/ammo_magazine/box/a57,
 /obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
@@ -19872,12 +19869,6 @@
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "bho" = (
@@ -19914,9 +19905,6 @@
 /obj/item/reagent_containers/spray/chemsprayer,
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/checkequip)
 "bhu" = (
@@ -21329,15 +21317,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
-"bQp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
 "bQJ" = (
 /obj/machinery/door/airlock/security{
 	name = "Heavy Containment Zone Gate Security Post";
@@ -25957,9 +25936,6 @@
 /obj/item/ammo_magazine/box/a57,
 /obj/item/ammo_magazine/box/a57,
 /obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
-/obj/item/ammo_magazine/box/a57,
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
@@ -25967,12 +25943,6 @@
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/item/ammo_magazine/scp/p90_mag,
 /obj/effect/floor_decal/industrial/hatch/red,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
-/obj/item/ammo_magazine/scp/p90_mag,
 /turf/simulated/floor/tiled/dark,
 /area/site53/llcz/dclass/armory)
 "heA" = (
@@ -28829,12 +28799,6 @@
 /obj/item/book/manual/barman_recipes,
 /turf/simulated/floor/wood/walnut,
 /area/site53/ulcz/humanoidcontainment)
-"kcw" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/checkequip)
 "kcV" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start{
@@ -61538,10 +61502,10 @@ aMS
 aMS
 aNs
 aVD
-bQp
-kcw
+lbi
 aMS
-kcw
+aMS
+aMS
 bhr
 gNi
 azA

--- a/maps/site53/structures/closets/security.dm
+++ b/maps/site53/structures/closets/security.dm
@@ -331,10 +331,8 @@
 /obj/structure/closet/secure_closet/guard/riotshotguns/WillContain()
 	return list(
 		/obj/item/gun/projectile/automatic/scp/saiga12/beanbag = 2,
-		/obj/item/ammo_magazine/scp/saiga12/beanbag = 6,
-		/obj/item/ammo_magazine/scp/saiga12/rubbershot = 6,
-		/obj/item/ammo_magazine/box/beanbag = 6,
-		/obj/item/ammo_magazine/box/rubbershot = 6,
+		/obj/item/ammo_magazine/scp/saiga12/beanbag = 8,
+		/obj/item/ammo_magazine/box/beanbag = 4,
 		/obj/item/clothing/accessory/storage/bandolier = 2,
 	)
 
@@ -349,17 +347,29 @@
 
 /obj/structure/closet/secure_closet/guard/specialistshotgun/WillContain()
 	return list(
-		/obj/item/gun/projectile/automatic/scp/saiga12/beanbag = 1,
-		/obj/item/gun/projectile/shotgun/pump/combat = 1,
 		/obj/item/ammo_magazine/scp/saiga12/beanbag = 3,
 		/obj/item/ammo_magazine/scp/saiga12/rubbershot = 3,
 		/obj/item/ammo_magazine/scp/saiga12/stunshell = 3,
-		/obj/item/ammo_magazine/scp/saiga12/flash = 4,
+		/obj/item/ammo_magazine/scp/saiga12/flash = 3,
 		/obj/item/ammo_magazine/box/beanbag = 3,
 		/obj/item/ammo_magazine/box/rubbershot = 3,
 		/obj/item/ammo_magazine/box/stunshell = 3,
 		/obj/item/ammo_magazine/box/flash = 3,
-		/obj/item/clothing/accessory/storage/bandolier = 2,
+	)
+
+/obj/structure/closet/secure_closet/guard/lethalshotgunammunitionbuckshot
+	name = "Buckshot Storage Locker"
+	req_access = list(ACCESS_SECURITY_LVL2)
+	icon_state = "gun-locked"
+	icon_closed = "gun-unlocked"
+	icon_locked = "gun-locked"
+	icon_opened = "gun-open"
+	icon_off = "gun-off"
+
+/obj/structure/closet/secure_closet/guard/lethalshotgunammunitionbuckshot/WillContain()
+	return list(
+		/obj/item/ammo_magazine/scp/saiga12/buckshot = 16,
+		/obj/item/ammo_magazine/box/buckshot = 8,
 	)
 
 /obj/structure/closet/secure_closet/guard/riotgear


### PR DESCRIPTION
## About the Pull Request
Re-add P90 Full Auto Feature
Gives armour values to the MTF/ERT Alpha 1 beret (equivalent to their body armour)
Adds lockable specialist non lethal and lethal compartments to LCZ Armoury
Replace Riot Shotguns of LCZ with proper Saiga 12 with Beanbag shells

## Why It's Good For The Game
P90 without the full auto kinda suck (slow bursts with a 50 rounds PDW?). 
MTF Alpha 1, the most elite/well equipped MTF you can deploy, being equipped with BERETS instead of properly armoured helmet was kinda cringe, too. I didn't remove their beret, but I added the same armour values that their main body armour has (after all in the description of the beret its implied that they are armoured) 

Now, why should LCZ spawn with ten Saiga 12 and assorted Beanbag shells? 
Previously the go to weapon of choice for non lethal at LCZ was P90's with rubber mags, but frankly these makes 0 sense (and it's not really fun either for Class D to be peppered by 50 rubber bullets). It's a PDW, not a non lethal weapon, rubber projectiles going at a muzzle velocity of 715 meters/s is going to kill you if it hits you a few times in the head after all.
I believe that Saiga (Or whatever resprite/replacement shotgun you would give them), a semi auto shotgun with eight round mags, is a decent compromise. 
It's semi auto but has a limited magazine capacity and it holds beanbags which are realistic choice for riot control especially in prison environment. Someone once mentioned that beanbag downed guards too quickly, but I did some test; you can paincrit an LCZ guard in his armour with around 6 shells when you aren't pointblanking, but considering that a magazine holds 8 shells I'd say this is a rather fair number, no? 



## Changelog

:cl:
add: Made the MTF Alpha 1 Red Right Hand beret actually armoured (on the same level as their armour). No more quick death for the elites of Alpha One
add: the LCZ Armoury has the very inefficient "riot shotguns" replaced with Saiga 12 (There are 10 in total, plus the one in the ZC locker, totalling 11 for all 11 LCZ slots). They only start with beanbag mags and boxes, to get lethal buckshot or other specialized shells they'd need ZC approval to open the armoury
add: Gave P90 it's full auto settign back
add: Divided LCZ armoury into a lethal area and a non lethal area compartment, both compartment can be opened or locked by the ZC. 
/:cl:
