### PR TITLE
Fixes poor implementation of open icons for boxes and also cleans up storage code

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -202,15 +202,7 @@
 	item_state_slots = null
 	w_class = ITEM_SIZE_HUGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE + 10
-
-/obj/item/storage/backpack/dufflebag/open(mob/user)
-	. = ..()
-	icon_state = "duffleopen"
-
-/obj/item/storage/backpack/dufflebag/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "duffleopen"
 
 /obj/item/storage/backpack/dufflebag/Initialize()
 	. = ..()
@@ -221,83 +213,53 @@
 	desc = "A large dufflebag for holding extra tactical supplies."
 	icon_state = "duffle_syndie"
 	item_state_slots = list(slot_l_hand_str = "duffle_syndie", slot_r_hand_str = "duffle_syndie")
+	open_icon = "duffle_syndieopen"
 
 /obj/item/storage/backpack/dufflebag/syndie/Initialize()
 	. = ..()
 	slowdown_per_slot[slot_back] = 0
-
-
-/obj/item/storage/backpack/dufflebag/syndie/open(mob/user)
-	. = ..()
-	icon_state = "duffle_syndieopen"
-
-/obj/item/storage/backpack/dufflebag/syndie/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
 
 /obj/item/storage/backpack/dufflebag/syndie/med
 	name = "medical dufflebag"
 	desc = "A large dufflebag for holding extra tactical medical supplies."
 	icon_state = "duffle_syndiemed"
 	item_state_slots = list(slot_l_hand_str = "duffle_syndiemed", slot_r_hand_str = "duffle_syndiemed")
+	open_icon = null
 
 /obj/item/storage/backpack/dufflebag/syndie/ammo
 	name = "ammunition dufflebag"
 	desc = "A large dufflebag for holding extra weapons ammunition and supplies."
 	icon_state = "duffle_syndieammo"
 	item_state_slots = list(slot_l_hand_str = "duffle_syndieammo", slot_r_hand_str = "duffle_syndieammo")
+	open_icon = null
 
 /obj/item/storage/backpack/dufflebag/com
 	name = "command dufflebag"
 	desc = "A large dufflebag for holding extra goods for senior command."
 	icon_state = "duffle_captain"
 	item_state_slots = list(slot_l_hand_str = "duffle_captain", slot_r_hand_str = "duffle_captain")
+	open_icon = null
 
 /obj/item/storage/backpack/dufflebag/med
 	name = "medical dufflebag"
 	desc = "A large dufflebag for holding extra medical supplies."
 	icon_state = "duffle_med"
 	item_state_slots = list(slot_l_hand_str = "duffle_med", slot_r_hand_str = "duffle_med")
-
-/obj/item/storage/backpack/dufflebag/med/open(mob/user)
-	. = ..()
-	icon_state = "duffle_medopen"
-
-/obj/item/storage/backpack/dufflebag/med/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "duffle_medopen"
 
 /obj/item/storage/backpack/dufflebag/sec
 	name = "security dufflebag"
 	desc = "A large dufflebag for holding extra security supplies and ammunition."
 	icon_state = "duffle_sec"
 	item_state_slots = list(slot_l_hand_str = "duffle_sec", slot_r_hand_str = "duffle_sec")
-
-/obj/item/storage/backpack/dufflebag/sec/open(mob/user)
-	. = ..()
-	icon_state = "duffle_secopen"
-
-/obj/item/storage/backpack/dufflebag/sec/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "duffle_secopen"
 
 /obj/item/storage/backpack/dufflebag/eng
 	name = "industrial dufflebag"
 	desc = "A large dufflebag for holding extra tools and supplies."
 	icon_state = "duffle_eng"
 	item_state_slots = list(slot_l_hand_str = "duffle_eng", slot_r_hand_str = "duffle_eng")
-
-/obj/item/storage/backpack/dufflebag/eng/open(mob/user)
-	. = ..()
-	icon_state = "duffle_engopen"
-
-/obj/item/storage/backpack/dufflebag/eng/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "duffle_engopen"
 
 /obj/item/storage/backpack/dufflebag/firefighter
 	name = "firefighter's dufflebag"
@@ -312,6 +274,7 @@
 		/obj/item/clothing/head/hardhat/firefighter,
 		/obj/item/extinguisher
 	)
+	open_icon = null
 /*
  * Satchel Types
  */

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -12,15 +12,6 @@
 	var/renamed = 0
 	var/icon_changed = 0
 
-/obj/item/storage/bible/open(mob/user)
-	. = ..()
-	icon_state = "bibleopen"
-
-/obj/item/storage/bible/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
-
 /obj/item/storage/bible/booze
 	name = "bible"
 	desc = "To be applied to the head repeatedly."
@@ -37,6 +28,7 @@
 	desc = "The central religious text of Christianity."
 	renamed = 1
 	icon_changed = 1
+	open_icon = "bibleopen"
 
 /obj/item/storage/bible/tanakh
 	name = "\improper Tanakh"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -26,16 +26,8 @@
 	item_state = "syringe_kit"
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sounds/effects/storage/box.ogg'
+	open_icon = "boxopen"
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
-
-/obj/item/storage/box/open(mob/user)
-	. = ..()
-	icon_state = "boxopen"
-
-/obj/item/storage/box/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
 
 /obj/item/storage/box/large
 	name = "large box"
@@ -43,15 +35,7 @@
 	w_class = ITEM_SIZE_LARGE
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
-
-/obj/item/storage/box/large/open(mob/user)
-	. = ..()
-	icon_state = "largeboxopen"
-
-/obj/item/storage/box/large/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "largeboxopen"
 
 /obj/item/storage/box/union_cards
 	name = "box of union cards"
@@ -208,15 +192,7 @@
 	icon_state = "ammo"
 	desc = "A sturdy metal box with several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 	use_sound = 'sounds/effects/closet_open.ogg'
-
-/obj/item/storage/box/ammo/open(mob/user)
-	. = ..()
-	item_state = "ammoopen"
-
-/obj/item/storage/box/ammo/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "ammoopen"
 
 /obj/item/storage/box/ammo/blanks
 	name = "box of blank shells"
@@ -373,6 +349,7 @@
 	desc = "Drymate brand monkey cubes. Just add water!"
 	icon = 'icons/obj/food.dmi'
 	icon_state = "monkeycubebox"
+	open_icon = null
 	can_hold = list(/obj/item/reagent_containers/food/snacks/monkeycube)
 	startswith = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped = 5)
 
@@ -533,18 +510,10 @@
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 	temperature = -16 CELSIUS
+	open_icon = "portafreezeropen"
 
 /obj/item/storage/box/freezer/ProcessAtomTemperature()
 	return PROCESS_KILL
-
-/obj/item/storage/box/freezer/open(mob/user)
-	. = ..()
-	icon_state = "portafreezeropen"
-
-/obj/item/storage/box/freezer/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
 
 /obj/item/storage/box/checkers
 	name = "checkers box"

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -16,15 +16,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_BOX_STORAGE
 	use_sound = 'sounds/effects/storage/box.ogg'
-
-/obj/item/storage/firstaid/open(mob/user)
-	. = ..()
-	icon_state = "firstaidopen"
-
-/obj/item/storage/firstaid/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "firstaidopen"
 
 /obj/item/storage/firstaid/empty
 	icon_state = "firstaid"
@@ -46,6 +38,7 @@
 	desc = "It's an emergency medical kit for when people brought ballistic weapons to a laser fight."
 	icon_state = "radfirstaid"
 	item_state = "firstaid-ointment"
+	open_icon = "radopen"
 
 	startswith = list(
 		/obj/item/storage/med_pouch/trauma = 4
@@ -55,20 +48,12 @@
 	..()
 	icon_state = pick("radfirstaid", "radfirstaid2")
 
-/obj/item/storage/firstaid/trauma/open(mob/user)
-	. = ..()
-	icon_state = "radopen"
-
-/obj/item/storage/firstaid/trauma/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
-
 /obj/item/storage/firstaid/fire
 	name = "fire first-aid kit"
 	desc = "It's an emergency medical kit for when the toxins lab <i>-spontaneously-</i> burns down."
 	icon_state = "ointment"
 	item_state = "firstaid-ointment"
+	open_icon = "fireopen"
 
 	startswith = list(
 		/obj/item/storage/med_pouch/burn = 4
@@ -78,20 +63,12 @@
 	..()
 	icon_state = pick("ointment","firefirstaid")
 
-/obj/item/storage/firstaid/fire/open(mob/user)
-	. = ..()
-	icon_state = "fireopen"
-
-/obj/item/storage/firstaid/fire/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
-
 /obj/item/storage/firstaid/toxin
 	name = "toxin first aid"
 	desc = "Used to treat when you have a high amount of toxins in your body."
 	icon_state = "antitoxin"
 	item_state = "firstaid-toxin"
+	open_icon = "toxinopen"
 
 	startswith = list(
 		/obj/item/storage/med_pouch/toxin = 4
@@ -101,39 +78,23 @@
 	..()
 	icon_state = pick("antitoxin","antitoxfirstaid")
 
-/obj/item/storage/firstaid/toxin/open(mob/user)
-	. = ..()
-	icon_state = "toxinopen"
-
-/obj/item/storage/firstaid/toxin/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
-
 /obj/item/storage/firstaid/o2
 	name = "oxygen deprivation first aid"
 	desc = "A box full of oxygen goodies."
 	icon_state = "o2"
 	item_state = "firstaid-o2"
+	open_icon = "o2open"
 
 	startswith = list(
 		/obj/item/storage/med_pouch/oxyloss = 4
 		)
-
-/obj/item/storage/firstaid/o2/open(mob/user)
-	. = ..()
-	icon_state = "o2open"
-
-/obj/item/storage/firstaid/o2/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
 
 /obj/item/storage/firstaid/adv
 	name = "advanced first-aid kit"
 	desc = "Contains advanced medical treatments."
 	icon_state = "doctor-kit"
 	item_state = "firstaid-advanced"
+	open_icon = "doctor-kitopen"
 
 	startswith = list(
 		/obj/item/storage/pill_bottle/assorted,
@@ -142,20 +103,12 @@
 		/obj/item/stack/medical/splint
 		)
 
-/obj/item/storage/firstaid/adv/open(mob/user)
-	. = ..()
-	icon_state = "doctor-kitopen"
-
-/obj/item/storage/firstaid/adv/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
-
 /obj/item/storage/firstaid/combat
 	name = "combat medical kit"
 	desc = "Contains advanced medical treatments."
 	icon_state = "bezerk"
 	item_state = "firstaid-advanced"
+	open_icon = "bezerkopen"
 
 	startswith = list(
 		/obj/item/storage/pill_bottle/bicaridine,
@@ -166,15 +119,6 @@
 		/obj/item/storage/pill_bottle/spaceacillin,
 		/obj/item/stack/medical/splint,
 		)
-
-/obj/item/storage/firstaid/combat/open(mob/user)
-	. = ..()
-	icon_state = "bezerkopen"
-
-/obj/item/storage/firstaid/combat/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
 
 /obj/item/storage/firstaid/stab
 	name = "stabilisation first aid"
@@ -200,6 +144,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = null
 	use_sound = 'sounds/effects/storage/briefcase.ogg'
+	open_icon = "surgerykitopen"
 
 	can_hold = list(
 		/obj/item/bonesetter,
@@ -227,15 +172,6 @@
 		/obj/item/FixOVein,
 		/obj/item/stack/medical/advanced/bruise_pack,
 		)
-
-/obj/item/storage/firstaid/surgery/open(mob/user)
-	. = ..()
-	icon_state = "surgerykitopen"
-
-/obj/item/storage/firstaid/surgery/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
 
 /*
  * Pill Bottles

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -26,8 +26,11 @@
 	//the assoc value can either be the quantity, or a list whose first value is the quantity and the rest are args.
 	var/list/startswith
 	var/datum/storage_ui/storage_ui = /datum/storage_ui/default
-	var/opened = null
+	var/opened = FALSE
 	var/open_sound = null
+
+	///Open Icon (If populated storage icon will change to this on being opened)
+	var/open_icon
 
 /obj/item/storage/Destroy()
 	QDEL_NULL(storage_ui)
@@ -94,14 +97,18 @@
 		storage_ui.hide_from(user)
 
 /obj/item/storage/proc/open(mob/user as mob)
-	if(!opened)
-		playsound(src.loc, src.open_sound, 50, 0, -5)
-		show_sound_effect(get_turf(src), user, SFX_ICON_SMALL)
-		opened = 1
-		queue_icon_update()
-	if (src.use_sound)
+	if(src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 0, -5)
 		show_sound_effect(get_turf(src), user, SFX_ICON_SMALL)
+	if(!opened)
+		if(open_icon)
+			set_icon_state(open_icon)
+		opened = TRUE
+		queue_icon_update()
+	else
+		close(user)
+		opened = FALSE
+		return
 	if (isrobot(user) && user.hud_used)
 		var/mob/living/silicon/robot/robot = user
 		if(robot.shown_robot_modules) //The robot's inventory is open, need to close it first.
@@ -116,6 +123,10 @@
 
 /obj/item/storage/proc/close(mob/user as mob)
 	hide_from(user)
+
+	if(open_icon)
+		set_icon_state(initial(icon_state))
+
 	if(storage_ui)
 		storage_ui.after_close(user)
 

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -18,15 +18,7 @@
 	attack_verb = list("robusted")
 	use_sound = 'sounds/effects/storage/toolbox.ogg'
 	matter = list(MATERIAL_STEEL = 5000)
-
-/obj/item/storage/toolbox/open(mob/user)
-	. = ..()
-	icon_state = "redopen"
-
-/obj/item/storage/toolbox/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "redopen"
 
 /obj/item/storage/toolbox/emergency
 	name = "emergency toolbox"
@@ -48,30 +40,14 @@
 	icon_state = "blue"
 	item_state = "toolbox_blue"
 	startswith = list(/obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/device/scanner/gas, /obj/item/wirecutters)
-
-/obj/item/storage/toolbox/mechanical/open(mob/user)
-	. = ..()
-	icon_state = "blueopen"
-
-/obj/item/storage/toolbox/mechanical/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "blueopen"
 
 /obj/item/storage/toolbox/electrical
 	name = "electrical toolbox"
 	icon_state = "yellow"
 	item_state = "toolbox_yellow"
+	open_icon = "yellowopen"
 	startswith = list(/obj/item/screwdriver, /obj/item/wirecutters, /obj/item/device/t_scanner, /obj/item/crowbar)
-
-/obj/item/storage/toolbox/electrical/open(mob/user)
-	. = ..()
-	icon_state = "yellowopen"
-
-/obj/item/storage/toolbox/electrical/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
 
 /obj/item/storage/toolbox/electrical/Initialize()
 	. = ..()
@@ -90,12 +66,4 @@
 	origin_tech = list(TECH_COMBAT = 1, TECH_ESOTERIC = 1)
 	attack_cooldown = 10
 	startswith = list(/obj/item/clothing/gloves/insulated, /obj/item/screwdriver, /obj/item/wrench, /obj/item/weldingtool, /obj/item/crowbar, /obj/item/wirecutters, /obj/item/device/multitool)
-
-/obj/item/storage/toolbox/syndicate/open(mob/user)
-	. = ..()
-	icon_state = "syndicateopen"
-
-/obj/item/storage/toolbox/syndicate/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "syndicateopen"

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -2,15 +2,7 @@
 	name = "box"
 	desc = "A sleek, sturdy box."
 	icon_state = "box_of_doom"
-
-/obj/item/storage/box/syndie_kit/open(mob/user)
-	. = ..()
-	icon_state = "box_of_doomopen"
-
-/obj/item/storage/box/syndie_kit/close(mob/user)
-	. = ..()
-	icon_state = initial(icon_state)
-	playsound(src, use_sound, 30)
+	open_icon = "box_of_doomopen"
 
 //For uplink kits that provide bulkier items
 /obj/item/storage/backpack/satchel/syndie_kit


### PR DESCRIPTION
## About the Pull Request

This makes sevens code not be fucking shit (I rewrote it from scratch). This also fixes storage code in general a little bit.

## Why It's Good For The Game

Bugs Bad

## Changelog

:cl:
fix: No more missing texture of monkeycube open
fix: storage items now behave properly (clicking on a storage item closes it).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
