### PR TITLE
Fixes 173's pathing getting stuck as a result of JPS

### DIFF
--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -382,7 +382,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 		return FALSE
 
 	var/list/temp_steps_to_target = get_path_to(src, new_target, flee_distance * 2, min_target_dist = 1)
-	if(temp_steps_to_target) //Double check to ensure that whatever target we assign we can actually get to
+	if(LAZYLEN(temp_steps_to_target)) //Double check to ensure that whatever target we assign we can actually get to
 		steps_to_target = temp_steps_to_target
 		target = new_target
 		target_pos_last = get_turf(new_target)
@@ -395,6 +395,7 @@ GLOBAL_LIST_EMPTY(scp173s)
 
 /mob/living/scp_173/proc/move_to_target() //Moves 173 towards the target using steps list and also deals with any obstacles
 	if(!target || !LAZYLEN(steps_to_target))
+		clear_target()
 		return
 
 	var/turf/step_turf = steps_to_target[1]


### PR DESCRIPTION
## About the Pull Request

JPS returns a list and not null when there is no path which broke 173 because I didn't use lazylen when I coded its AI.

## Why It's Good For The Game

AI fixy

## Changelog

:cl:
fix: 173's pathing getting stuck.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
