### PR TITLE
Adds automatic dir-facing on fire + a few balloon alerts + spellcheck

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -812,12 +812,14 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	return copiedobjs
 
-
-
-/proc/get_cardinal_dir(atom/A, atom/B)
-	var/dx = abs(B.x - A.x)
-	var/dy = abs(B.y - A.y)
-	return get_dir(A, B) & (rand() * (dx+dy) < dy ? 3 : 12)
+/// Get the cardinal direction between two atoms
+/proc/get_cardinal_dir(atom/start, atom/end)
+	var/dx = end.x - start.x
+	var/dy = end.y - start.y
+	if(abs(dx) > abs(dy))
+		return (dx > 0) ? EAST : WEST
+	else
+		return (dy > 0) ? NORTH : SOUTH
 
 //chances are 1:value. anyprob(1) will always return true
 /proc/anyprob(value)

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -201,6 +201,12 @@ var/list/_client_preferences_by_type
 	description = "Draw gun based on intent"
 	key = "HOLSTER_ON_INTENT"
 
+/datum/client_preference/facedir_after_shoot
+	description = "Auto-face direction after shooting"
+	key = "FACEDIR_AFTER_SHOOT"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_NO
+
 /datum/client_preference/show_credits
 	description = "Show End Titles"
 	key = "SHOW_CREDITS"
@@ -270,7 +276,7 @@ var/list/_client_preferences_by_type
 	default_value = GLOB.PREF_NO
 
 /datum/client_preference/swap_tgui_inputs
-	description = "Swap Sumbmit/Cancle buttons"
+	description = "Swap Submit/Cancel buttons"
 	key = "SWAP_TGUI_INPUTS"
 	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
 	default_value = GLOB.PREF_YES

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1018,9 +1018,9 @@
 	set_face_dir()
 
 	if(!facing_dir)
-		to_chat(usr, "You are now not facing anything.")
+		balloon_alert(usr, "not facing")
 	else
-		to_chat(usr, "You are now facing [dir2text(facing_dir)].")
+		balloon_alert(usr, "facing [dir2text(facing_dir)]")
 
 /mob/proc/set_face_dir(newdir)
 	if(!isnull(facing_dir) && newdir == facing_dir)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1015,24 +1015,26 @@
 	set category = "IC"
 	set src = usr
 
-	set_face_dir()
+	face_current_direction()
 
+/mob/proc/face_current_direction()
 	if(!facing_dir)
-		balloon_alert(usr, "not facing")
+		set_face_dir(dir)
 	else
-		balloon_alert(usr, "facing [dir2text(facing_dir)]")
+		set_face_dir(null)
 
+/// Sets a mobs facing_dir to newdir, and gives an alert
 /mob/proc/set_face_dir(newdir)
-	if(!isnull(facing_dir) && newdir == facing_dir)
-		facing_dir = null
-	else if(newdir)
-		set_dir(newdir)
-		facing_dir = newdir
-	else if(facing_dir)
-		facing_dir = null
+	if(newdir)
+		if(!facing_dir || facing_dir != newdir)
+			facing_dir = newdir
+			set_dir(newdir)
+
+			balloon_alert(src, "facing [dir2text(facing_dir)]")
 	else
-		set_dir(dir)
-		facing_dir = dir
+		facing_dir = null
+
+		balloon_alert(src, "not facing")
 
 /mob/set_dir()
 	if(facing_dir)
@@ -1054,22 +1056,6 @@
 		return
 	. = stat
 	stat = new_stat
-
-/mob/verb/northfaceperm()
-	set hidden = 1
-	set_face_dir(client.client_dir(NORTH))
-
-/mob/verb/southfaceperm()
-	set hidden = 1
-	set_face_dir(client.client_dir(SOUTH))
-
-/mob/verb/eastfaceperm()
-	set hidden = 1
-	set_face_dir(client.client_dir(EAST))
-
-/mob/verb/westfaceperm()
-	set hidden = 1
-	set_face_dir(client.client_dir(WEST))
 
 #define SHIFT_MAX 8
 

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -200,7 +200,8 @@
 			toggle_safety()
 			return 1
 	if(MUTATION_HULK in M.mutations)
-		to_chat(M, SPAN_DANGER("Your fingers are much too large for the trigger guard!"))
+		balloon_alert(M, "fingers too big!")
+		to_chat(M, SPAN_DANGER("Your fingers are too big for the trigger guard!"))
 		return 0
 	if((MUTATION_CLUMSY in M.mutations) && prob(40)) //Clumsy handling
 		var/obj/P = consume_next_projectile()
@@ -259,6 +260,9 @@
 
 	add_fingerprint(user)
 
+	if(user.client?.get_preference_value(/datum/client_preference/facedir_after_shoot) == GLOB.PREF_YES && !user.facing_dir)	// could be signallified but w/e
+		user.face_direction()
+
 	if((!waterproof && submerged()) || !special_check(user))
 		return
 
@@ -270,8 +274,7 @@
 			return
 
 	if(world.time < next_fire_time)
-		if (world.time % 3) //to prevent spam
-			to_chat(user, SPAN_WARNING("[src] is not ready to fire again!"))
+		balloon_alert(user, "can't fire!")
 		return
 
 	last_safety_check = world.time
@@ -346,13 +349,12 @@
 		flick(fire_anim, src)
 
 	if (user)
-		var/user_message = SPAN_WARNING("You fire \the [src][pointblank ? " point blank":""] at \the [target][reflex ? " by reflex" : ""]!")
 		if (silenced)
-			to_chat(user, user_message)
+			to_chat(user, SPAN_WARNING("You fire \the [src][pointblank ? " point blank":""] at \the [target][reflex ? " by reflex" : ""]!"))
 		else
 			user.visible_message(
 				SPAN_DANGER("\The [user] fires \the [src][pointblank ? " point blank":""] at \the [target][reflex ? " by reflex" : ""]!"),
-				user_message,
+				SPAN_WARNING("You fire \the [src][pointblank ? " point blank":""] at \the [target][reflex ? " by reflex" : ""]!"),
 				SPAN_DANGER("You hear a [fire_sound_text]!")
 			)
 
@@ -530,7 +532,7 @@
 			user.apply_damage(in_chamber.damage*2.5, in_chamber.damage_type, BP_HEAD, in_chamber.damage_flags(), used_weapon = "Point blank shot in the mouth with \a [in_chamber]")
 			user.death()
 		else
-			to_chat(user, "<span class = 'notice'>Ow...</span>")
+			to_chat(user, SPAN_NOTICE("Ow..."))
 			user.apply_effect(110,PAIN,0)
 		qdel(in_chamber)
 		mouthshoot = 0
@@ -609,7 +611,7 @@
 	if(prob(20) && !user.skill_check(SKILL_WEAPONS, SKILL_BASIC))
 		new_mode = switch_firemodes(user)
 	if(new_mode)
-		to_chat(user, SPAN_NOTICE("\The [src] is now set to [new_mode.name]."))
+		balloon_alert(user, "set to [new_mode.name]")
 
 /obj/item/gun/proc/toggle_safety(mob/user)
 	if (user?.is_physically_disabled())

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -260,8 +260,8 @@
 
 	add_fingerprint(user)
 
-	if(user.client?.get_preference_value(/datum/client_preference/facedir_after_shoot) == GLOB.PREF_YES && !user.facing_dir)	// could be signallified but w/e
-		user.face_direction()
+	if(user.client?.get_preference_value(/datum/client_preference/facedir_after_shoot) == GLOB.PREF_YES)	// could be signallified but w/e
+		user.set_face_dir(get_cardinal_dir(user, target))
 
 	if((!waterproof && submerged()) || !special_check(user))
 		return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -274,7 +274,7 @@
 			return
 
 	if(world.time < next_fire_time)
-		balloon_alert(user, "can't fire!")
+		balloon_alert(user, "can't fire yet!")
 		return
 
 	last_safety_check = world.time

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -72,7 +72,7 @@
 			if(prob(user.skill_fail_chance(SKILL_WEAPONS, 100, SKILL_MASTER)))
 				return null
 			else
-				to_chat(user, SPAN_NOTICE("You reflexively clear the jam on \the [src]."))
+				balloon_alert(user, "jam cleared")
 				is_jammed = 0
 				playsound(src.loc, 'sounds/weapons/flipblade.ogg', 50, 1)
 	if(is_jammed)
@@ -149,17 +149,14 @@
 		switch(AM.mag_type)
 			if(MAGAZINE)
 				if((ispath(allowed_magazines) && !istype(A, allowed_magazines)) || (islist(allowed_magazines) && !is_type_in_list(A, allowed_magazines)))
-					to_chat(user, SPAN_WARNING("\The [A] won't fit into [src]."))
+					balloon_alert(user, "won't fit!")
 					return
 				if(ammo_magazine)
-					if(user.a_intent == I_HELP || user.a_intent == I_DISARM || !user.skill_check(SKILL_WEAPONS, SKILL_EXPERIENCED))
-						to_chat(user, SPAN_WARNING("[src] already has a magazine loaded."))//already a magazine here
+					if(!can_special_reload || user.a_intent == I_HELP || user.a_intent == I_DISARM || !user.skill_check(SKILL_WEAPONS, SKILL_EXPERIENCED))
+						balloon_alert(user, "already has a magazine!") //already a magazine here
 						return
 					else
 						if(user.a_intent == I_GRAB) //Tactical reloading
-							if(!can_special_reload)
-								to_chat(user, SPAN_WARNING("You can't tactically reload this gun!"))
-								return
 							//Experienced gets a 1 second delay, master gets a 0.5 second delay
 							if(!do_after(user, user.get_skill_value(SKILL_WEAPONS) == SKILL_MASTER ? PROF_TAC_RELOAD : EXP_TAC_RELOAD, src))
 								return
@@ -170,9 +167,6 @@
 							user.visible_message(SPAN_WARNING("\The [user] reloads \the [src] with \the [AM]!"),\
 												SPAN_WARNING("You tactically reload \the [src] with \the [AM]!"))
 						else //Speed reloading
-							if(!can_special_reload)
-								to_chat(user, SPAN_WARNING("You can't speed reload with this gun!"))
-								return
 							//Experienced gets a 0.5 second delay, master gets a 0.25 second delay
 							if(!do_after(user, user.get_skill_value(SKILL_WEAPONS) == SKILL_MASTER ? PROF_SPD_RELOAD : EXP_SPD_RELOAD, src))
 								return
@@ -196,7 +190,7 @@
 				show_sound_effect(loc, user, SFX_ICON_SMALL)
 			if(SPEEDLOADER)
 				if(loaded.len >= max_shells)
-					to_chat(user, SPAN_WARNING("[src] is full!"))
+					balloon_alert(user, "full!")
 					return
 				var/count = 0
 				for(var/obj/item/ammo_casing/C in AM.stored_ammo)
@@ -217,7 +211,7 @@
 		if(!(load_method & SINGLE_CASING) || caliber != C.caliber)
 			return //incompatible
 		if(loaded.len >= max_shells)
-			to_chat(user, SPAN_WARNING("[src] is full."))
+			balloon_alert(user, "full!")
 			return
 		if(!user.unEquip(C, src))
 			return
@@ -266,7 +260,7 @@
 			user.put_in_hands(C)
 			user.visible_message("[user] removes \a [C] from [src].", SPAN_NOTICE("You remove \a [C] from [src]."))
 	else
-		to_chat(user, SPAN_WARNING("[src] is empty."))
+		balloon_alert(user, "empty!")
 	update_icon()
 
 /obj/item/gun/projectile/attackby(obj/item/A as obj, mob/user as mob)


### PR DESCRIPTION
## About the Pull Request

Adds an OPTIONAL pref for automatically facing direction after firing a gun.

Also converts a few gun-related to_chats to balloon_alerts

Also also fixes a pref's spelling

## Why It's Good For The Game

The auto-facedir was suggested as a nice QoL feature, to make it easier to shoot while retreating.

## Changelog

:cl:
qol: New preference: "Auto-face direction after shooting". Now you can retreat while firing WITHOUT having to struggle with Bay controls!
qol: A few gun-related to_chats (on the sidebar) have been changed to balloon_alerts (right on top of the gun).
balance: rebalanced something
spellcheck: Fixes submit/cancel swap button typo.
/:cl: