### PR TITLE
Fixes class D random name

### DIFF
--- a/code/game/jobs/job/misc.dm
+++ b/code/game/jobs/job/misc.dm
@@ -21,13 +21,12 @@
 	)
 
 /datum/job/classd/equip(mob/living/carbon/human/H)
+	H.fully_replace_character_name(random_name(H.gender, H.species.name))
 	. = ..()
 	var/r = rand(100,9000)
 	while (used_numbers.Find(r))
 		r = rand(100,9000)
 	used_numbers += r
-	H.name = random_name(H.gender, H.species.name)
-	H.real_name = H.name
 	if(istype(H.wear_id, /obj/item/card/id))
 		var/obj/item/card/id/ID = H.wear_id
 		ID.registered_name = "D-[used_numbers[used_numbers.len]]"


### PR DESCRIPTION
## About the Pull Request

Uses the proper proc to fully replace name of a mob and moves it before parent call of equip().

## Why It's Good For The Game

Previous "solution" created issues by not changing the name of the mind and *potentially* not showing up properly on the ID in certain scenarios.

## Changelog

:cl:
fix: Class D randomized names now work properly.
/:cl: