### PR TITLE
inflatable door dupe hotfix

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -30,6 +30,8 @@
 	)
 	if (!do_after(user, 1 SECOND))
 		return
+	if(QDELETED(src))
+		return
 	obstruction = T.get_obstruction()
 	if (obstruction)
 		to_chat(user, SPAN_WARNING("\The [english_list(obstruction)] is blocking that spot."))


### PR DESCRIPTION
## About the Pull Request

tin
closes #1237 
untested but 99% likely works

## Why It's Good For The Game

![dreamseeker_Sfv93rHysO](https://github.com/Foundation-19/Foundation-19/assets/19525688/03161bc1-32cc-43e3-a41c-ecfa1e29f2d6)

## Changelog

:cl:
fix: You can no longer duplicate inflatable doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
