### PR TITLE
Ports Tegu dressup verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -312,7 +312,8 @@ var/list/admin_verbs_mod = list(
 	/datum/admins/proc/view_txt_log,
 	/client/proc/game_panel,
 	/client/proc/free_slot_crew,
-	/client/proc/cmd_admin_create_centcom_report
+	/client/proc/cmd_admin_create_centcom_report,
+	/datum/admins/proc/DressUpMob,
 )
 var/list/admin_verbs_mentors = list(
 	/client/proc/cmd_mentor_say,
@@ -942,3 +943,38 @@ var/list/admin_verbs_mentors = list(
 	T.add_spell(new S)
 	SSstatistics.add_field_details("admin_verb","GS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	log_and_message_staff("gave [key_name(T)] the spell [S].")
+
+// Right click panel
+/datum/admins/proc/DressUpMob(mob/M as mob in GLOB.player_list)
+	set category = null
+	set name = "Dressup"
+	set desc = "Changes outfit of a target mob. If it is a ghost - spawns their character first."
+
+	if(!check_rights(R_SPAWN))
+		return
+
+	DressUpMobTarget(M)
+
+/proc/DressUpMobTarget(mob/M)
+	if(!check_rights(R_SPAWN))
+		return
+
+	if(!ishuman(M) && !isghost(M))
+		to_chat(usr, SPAN_DANGER("This can only be used on instances of type /mob/living/carbon/human or /mob/observer/ghost"))
+		return
+
+	var/decl/hierarchy/outfit/outfit = input("Select outfit.", "Select equipment.") as null|anything in outfits()
+	if(!outfit)
+		return
+
+	if(QDELETED(M) || isnull(M))
+		to_chat(usr, SPAN_DANGER("The target mob has been deleted while you were choosing the outfit!"))
+		return
+
+	if(isghost(M))
+		if(!M.client)
+			M = new /mob/living/carbon/human(get_turf(M))
+		else
+			M = M.client.SpawnPrefsCharacter(get_turf(M))
+
+	dressup_human(M, outfit, TRUE)

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -23,17 +23,10 @@
 		href_list["datumrefresh"] = href_list["rename"]
 
 	else if(href_list["dressup"])
-		if(!check_rights(R_VAREDIT))	return
-
-		var/mob/living/carbon/human/H = locate(href_list["dressup"])
-		if(!istype(H))
-			to_chat(usr, "This can only be used on instances of type /mob/living/carbon/human")
-			return
-		var/decl/hierarchy/outfit/outfit = tgui_input_list(usr, "Select outfit.", "Select equipment.", outfits())
-		if(!outfit)
+		if(!check_rights(R_SPAWN))
 			return
 
-		dressup_human(H, outfit, TRUE)
+		DressUpMobTarget(locate(href_list["dressup"]))
 
 	else if(href_list["varnameedit"] && href_list["datumedit"])
 		if(!check_rights(R_VAREDIT))	return

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -685,3 +685,20 @@
 		winset(usr, "mapwindow.status_bar", "is-visible=true")
 	else
 		winset(usr, "mapwindow.status_bar", "is-visible=false")
+
+// Creates the character out of client's preferences
+/client/proc/SpawnPrefsCharacter(turf/T)
+	var/mob/living/carbon/human/new_character = new(T)
+	new_character.lastarea = get_area(T)
+	prefs.copy_to(new_character)
+	new_character.dna.ready_dna(new_character)
+	new_character.dna.b_type = prefs.b_type
+	new_character.sync_organ_dna()
+	if(prefs.disabilities)
+		new_character.dna.SetSEState(GLOB.GLASSESBLOCK,1,0)
+		new_character.disabilities |= NEARSIGHTED
+	new_character.force_update_limbs()
+	new_character.update_eyes()
+	new_character.regenerate_icons()
+	new_character.ckey = ckey
+	return new_character


### PR DESCRIPTION
## About the Pull Request

Ports vlggms/tegustation-bay12/pull/456

- Dressup will now spawn your character in, if used on a ghost.
- Dressup verb is now available via right-click.

## Why It's Good For The Game

- A **very** useful admin tool for events and everything else.
- Accessibility.

## Changelog

:cl:
admin: Dressup can be used on ghosts now. This will spawn in their character from currently selected prefs, if they have one.
admin: Dressup verb is now accessible from right-click menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
