### PR TITLE
Fixes cross-server evacuation report

### DIFF
--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -91,6 +91,8 @@ var/datum/evacuation_controller/evacuation_controller
 		if(!skip_announce)
 			priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_called_message, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60)] minute\s"))
 
+	SSticker.news_report = max(SSticker.news_report, FACILITY_EVACUATED) // TODO: If we ever use more options - move it elsewhere and add more
+
 	return 1
 
 /datum/evacuation_controller/proc/cancel_evacuation()

--- a/code/controllers/evacuation/evacuation_option.dm
+++ b/code/controllers/evacuation/evacuation_option.dm
@@ -7,5 +7,4 @@
 	var/abandon_ship = FALSE
 
 /datum/evacuation_option/proc/execute(mob/user)
-	SSticker.news_report = max(SSticker.news_report, FACILITY_EVACUATED) // TODO: If we ever use more options - move it elsewhere and add more
 	return


### PR DESCRIPTION
## About the Pull Request

Fixes cross-server news report when facility simply evacuates.

## Why It's Good For The Game

Fix

## Changelog

:cl:
fix: Cross-server comms news report on evacuation gets sent properly now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
