### PR TITLE
Fixes obj/item/stack duping exploit

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -256,6 +256,10 @@
 	if (!amount)
 		return null
 
+	tamount = Floor(tamount)	// sanity check to prevent duping
+	if(tamount <= 0)				// if tamount was rounded to 0 (or below, somehow) just quit here
+		return null
+
 	var/transfer = max(min(tamount, src.amount, initial(max_amount)), 0)
 
 	var/orig_amount = src.amount


### PR DESCRIPTION
## About the Pull Request

Fixes #1267 

## Why It's Good For The Game

Whoooooooops

## Changelog

:cl:
fix: Stacks of items are no longer duplicated with fractional inputs.
/:cl: