### PR TITLE
Protolathe access quickfix

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -65,8 +65,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
 	var/can_analyze = TRUE //If the console is allowed to use destructive analyzers
 
-	// req_access = list(ACCESS_RESEARCH)	//Data and setting manipulation requires scientist access.
-
 /obj/machinery/computer/rdconsole/proc/CallMaterialName(ID)
 	var/return_name = ID
 	switch(return_name)

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -65,7 +65,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	var/sync = 1		//If sync = 0, it doesn't show up on Server Control Console
 	var/can_analyze = TRUE //If the console is allowed to use destructive analyzers
 
-	req_access = list(ACCESS_RESEARCH)	//Data and setting manipulation requires scientist access.
+	// req_access = list(ACCESS_RESEARCH)	//Data and setting manipulation requires scientist access.
 
 /obj/machinery/computer/rdconsole/proc/CallMaterialName(ID)
 	var/return_name = ID


### PR DESCRIPTION
## About the Pull Request

Removes access requirements from protolathe computer, allowing anyone (next to to the computer) to use it.

Fixes #557 

## Why It's Good For The Game

Both protolathes are in access-restricted areas anyways, so there's no real need for the computer to check for IDs (aside from causing issues). The protolathe computer is due for a rework sometime anyways, so this is more of a quickfix than a permanent solution.

## Changelog

:cl:
balance: Protolathe computers don't need access to use anymore.
fix: Logistics personnel can now use the protolathe in their department.
/:cl:
