### PR TITLE
Holopad updates

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -101,15 +101,15 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 	if(world.time > request_cooldown && incoming_connection)
 		if(sourcepad)
-			sourcepad.audible_message("<i><span class='game say'>The holopad connection timed out</span></i>")
+			sourcepad.audible_message(SPAN_WARNING("<i>The holopad connection timed out</i>"))
 		incoming_connection = 0
 		end_call()
 
 	if(caller_id && sourcepad)
 		if(caller_id.loc != sourcepad.loc)
-			to_chat(sourcepad.caller_id, "Severing connection to distant holopad.")
+			to_chat(sourcepad.caller_id, SPAN_WARNING("Severing connection to distant holopad."))
 			end_call()
-			audible_message("The connection has been terminated by the caller.")
+			audible_message(SPAN_WARNING("The connection has been terminated by the caller."))
 
 	return TRUE
 
@@ -267,7 +267,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 /obj/machinery/hologram/holopad/proc/addrecentcall(id)
 	recent_calls += id
-	if(recent_calls.len > 5)
+	if(length(recent_calls) > 5)
 		recent_calls -= recent_calls[1]
 
 /obj/machinery/hologram/holopad/check_eye(mob/user)
@@ -433,7 +433,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 		qdel(masters[caller_id])//Get rid of user's hologram
 		masters -= caller_id //Discard the caller from the list of those who use holopad
 
-	if(!masters.len)//If no users left
+	if(!length(masters))//If no users left
 		set_light(0)			//pad lighting (hologram lighting will be handled automatically since its owner was deleted)
 		icon_state = "[base_icon]0"
 		if(sourcepad)

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -99,7 +99,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 		use_power_oneoff(power_per_hologram)
 
-	if(request_cooldown > world.time && incoming_connection)
+	if(world.time > request_cooldown && incoming_connection)
 		if(sourcepad)
 			sourcepad.audible_message("<i><span class='game say'>The holopad connection timed out</span></i>")
 		incoming_connection = 0

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -29,6 +29,7 @@ Possible to do for anyone motivated enough:
 #define RANGE_BASED 				(1<<2)
 #define AREA_BASED 					6
 
+GLOBAL_LIST_EMPTY(holopad_list)
 var/const/HOLOPAD_MODE = RANGE_BASED
 
 /obj/machinery/hologram/holopad
@@ -38,19 +39,26 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 	layer = ABOVE_TILE_LAYER
 
-	var/power_per_hologram = 500 //per usage per hologram
 	idle_power_usage = 5
 
+	var/power_per_hologram = 500 //per usage per hologram
+
 	var/list/mob/living/silicon/ai/masters = new() //List of AIs that use the holopad
-	var/last_request = 0 //to prevent request spam. ~Carn
 	var/holo_range = 5 // Change to change how far the AI can move away from the holopad before deactivating.
 
-	var/incoming_connection = 0
+	/// World.time at which the holopad can attempt to call other pads again
+	var/request_cooldown = 0
+	/// Cooldown time added to world.time upon successful request
+	var/request_cooldown_time = 20 SECONDS
+
+	var/last_message
+
+	var/incoming_connection = FALSE
 	var/mob/living/caller_id
 	var/obj/machinery/hologram/holopad/sourcepad
 	var/obj/machinery/hologram/holopad/targetpad
-	var/last_message
 
+	var/holopad_id = null
 	var/list/recent_calls = list()
 
 	var/holopadType = HOLOPAD_SHORT_RANGE //Whether the holopad is short-range or long-range.
@@ -58,30 +66,78 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 	var/allow_ai = TRUE
 
-/obj/machinery/hologram/holopad/New()
-	..()
-	desc = "It's a floor-mounted device for projecting holographic images. Its ID is '[loc.loc]'"
+/obj/machinery/hologram/holopad/Initialize()
+	. = ..()
+	if(isnull(holopad_id))
+		var/area/A = get_area(src)
+		holopad_id = A.name
+	// Handling duplicate IDs
+	var/holo_number = 0
+	var/new_holo_id = holopad_id
+	while(new_holo_id in GLOB.holopad_list)
+		holo_number += 1
+		new_holo_id = "[holopad_id] #[holo_number]"
+	holopad_id = new_holo_id
+	GLOB.holopad_list[holopad_id] = src
+
+/obj/machinery/hologram/holopad/Destroy()
+	GLOB.holopad_list -= holopad_id
+	for(var/mob/living/master in masters)
+		clear_holo(master)
+	return ..()
+
+/obj/machinery/hologram/holopad/Process()
+	for(var/mob/living/silicon/ai/master in masters)
+		var/active_ai = (master && !master.incapacitated() && master.client && master.eyeobj)//If there is an AI with an eye attached, it's not incapacitated, and it has a client
+		if((stat & NOPOWER) || !active_ai)
+			clear_holo(master)
+			continue
+
+		if(!(masters[master] in view(src)))
+			clear_holo(master)
+			continue
+
+		use_power_oneoff(power_per_hologram)
+
+	if(request_cooldown > world.time && incoming_connection)
+		if(sourcepad)
+			sourcepad.audible_message("<i><span class='game say'>The holopad connection timed out</span></i>")
+		incoming_connection = 0
+		end_call()
+
+	if(caller_id && sourcepad)
+		if(caller_id.loc != sourcepad.loc)
+			to_chat(sourcepad.caller_id, "Severing connection to distant holopad.")
+			end_call()
+			audible_message("The connection has been terminated by the caller.")
+
+	return TRUE
 
 /obj/machinery/hologram/holopad/examine(mob/user)
 	. = ..()
-	if (incoming_connection && sourcepad)
+	if(holopad_id)
+		to_chat(user, SPAN_NOTICE("Its ID is '<b>[holopad_id]</b>'"))
+
+	if(incoming_connection && sourcepad)
 		to_chat(user, SPAN_NOTICE("There is currently an incoming call from [get_area(sourcepad)]!"))
+
 	var/callstring = "Recent incoming calls:"
-	for (var/id in recent_calls)
+	for(var/id in recent_calls)
 		callstring += "\n[id]"
 	callstring = SPAN_NOTICE(callstring)
 	to_chat(user, callstring)
 
