### PR TITLE
Invoke async on full breach

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -308,7 +308,7 @@ var/list/mob/living/forced_ambiance_list = new
 	for(var/obj/machinery/door/temp_door in src)
 		if(istype(temp_door, /obj/machinery/door/blast))
 			var/obj/machinery/door/blast/BD = temp_door
-			BD.force_open()
+			INVOKE_ASYNC(BD, /obj/machinery/door/blast/proc/force_open)
 			continue
 		temp_door.open(TRUE) // Forced
 	for(var/obj/machinery/power/apc/temp_apc in src)


### PR DESCRIPTION
## About the Pull Request

Uses INVOKE_ASYNC on full_breach's blastdoors force open proc.

## Why It's Good For The Game

The blastdoors will not be opening one at a time anymore.

## Changelog

:cl:
tweak: SCP 173's auto-breach effect is now instant, instead of one blastdoor at a time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
