### PR TITLE
Backpack notification improvement

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -210,12 +210,9 @@
 
 		if(!prevent_warning)
 			for(var/mob/M in viewers(usr, null))
-				if (M == usr)
-					to_chat(usr, SPAN_NOTICE("You put \the [W] into [src]."))
-				else if (M in range(1, src)) //If someone is standing close enough, they can tell what it is... TODO replace with distance check
-					M.show_message(SPAN_NOTICE("\The [usr] puts [W] into [src]."), VISIBLE_MESSAGE)
-				else if (W?.w_class >= ITEM_SIZE_NORMAL) //Otherwise they can only see large or normal items from a distance...
-					M.show_message(SPAN_NOTICE("\The [usr] puts [W] into [src]."), VISIBLE_MESSAGE)
+				// If we aren't the one inserting AND we can see the item AND we're close enough (enough being dependant on the size of the item), we notice the item
+				if (M != usr && M.can_see(src) && (get_dist(M, src) <= W.w_class))
+					M.show_message(SPAN_NOTICE("\The [usr] puts \the [W] into \the [src]."), VISIBLE_MESSAGE)
 
 		if(!NoUpdate)
 			update_ui_after_item_insertion()


### PR DESCRIPTION
## About the Pull Request

Optimizes the notification for putting an item in a storage item.
Removes the to_chat message you get for your own items.
Slightly alters the requirements for seeing an item get put in a backpack (can_see check + range is dependent on weight class instead of having two separate checks_

## Why It's Good For The Game

It's pointless to get a message for an action you did yourself.
The formula change is a little more sensible and dynamic, and 

## Changelog

:cl:
del: You don't see chat messages for objects you put in your own backpack.
balance: Item insertion message checks slightly improved. The item's size matters a little more and you can't get a message for items you can't see.
/:cl: