### PR TITLE
SD no longer starts with Jerraman

### DIFF
--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -11,7 +11,6 @@
 	l_ear = /obj/item/device/radio/headset/heads/captain
 	backpack_contents = list(/obj/item/ammo_magazine/scp/m1911 = 1)
 	belt = /obj/item/gun/projectile/pistol/m1911
-	l_hand = /obj/item/storage/briefcase/foundation/jerraman
 
 /decl/hierarchy/outfit/job/command/headofhr
 	name = OUTFIT_JOB_NAME("Head of Human Resources")


### PR DESCRIPTION
## About the Pull Request

Removes the SD's jerraman briefcase.

## Why It's Good For The Game

- Giving the SD powergame-y equipment promotes, well, powergaming, as well as individualism and many other forms of unsavory behavior.
- Jerraman is an old Bay leftover and doesn't fit with SCP.
- In fact, psionics in general is on my shitlist.
- Lore-wise, the entire thing just makes no goddamn _sense_.

## Changelog

:cl:
balance: The Site Director no longer starts with a briefcase of Jerraman.
/:cl: