### PR TITLE
Adds "succumb" verb to humans

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -106,3 +106,22 @@
 		E.status |= ORGAN_DISFIGURED
 	update_body(1)
 	return
+
+/mob/living/carbon/human/verb/succumb()
+	set category = "IC"
+	set name = "Succumb"
+	set desc = "Succumb to your pain and die."
+
+	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
+	if((heart && heart.is_working()) || (getBrainLoss() < 100 && stat != UNCONSCIOUS))
+		to_chat(src, SPAN_WARNING("You can only succumb to your injuries when dying!"))
+		return
+	if(alert("Are you sure you want to succumb?",, "Yes", "No") != "Yes")
+		return
+	// You got fixed while thinking, keep on living!
+	if((heart && heart.is_working()) || (getBrainLoss() < 100 && stat != UNCONSCIOUS))
+		to_chat(src, SPAN_WARNING("You can only succumb to your injuries when dying!"))
+		return
+	to_chat(src, SPAN_NOTICE("You succumb to your injuries and leave the mortal plane."))
+	visible_message(SPAN_DANGER("[src] lets out the final gasp, succumbing to [get_visible_gender() == MALE ? "his" : get_visible_gender() == FEMALE ? "her" : "their"] injuries."))
+	death()

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -527,13 +527,3 @@ meteor_act
 	// distribute the remaining 30% on all limbs equally (including the one already dealt damage)
 	apply_damage(0.3 * b_loss, BRUTE, null, DAM_EXPLODE | DAM_DISPERSED, used_weapon = "Explosive blast")
 	apply_damage(0.3 * f_loss, BURN, null, DAM_EXPLODE | DAM_DISPERSED, used_weapon = "Explosive blast")
-
-/mob/living/carbon/human/verb/succumb()
-	set category = "IC"
-	set name = "Succumb"
-	set desc = "Succumb to your pain, and die."
-
-	var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
-	if(!heart.is_working())
-		death()
-


### PR DESCRIPTION
## About the Pull Request

Ports vlggms/tegustation-bay12/pull/364

- Adds "succumb" verb to IC tab for human mobs.

## Why It's Good For The Game

- Allows people stuck in near-death state to simply die. Sometimes, with Bay med, it takes too long to actually die, despite there being absolutely no chance of you surviving it even if you lie there for 10 minutes. Additionally, many people would already simply ghost in such scenarios, which is less than ideal in my opinion.

## Changelog

:cl:
tweak: Players can now succumb if their heart stops(no pulse), dying on the spot, allowing them to skip the grueling time of observing the black screen as they die for the next 10 minutes.
/:cl: