### PR TITLE
fixes storage having to be clicked on twice to open if closed using the x

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -107,7 +107,6 @@
 		queue_icon_update()
 	else
 		close(user)
-		opened = FALSE
 		return
 	if (isrobot(user) && user.hud_used)
 		var/mob/living/silicon/robot/robot = user
@@ -122,6 +121,7 @@
 	storage_ui.prepare_ui()
 
 /obj/item/storage/proc/close(mob/user as mob)
+	opened = FALSE
 	hide_from(user)
 
 	if(open_icon)


### PR DESCRIPTION
## About the Pull Request

see title

## Why It's Good For The Game

bug bad

## Changelog

:cl:
fix: storage no longer has to be double clicked to open if closed using the x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