-/obj/machinery/hologram/holopad/interface_interact(mob/living/carbon/human/user) //Carn: Hologram requests.
+/obj/machinery/hologram/holopad/interface_interact(mob/living/carbon/human/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE
+
 	if(incoming_connection && caller_id)
 		if(QDELETED(sourcepad)) // If the sourcepad was deleted, most likely.
 			incoming_connection = 0
 			clear_holo()
 			return TRUE
 		visible_message("The pad hums quietly as it establishes a connection.")
-		if(caller_id.loc!=sourcepad.loc)
+		if(caller_id.loc != sourcepad.loc)
 			visible_message("The pad flashes an error message. The caller has left their holopad.")
 			return TRUE
 		take_call(user)
@@ -92,11 +148,13 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 		return TRUE
 
 	. = TRUE
+
 	var/handle_type = "Holocomms"
 	var/ai_exists = FALSE
 
 	for(var/mob/living/silicon/ai/AI in GLOB.living_mob_list_)
-		if(!AI.client)	continue
+		if(!AI.client)
+			continue
 		ai_exists = TRUE
 		break
 
@@ -105,59 +163,85 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 	switch(handle_type)
 		if("AIC")
-			if(last_request + 200 < world.time) //don't spam the AI with requests you jerk!
-				last_request = world.time
-				to_chat(user, SPAN_NOTICE("You request an AI's presence."))
-				var/area/area = get_area(src)
-				for(var/mob/living/silicon/ai/AI in GLOB.living_mob_list_)
-					if(!AI.client)	continue
-					if (holopadType != HOLOPAD_LONG_RANGE && !AreConnectedZLevels(AI.z, src.z))
-						continue
-					to_chat(AI, SPAN_INFO("Your presence is requested at <a href='?src=\ref[AI];jumptoholopad=\ref[src]'>\the [area]</a>."))
-			else
-				to_chat(user, SPAN_NOTICE("A request for AI presence was already sent recently."))
+			if(request_cooldown > world.time) // Don't spam the AI with requests you jerk!
+				to_chat(user, SPAN_NOTICE("A request for AIC presence was already sent recently."))
+				return
+
+			request_cooldown = world.time + request_cooldown_time
+			to_chat(user, SPAN_NOTICE("You request an AIC's presence."))
+			for(var/mob/living/silicon/ai/AI in GLOB.living_mob_list_)
+				if(!AI.client)
+					continue
+				if(holopadType != HOLOPAD_LONG_RANGE && !AreConnectedZLevels(AI.z, src.z))
+					continue
+				to_chat(AI, SPAN_INFO("Your presence is requested at <a href='?src=\ref[AI];jumptoholopad=\ref[src]'>\the [holopad_id]</a>."))
+
 		if("Holocomms")
-			if(user.loc != src.loc)
+			if(user.loc != loc)
 				to_chat(user, SPAN_INFO("Please step onto the holopad."))
 				return
-			if(last_request + 200 < world.time) //don't spam other people with requests either, you jerk!
-				last_request = world.time
-				var/list/holopadlist = list()
-				var/zlevels = GetConnectedZlevels(z)
-				var/zlevels_long = list()
-				if(GLOB.using_map.use_overmap && holopadType == HOLOPAD_LONG_RANGE)
-					for(var/zlevel in map_sectors)
-						var/obj/effect/overmap/visitable/O = map_sectors["[zlevel]"]
-						if(!isnull(O))
-							zlevels_long |= O.map_z
-				for(var/obj/machinery/hologram/holopad/H in SSmachines.machinery)
-					if (H.operable())
-						if(H.z in zlevels)
-							holopadlist["[H.loc.loc.name]"] = H	//Define a list and fill it with the area of every holopad in the world
-						if (H.holopadType == HOLOPAD_LONG_RANGE && (H.z in zlevels_long))
-							holopadlist["[H.loc.loc.name]"] = H
-				holopadlist = sortAssoc(holopadlist)
-				var/temppad = input(user, "Which holopad would you like to contact?", "holopad list") as null|anything in holopadlist
-				targetpad = holopadlist["[temppad]"]
-				if(targetpad==src)
-					to_chat(user, SPAN_INFO("Using such sophisticated technology, just to talk to yourself seems a bit silly."))
-					targetpad = null //Clean up the mess after an unsuccessful call
-					return
-				if(targetpad && targetpad.caller_id)
-					to_chat(user, SPAN_INFO("The pad flashes a busy sign. Maybe you should try again later.."))
-					targetpad = null //Clean up the mess after an unsuccessful call
-					return
-				if(targetpad)
-					make_call(targetpad, user)
-			else
-				to_chat(user, SPAN_NOTICE("A request for holographic communication was already sent recently."))
 
+			if(request_cooldown > world.time) // Don't spam other people with requests either, you jerk!
+				to_chat(user, SPAN_NOTICE("A request for holographic communication was already sent recently."))
+				return
+
+			request_cooldown = world.time + request_cooldown_time
+			var/zlevels = GetConnectedZlevels(z)
+			var/zlevels_long = list()
+			if(GLOB.using_map.use_overmap && holopadType == HOLOPAD_LONG_RANGE)
+				for(var/zlevel in map_sectors)
+					var/obj/effect/overmap/visitable/O = map_sectors["[zlevel]"]
+					if(!isnull(O))
+						zlevels_long |= O.map_z
+			var/list/holopad_list = list()
+			for(var/HID in GLOB.holopad_list)
+				var/obj/machinery/hologram/holopad/H = GLOB.holopad_list[HID]
+				if(!istype(H))
+					continue
+				if(!H.operable())
+					continue
+				if(H.z in zlevels)
+					holopad_list[HID] = H
+				else if(H.holopadType == HOLOPAD_LONG_RANGE && (H.z in zlevels_long))
+					holopad_list[HID] = H
+			holopad_list = sortAssoc(holopad_list)
+			var/temp_pad = input(user, "Which holopad would you like to contact?", "holopad list") as null|anything in holopad_list
+			targetpad = holopad_list[temp_pad]
+
+			if(QDELETED(targetpad) || !istype(targetpad))
+				to_chat(user, SPAN_WARNING("The connection could not be made due to an instance error!"))
+				targetpad = null
+				return
+			if(!targetpad.operable())
+				to_chat(user, SPAN_WARNING("The connection could not be made due to target pad being unreachable!"))
+				targetpad = null
+				return
+			if(targetpad == src)
+				to_chat(user, SPAN_INFO("Using such sophisticated technology, just to talk to yourself seems a bit silly."))
+				targetpad = null //Clean up the mess after an unsuccessful call
+				return
+			if(targetpad.caller_id)
+				to_chat(user, SPAN_INFO("The pad flashes a busy sign. Maybe you should try again later.."))
+				targetpad = null //Clean up the mess after an unsuccessful call
+				return
+			// Successful call attempt
+			make_call(targetpad, user)
+
+/obj/machinery/hologram/holopad/attackby(obj/item/W, mob/user)
+	if(isMultitool(W))
+		var/new_hid = sanitize(input(user, "Select new holopad ID.",,holopad_id) as text|null, 30)
+		if(new_hid)
+			ChangeID(new_hid)
+			playsound(get_turf(src), 'sound/effects/pop.ogg', 25)
+			to_chat(user, SPAN_NOTICE("\The [src] ID has been changed to [holopad_id]!"))
+		return
+	return ..()
 
 /obj/machinery/hologram/holopad/proc/make_call(obj/machinery/hologram/holopad/targetpad, mob/living/carbon/user)
-	targetpad.last_request = world.time
+	targetpad.request_cooldown = world.time + request_cooldown_time
 	targetpad.sourcepad = src //This marks the holopad you are making the call from
 	targetpad.caller_id = user //This marks you as the caller
-	targetpad.incoming_connection = 1
+	targetpad.incoming_connection = TRUE
 	playsound(targetpad.loc, 'sound/machines/chime.ogg', 25, 5)
 	targetpad.icon_state = "[targetpad.base_icon]1"
 	targetpad.audible_message("<b>\The [src]</b> announces, \"Incoming communications request from [targetpad.sourcepad.loc.loc].\"")
@@ -166,7 +250,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 
 /obj/machinery/hologram/holopad/proc/take_call(mob/living/carbon/user)
-	incoming_connection = 0
+	incoming_connection = FALSE
 	caller_id.machine = sourcepad
 	caller_id.reset_view(src)
 	if(!masters[caller_id])//If there is no hologram, possibly make one.
@@ -183,7 +267,7 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 
 /obj/machinery/hologram/holopad/proc/addrecentcall(id)
 	recent_calls += id
-	if (recent_calls.len > 5)
+	if(recent_calls.len > 5)
 		recent_calls -= recent_calls[1]
 
 /obj/machinery/hologram/holopad/check_eye(mob/user)
@@ -197,9 +281,9 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 	This may change in the future but for now will suffice.*/
 	if(user.eyeobj && (user.eyeobj.loc != src.loc))//Set client eye on the object if it's not already.
 		user.eyeobj.setLoc(get_turf(src))
-	else if (!allow_ai)
+	else if(!allow_ai)
 		to_chat(user, SPAN_WARNING("Access denied."))
-	else if (holopadType != HOLOPAD_LONG_RANGE && !AreConnectedZLevels(user.z, src.z))
+	else if(holopadType != HOLOPAD_LONG_RANGE && !AreConnectedZLevels(user.z, src.z))
 		to_chat(user, SPAN_WARNING("Out of range."))
 	else if(!masters[user])//If there is no hologram, possibly make one.
 		activate_holo(user)
@@ -210,12 +294,12 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 /obj/machinery/hologram/holopad/proc/activate_holo(mob/living/silicon/ai/user)
 	if(!(stat & NOPOWER) && user.eyeobj && user.eyeobj.loc == src.loc)//If the projector has power and client eye is on it
 		if (user.holo)
-			to_chat(user, "<span class='danger'>ERROR:</span> Image feed in progress.")
+			to_chat(user, SPAN_DANGER("ERROR: Image feed in progress."))
 			return
 		src.visible_message("A holographic image of [user] flicks to life right before your eyes!")
 		create_holo(user)//Create one.
 	else
-		to_chat(user, "<span class='danger'>ERROR:</span> Unable to project hologram.")
+		to_chat(user, SPAN_DANGER("ERROR: Unable to project hologram."))
 	return
 
 /obj/machinery/hologram/holopad/proc/activate_holocall(mob/living/carbon/caller_id)
@@ -223,8 +307,20 @@ var/const/HOLOPAD_MODE = RANGE_BASED
 		src.visible_message("A holographic image of [caller_id] flicks to life right before your eyes!")
 		create_holo(0,caller_id)//Create one.
 	else
-		to_chat(caller_id, "<span class='danger'>ERROR:</span> Unable to project hologram.")
+		to_chat(caller_id, SPAN_DANGER("ERROR: Unable to project hologram."))
 	return
+
+// VV handler for updating the global list
+/obj/machinery/hologram/holopad/proc/ChangeID(new_id)
+	GLOB.holopad_list -= holopad_id
+	// Handling duplicate IDs
+	var/holo_number = 0
+	var/new_holo_id = new_id
+	while(new_holo_id in GLOB.holopad_list)
+		holo_number += 1
+		new_holo_id = "[holopad_id] #[holo_number]"
+	holopad_id = new_holo_id
+	GLOB.holopad_list[holopad_id] = src
 
 /*This is the proc for special two-way communication between AI and holopad/people talking near holopad.
 For the other part of the code, check silicon say.dm. Particularly robot talk.*/
@@ -325,49 +421,27 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	hologram.color = color //painted holopad gives coloured holograms
 	set_light(1, 0.1, 2)			//pad lighting
 	icon_state = "[base_icon]1"
-	return 1
+	return TRUE
 
 /obj/machinery/hologram/holopad/proc/clear_holo(mob/living/silicon/ai/user, mob/living/carbon/caller_id)
 	if(user)
 		qdel(masters[user])//Get rid of user's hologram
 		user.holo = null
 		masters -= user //Discard AI from the list of those who use holopad
+
 	if(caller_id)
 		qdel(masters[caller_id])//Get rid of user's hologram
 		masters -= caller_id //Discard the caller from the list of those who use holopad
-	if (!masters.len)//If no users left
+
+	if(!masters.len)//If no users left
 		set_light(0)			//pad lighting (hologram lighting will be handled automatically since its owner was deleted)
 		icon_state = "[base_icon]0"
 		if(sourcepad)
 			sourcepad.targetpad = null
 			sourcepad = null
 			caller_id = null
-	return 1
 
-
-/obj/machinery/hologram/holopad/Process()
-	for (var/mob/living/silicon/ai/master in masters)
-		var/active_ai = (master && !master.incapacitated() && master.client && master.eyeobj)//If there is an AI with an eye attached, it's not incapacitated, and it has a client
-		if((stat & NOPOWER) || !active_ai)
-			clear_holo(master)
-			continue
-
-		if(!(masters[master] in view(src)))
-			clear_holo(master)
-			continue
-
-		use_power_oneoff(power_per_hologram)
-	if(last_request + 200 < world.time&&incoming_connection==1)
-		if(sourcepad)
-			sourcepad.audible_message("<i><span class='game say'>The holopad connection timed out</span></i>")
-		incoming_connection = 0
-		end_call()
-	if (caller_id&&sourcepad)
-		if(caller_id.loc!=sourcepad.loc)
-			to_chat(sourcepad.caller_id, "Severing connection to distant holopad.")
-			end_call()
-			audible_message("The connection has been terminated by the caller.")
-	return 1
+	return TRUE
 
 /obj/machinery/hologram/holopad/proc/move_hologram(mob/living/silicon/ai/user)
 	if(masters[user])
@@ -420,11 +494,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 				qdel(src)
 	return
 
-/obj/machinery/hologram/holopad/Destroy()
-	for (var/mob/living/master in masters)
-		clear_holo(master)
-	return ..()
-
 /*
 Holographic project of everything else.
 
@@ -452,7 +521,7 @@ Holographic project of everything else.
  */
 /obj/machinery/hologram/projector
 	name = "hologram projector"
-	desc = "It makes a hologram appear...with magnets or something..."
+	desc = "It makes a hologram appear... with magnets or something..."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "hologram0"
 

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -140,3 +140,8 @@
 //You cant change this!
 /decl/vv_set_handler/light_handler/handle_set_var(atom/A, variable, var_value, client)
 	return
+
+/decl/vv_set_handler/holopad_id_handler
+	handled_type = /obj/machinery/hologram/holopad
+	handled_vars = list("holopad_id" = /obj/machinery/hologram/holopad/proc/ChangeID)
+	predicates = list(/proc/is_text_predicate)


### PR DESCRIPTION
## About the Pull Request

Ports #vlggms/tegustation-bay12/pull/361

- Holopad's ID is now a proper variable, instead of being "loc.loc" everywhere.
- Allows players to change holopad's ID by using multitool.
- Cleaned up variables and code.

## Why It's Good For The Game

- Allows us to place more than one holopad in the same area. Additionally, added a "system" that will prevent multiple holopads from having duplicate names.
- Ever wanted to build a base? Maybe renovate some room and name the pad "Schizo Office"? Now you can.
- Clean.

## Changelog

:cl:
tweak: Holopad's ID is not strictly tied to its area anymore.
tweak: Holopads can now be renamed by using a multitool.
/:cl: