### PR TITLE
Fixes game not loading the comms config

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -74,6 +74,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		config = new /datum/configuration()
 		config.load("config/config.txt")
 		config.load("config/game_options.txt","game_options")
+		config.load("config/comms.txt", "comms")
 		if (GLOB.using_map?.config_path)
 			config.load(GLOB.using_map.config_path, "using_map")
 		config.load_text("config/motd.txt", "motd")


### PR DESCRIPTION
## About the Pull Request

Makes the game load cross-server communications config on the start.

## Why It's Good For The Game

The part where game loads config files was in a weird place, so I missed it. This fixes it.
