### PR TITLE
Renamed 'space bat swarm' to 'bat swarm' - fixes #1347

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/scarybat
-	name = "space bat swarm"
+	name = "bat swarm"
 	desc = "A swarm of cute little blood sucking bats that looks pretty upset."
 	icon = 'icons/mob/simple_animal/bats.dmi'
 	icon_state = "bat"


### PR DESCRIPTION
Fixes #1347

This PR renames the entity previously called 'space bat swarm' to 'bat swarm' in the bat.dm file. 

Changes:

Updated the name attribute in bat.dm to "bat swarm".

I appreciate any feedback or further suggestions on this PR.