### PR TITLE
Returns missing Ascent stuff

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1458,6 +1458,8 @@
 #include "code\modules\ascent\ascent_doodads.dm"
 #include "code\modules\ascent\ascent_id.dm"
 #include "code\modules\ascent\ascent_machines.dm"
+#include "code\modules\ascent\ascent_outfit.dm"
+#include "code\modules\ascent\ascent_props.dm"
 #include "code\modules\ascent\ascent_rigs.dm"
 #include "code\modules\ascent\ascent_structures.dm"
 #include "code\modules\ascent\ascent_suits.dm"

--- a/code/modules/ascent/ascent_id.dm
+++ b/code/modules/ascent/ascent_id.dm
@@ -2,7 +2,7 @@
 /obj/item/card/id/ascent
 	name = "alien chip"
 	icon = 'icons/obj/ascent.dmi'
-	icon_state = "ACCESS_CARD"
+	icon_state = "access_card"
 	desc = "A slender, complex chip of alien circuitry."
 	access = list(ACCESS_ASCENT)
 

--- a/code/modules/ascent/ascent_outfit.dm
+++ b/code/modules/ascent/ascent_outfit.dm
@@ -1,0 +1,113 @@
+/* These outfits are, obviously, only used for Ascent, which are normally only admin spawned for events */
+
+/decl/hierarchy/outfit/job/ascent
+	name = "Ascent - Gyne"
+	mask =     /obj/item/clothing/mask/gas/ascent
+	uniform =  /obj/item/clothing/under/ascent
+	id_type = list( /obj/item/card/id/ascent)
+	shoes =    /obj/item/clothing/shoes/magboots/ascent
+	l_ear =    null
+	pda_type = null
+	flags =    0
+
+/decl/hierarchy/outfit/job/ascent/attendant
+	name = "Ascent - Attendant"
+	back = /obj/item/rig/mantid
+
+/decl/hierarchy/outfit/job/ascent/tech
+	name = "Ascent - Technician"
+	belt = /obj/item/clothing/suit/storage/ascent
+
+/decl/hierarchy/outfit/job/ascent/worker
+	name = "Ascent - Serpentid Adjunct"
+	uniform =  /obj/item/clothing/under/harness
+	belt = /obj/item/clothing/suit/storage/ascent
+
+/decl/hierarchy/outfit/job/ascent/queen
+	name = "Ascent - Serpentid Queen"
+	belt = /obj/item/clothing/suit/storage/ascent
+
+/obj/item/clothing/mask/gas/ascent
+	name = "mantid facemask"
+	desc = "An alien facemask with chunky gas filters and a breathing valve."
+	filter_water = TRUE
+	icon_state = "ascent_mask"
+	item_state = "ascent_mask"
+	sprite_sheets = list(
+		SPECIES_NABBER =       'icons/mob/species/nabber/onmob_mask_gas.dmi',
+		SPECIES_MANTID_GYNE =  'icons/mob/species/mantid/onmob_mask_gyne.dmi',
+		SPECIES_MANTID_ALATE = 'icons/mob/species/mantid/onmob_mask_alate.dmi'
+	)
+	species_restricted = list(SPECIES_MANTID_ALATE, SPECIES_MANTID_GYNE)
+	filtered_gases = list(GAS_PHORON,GAS_N2O,GAS_CHLORINE,GAS_AMMONIA,GAS_CO,GAS_METHANE)
+	flags_inv = 0
+
+/obj/item/clothing/mask/gas/ascent/monarch
+	name = "serpentid facemask"
+	desc = "An alien facemask with chunky gas filters and a breathing valve."
+	filtered_gases = list(GAS_PHORON,GAS_N2O,GAS_CHLORINE,GAS_AMMONIA,GAS_CO,GAS_METHYL_BROMIDE,GAS_METHANE)
+	species_restricted = list(SPECIES_NABBER, SPECIES_MONARCH_QUEEN)
+
+/obj/item/clothing/mask/gas/ascent_captive
+	name = "humanoid filter mask"
+	desc = "A small gas filter designed to enable long-term survival in a methyl bromide atmosphere. It has an input port for food and water."
+	icon_state = "halfgas"
+	item_state = "halfgas"
+	flags_inv = 0
+	body_parts_covered = 0
+	filtered_gases = list(GAS_METHYL_BROMIDE)
+
+/obj/item/clothing/shoes/magboots/ascent
+	name = "mantid mag-claws"
+	desc = "A set of powerful gripping claws."
+	icon_state = "ascent_boots0"
+	icon_base = "ascent_boots"
+	species_restricted = list(SPECIES_MANTID_ALATE, SPECIES_MANTID_GYNE)
+	sprite_sheets = list(
+		SPECIES_MANTID_GYNE =  'icons/mob/species/mantid/onmob_shoes_gyne.dmi',
+		SPECIES_MANTID_ALATE = 'icons/mob/species/mantid/onmob_shoes_alate.dmi'
+	)
+
+/obj/item/clothing/under/ascent
+	name = "mantid undersuit"
+	desc = "A ribbed, spongy undersuit of some sort. It has a big sleeve for a tail, so it probably isn't for humans."
+	species_restricted = ALL_ASCENT_SPECIES
+	icon_state = "ascent"
+	worn_state = "ascent"
+	color = COLOR_DARK_GUNMETAL
+
+/obj/item/clothing/suit/storage/ascent
+	name = "mantid gear harness"
+	desc = "A complex tangle of articulated cables and straps."
+	species_restricted = ALL_ASCENT_SPECIES
+	icon_state = "ascent_harness"
+	body_parts_covered = 0
+	slot_flags = SLOT_OCLOTHING | SLOT_BELT
+	sprite_sheets = list(
+		SPECIES_MANTID_GYNE =    'icons/mob/species/mantid/onmob_belt_gyne.dmi',
+		SPECIES_MANTID_ALATE =   'icons/mob/species/mantid/onmob_belt_alate.dmi',
+		SPECIES_NABBER =         'icons/mob/species/nabber/onmob_belt_gas.dmi',
+		SPECIES_MONARCH_QUEEN = 'icons/mob/species/nabber/msq/onmob_belt_msq.dmi'
+	)
+
+	allowed = list(
+		/obj/item/device/flashlight,
+		/obj/item/tank,
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/inflatable_dispenser,
+		/obj/item/rcd
+	)
+
+/obj/item/clothing/suit/storage/ascent/Initialize()
+	. = ..()
+	for(var/tool in list(
+		/obj/item/gun/energy/particle/small,
+		/obj/item/device/multitool/mantid,
+		/obj/item/clustertool,
+		/obj/item/clustertool,
+		/obj/item/weldingtool/electric/mantid,
+		/obj/item/stack/medical/resin
+	))
+		allowed |= tool
+		new tool(pockets)
+	pockets.make_exact_fit()

--- a/code/modules/ascent/ascent_props.dm
+++ b/code/modules/ascent/ascent_props.dm
@@ -1,0 +1,87 @@
+// These objects are from Tegu Station's away site Ascent Caulship.
+
+/obj/item/ascent_egg
+	name = "crystalline egg"
+	desc = "A lumpy, gooey egg with a thin crystalline exterior."
+	icon = 'icons/obj/ascent.dmi'
+	icon_state = "egg_single"
+
+/obj/item/ascent_egg/anchored
+	icon_state = "egg0"
+	anchored = TRUE
+
+/obj/item/ascent_egg/immovable/Initialize()
+	. = ..()
+	icon_state = pick("egg0", "egg1", "egg2")
+
+/obj/item/ascent_egg/empty
+	name = "crystalline eggshell"
+	desc = "A lumpy, gooey egg with a thin crystalline exterior. This one is broken and empty."
+	icon_state = "egg_broken"
+	anchored = TRUE
+
+/mob/living/simple_animal/hostile/retaliate/alate_nymph
+	name = "alate nymph"
+	desc = "A small, skittering, juvenile kharmaan alate, likely fresh from the egg."
+	icon = 'icons/mob/simple_animal/ascent.dmi'
+	icon_state = "larva"
+	icon_living = "larva"
+	icon_dead = "larva_dead"
+	holder_type = /obj/item/holder
+	destroy_surroundings = FALSE
+	health = 50
+	maxHealth = 50
+	movement_cooldown = 2
+	density = FALSE
+	min_gas = list(GAS_METHYL_BROMIDE = 5)
+	mob_size = MOB_MINISCULE
+	can_escape = TRUE
+	pass_flags = PASS_FLAG_TABLE
+	natural_weapon = /obj/item/natural_weapon/bite
+	faction = "kharmaani"
+	ai_holder_type = /datum/ai_holder/simple_animal/retaliate/alate_nymph
+	var/global/list/friendly_species = list(SPECIES_MANTID_ALATE, SPECIES_MANTID_GYNE, SPECIES_MONARCH_QUEEN, SPECIES_MONARCH_WORKER)
+	/// If TRUE - any ghost can click on it to play as it
+	var/possessable = FALSE
+
+/datum/ai_holder/simple_animal/retaliate/alate_nymph/list_targets()
+	. = list()
+	var/mob/living/simple_animal/hostile/retaliate/alate_nymph/A = holder
+	for(var/mob/living/M in hearers(src, vision_range))
+		if(M.faction == A.faction)
+			continue
+		if(istype(M,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			if(H.species.get_bodytype() in A.friendly_species)
+				continue
+		. += M
+
+/mob/living/simple_animal/hostile/retaliate/alate_nymph/Initialize()
+	. = ..()
+	add_language(LANGUAGE_MANTID_NONVOCAL)
+	add_language(LANGUAGE_MANTID_VOCAL)
+
+/mob/living/simple_animal/hostile/retaliate/alate_nymph/attack_ghost(mob/observer/ghost/user)
+	. = ..()
+	if(ckey || !possessable)
+		return
+	if(alert(user, "Do you wish to play as [src]?",, "Yes", "No") != "Yes")
+		return
+	if(ckey) // Someone was faster
+		to_chat(user, SPAN_WARNING("Someone is already in control of [src]!"))
+		return
+	if(!possessable) // Admin changed their mind, maybe?
+		to_chat(user, SPAN_WARNING("Admins forbid anyone to play as [src] while you were thinking!"))
+		return
+	PossessByGhost(user)
+
+/mob/living/simple_animal/hostile/retaliate/alate_nymph/get_scooped(mob/living/carbon/grabber)
+	if(!(grabber.species.get_bodytype() in friendly_species))
+		to_chat(grabber, SPAN_WARNING("\The [src] wriggles out of your hands before you can pick it up!"))
+		return
+	else
+		return ..()
+
+/mob/living/simple_animal/hostile/retaliate/alate_nymph/proc/PossessByGhost(mob/observer/ghost/user)
+	ckey = user.ckey
+	qdel(user)


### PR DESCRIPTION
## About the Pull Request

- Adds ascent outfits(and clothes) and ascent props files.

## Why It's Good For The Game

- The Ascent are the most commonly used alien species for admin events, so it'd be nice to have the full toolset for them.

## Changelog

:cl:
admin: Ascent outfits, clothes and "props" were re-added. Yes, Yawet, this is for you.
/:cl:
