### PR TITLE
Removes D-class PDAs

### DIFF
--- a/code/datums/outfits/jobs/civilian.dm
+++ b/code/datums/outfits/jobs/civilian.dm
@@ -6,6 +6,7 @@
 	l_ear = null
 	l_pocket = /obj/item/paper/dclass_orientation
 	id_type = /obj/item/card/id/classd
+	pda_type = null
 
 /decl/hierarchy/outfit/job/civ/classd/post_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
## About the Pull Request

Removed PDAs from d-class outfit spawns

## Changelog

:cl:
balance: Removed PDAs from class D outfits.
/:cl:
