### PR TITLE
Consistent glide size for observers

### DIFF
--- a/code/datums/orbit.dm
+++ b/code/datums/orbit.dm
@@ -59,6 +59,8 @@
 		orbiter.stop_orbit()
 		return
 	orbiter.loc = targetloc
+	if(istype(orbiting, /atom/movable))
+		orbiter.glide_size = AM.glide_size
 	//TODO-LESH-DEL orbiter.update_parallax_contents()
 	orbiter.update_light()
 	lastloc = orbiter.loc


### PR DESCRIPTION
## About the Pull Request

Ports vlggms/tegustation-bay12/pull/473

Glide size of an orbiter is set to the glide size of the atom they are orbiting.

## Why It's Good For The Game

This fixes "jumpy" movement when a ghost is orbiting a moving object/mob.

## Changelog

:cl:
fix: Ghosts will not longer "jump" while orbiting moving objects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
