### PR TITLE
Fixes item pickup ghost effect, removes /obj/effect/temporary

### DIFF
--- a/code/game/objects/auras/personal_shields/personal_shield.dm
+++ b/code/game/objects/auras/personal_shields/personal_shield.dm
@@ -8,7 +8,7 @@
 
 /obj/aura/personal_shield/bullet_act(obj/item/projectile/P, def_zone)
 	user.visible_message(SPAN_WARNING("\The [user]'s [src.name] flashes before \the [P] can hit them!"))
-	new /obj/effect/temporary(get_turf(src), 2 SECONDS,'icons/obj/machines/shielding.dmi',"shield_impact")
+	new /obj/effect/temp_visual/temporary(get_turf(src), 2 SECONDS,'icons/obj/machines/shielding.dmi',"shield_impact")
 	playsound(user,'sounds/effects/basscannon.ogg',35,1)
 	return AURA_FALSE|AURA_CANCEL
 

--- a/code/game/objects/effects/item_pickup_ghost.dm
+++ b/code/game/objects/effects/item_pickup_ghost.dm
@@ -1,13 +1,11 @@
-/obj/effect/temporary/item_pickup_ghost
-	var/lifetime = 0.2 SECONDS
+/obj/effect/temp_visual/temporary/item_pickup_ghost
+	duration = 0.2 SECONDS
 
-/obj/effect/temporary/item_pickup_ghost/Initialize(mapload, obj/item/picked_up)
-	. = ..(mapload, lifetime, picked_up.icon, picked_up.icon_state)
-	pixel_x = picked_up.pixel_x
-	pixel_y = picked_up.pixel_y
-	color = picked_up.color
+/obj/effect/temp_visual/item_pickup_ghost/Initialize(mapload, obj/item/picked_up)
+	. = ..()
+	appearance = picked_up.appearance
 
-/obj/effect/temporary/item_pickup_ghost/proc/animate_towards(atom/target)
+/obj/effect/temp_visual/temporary/item_pickup_ghost/proc/animate_towards(atom/target)
 	var/new_pixel_x = pixel_x + (target.x - src.x) * 32
 	var/new_pixel_y = pixel_y + (target.y - src.y) * 32
-	animate(src, pixel_x = new_pixel_x, pixel_y = new_pixel_y, transform = matrix()*0, time = lifetime)
+	animate(src, pixel_x = new_pixel_x, pixel_y = new_pixel_y, transform = matrix()*0, time = duration)

--- a/code/game/objects/effects/temporary.dm
+++ b/code/game/objects/effects/temporary.dm
@@ -14,6 +14,14 @@
 	. = ..()
 	QDEL_IN(src, duration)
 
+// Used in place of old /obj/effect/temporary where applicable.
+// Do not use it for new stuff, please
+/obj/effect/temp_visual/temporary/Initialize(mapload, new_dur = 5, new_icon = null, new_icon_state = null)
+	duration = new_dur
+	icon = new_icon
+	icon_state = new_icon_state
+	return ..()
+
 /obj/effect/temp_visual/bloodsplatter
 	icon = 'icons/effects/bloodspatter.dmi'
 	duration = 5

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -210,7 +210,7 @@
 	if (!user) return
 	if (anchored)
 		return ..()
-	if (hasorgans(user))
+	if (ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/temp = H.organs_by_name[BP_R_HAND]
 		if (user.hand)
@@ -246,7 +246,7 @@
 
 	if(user.put_in_active_hand(src))
 		if (isturf(old_loc))
-			var/obj/effect/temporary/item_pickup_ghost/ghost = new(old_loc, src)
+			var/obj/effect/temp_visual/temporary/item_pickup_ghost/ghost = new(old_loc, src)
 			ghost.animate_towards(user)
 		if(randpixel)
 			pixel_x = rand(-randpixel, randpixel)

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -679,7 +679,7 @@
 				SPAN_WARNING("\The [src] charges up in preparation for a slide!"),
 				blind_message = SPAN_WARNING("You hear a loud hum and an intense crackling.")
 			)
-			new /obj/effect/temporary(get_step(owner.loc, reverse_direction(owner.dir)), 2 SECONDS, 'icons/effects/effects.dmi',"cyan_sparkles")
+			new /obj/effect/temp_visual/temporary(get_step(owner.loc, reverse_direction(owner.dir)), 2 SECONDS, 'icons/effects/effects.dmi',"cyan_sparkles")
 			owner.setClickCooldown(2 SECONDS)
 			if (do_after(owner, 2 SECONDS, do_flags = (DO_DEFAULT | DO_PUBLIC_PROGRESS | DO_USER_UNIQUE_ACT) & ~DO_USER_CAN_TURN) && slideCheck(TT))
 				owner.visible_message(SPAN_DANGER("Burning hard, \the [owner] thrusts forward!"))

--- a/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
+++ b/code/modules/mob/living/carbon/alien/chorus/buildings/generic.dm
@@ -26,7 +26,7 @@
 		return
 	last_click = world.time
 	var/turf/T = get_turf(src)
-	new /obj/effect/temporary(T, 2, 'icons/effects/effects.dmi', "green_sparkles")
+	new /obj/effect/temp_visual/temporary(T, 2, 'icons/effects/effects.dmi', "green_sparkles")
 	var/list/adj = orange(1,T)
 	for(var/obj/structure/chorus/chor in adj)
 		chor?.chorus_click()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/tunneler.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/tunneler.dm
@@ -145,18 +145,18 @@
 /mob/living/simple_animal/hostile/giant_spider/tunneler/proc/submerge()
 	alpha = 0
 	dig_under_floor(get_turf(src))
-	new /obj/effect/temporary/tunneler_hole(get_turf(src), 1 MINUTE)
+	new /obj/effect/temp_visual/temporary/tunneler_hole(get_turf(src), 1 MINUTE)
 
 // Ditto.
 /mob/living/simple_animal/hostile/giant_spider/tunneler/proc/emerge()
 	alpha = 255
 	dig_under_floor(get_turf(src))
-	new /obj/effect/temporary/tunneler_hole(get_turf(src), 1 MINUTE)
+	new /obj/effect/temp_visual/temporary/tunneler_hole(get_turf(src), 1 MINUTE)
 
 /mob/living/simple_animal/hostile/giant_spider/tunneler/proc/dig_under_floor(turf/T)
 	new /obj/item/ore/glass(T) // This will be rather weird when on station but the alternative is too much work.
 
-/obj/effect/temporary/tunneler_hole
+/obj/effect/temp_visual/temporary/tunneler_hole
 	name = "hole"
 	desc = "A collapsing tunnel hole."
 	icon_state = "tunnel_hole"

--- a/code/modules/shield_generators/shield.dm
+++ b/code/modules/shield_generators/shield.dm
@@ -130,7 +130,7 @@
 
 	damage = round(damage)
 
-	new /obj/effect/temporary(get_turf(src), 2 SECONDS,'icons/obj/machines/shielding.dmi',"shield_impact")
+	new /obj/effect/temp_visual/temporary(get_turf(src), 2 SECONDS,'icons/obj/machines/shielding.dmi',"shield_impact")
 	impact_effect(round(abs(damage * 2)))
 
 	var/list/field_segments = gen.field_segments

--- a/code/modules/species/outsider/starlight.dm
+++ b/code/modules/species/outsider/starlight.dm
@@ -112,4 +112,4 @@
 
 /datum/species/starlight/blueforged/handle_death(mob/living/carbon/human/H)
 	..()
-	new /obj/effect/temporary(get_turf(H),11, 'icons/mob/mob.dmi', "liquify")
+	new /obj/effect/temp_visual/temporary(get_turf(H),11, 'icons/mob/mob.dmi', "liquify")

--- a/code/modules/spells/aoe_turf/exchange_wounds.dm
+++ b/code/modules/spells/aoe_turf/exchange_wounds.dm
@@ -22,12 +22,12 @@
 	..()
 
 /datum/spell/aoe_turf/exchange_wounds/cast(list/targets, mob/living/user)
-	new /obj/effect/temporary(get_turf(user),10,'icons/effects/effects.dmi',"purple_electricity_constant")
+	new /obj/effect/temp_visual/temporary(get_turf(user),10,'icons/effects/effects.dmi',"purple_electricity_constant")
 	for(var/t in targets)
 		for(var/mob/living/L in t)
 			if(L.faction != user.faction)
 				continue
-			new /obj/effect/temporary(get_turf(L),10,'icons/effects/effects.dmi',"green_sparkles")
+			new /obj/effect/temp_visual/temporary(get_turf(L),10,'icons/effects/effects.dmi',"green_sparkles")
 			if(L.getBruteLoss() > 5)
 				L.adjustBruteLoss(-5)
 				user.adjustBruteLoss(2)

--- a/code/modules/spells/hand/burning_grip.dm
+++ b/code/modules/spells/hand/burning_grip.dm
@@ -26,7 +26,7 @@
 	if(H.r_hand)
 		targets += BP_R_HAND
 
-	var/obj/O = new /obj/effect/temporary(get_turf(H),3, 'icons/effects/effects.dmi', "fire_goon")
+	var/obj/O = new /obj/effect/temp_visual/temporary(get_turf(H),3, 'icons/effects/effects.dmi', "fire_goon")
 	O.alpha = 150
 
 	for(var/organ in targets)

--- a/code/modules/spells/hand/slippery_surface.dm
+++ b/code/modules/spells/hand/slippery_surface.dm
@@ -14,7 +14,7 @@
 /datum/spell/hand/slippery_surface/cast_hand(atom/a, mob/user)
 	for(var/turf/simulated/T in view(1,a))
 		T.wet_floor(50)
-		new /obj/effect/temporary(T,3, 'icons/effects/effects.dmi', "sonar_ping")
+		new /obj/effect/temp_visual/temporary(T,3, 'icons/effects/effects.dmi', "sonar_ping")
 	return ..()
 
 /datum/spell/hand/slippery_surface/tower

--- a/code/modules/spells/targeted/_targeted.dm
+++ b/code/modules/spells/targeted/_targeted.dm
@@ -171,5 +171,5 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	target.confused += amt_confused
 	target.stuttering += amt_stuttering
 	if(effect_state)
-		var/obj/o = new /obj/effect/temporary(get_turf(target), effect_duration, 'icons/effects/effects.dmi', effect_state)
+		var/obj/o = new /obj/effect/temp_visual/temporary(get_turf(target), effect_duration, 'icons/effects/effects.dmi', effect_state)
 		o.color = effect_color

--- a/code/modules/spells/targeted/analyze.dm
+++ b/code/modules/spells/targeted/analyze.dm
@@ -15,5 +15,5 @@
 /datum/spell/targeted/analyze/cast(list/targets, mob/user)
 	for(var/a in targets)
 		var/mob/living/carbon/human/H = a
-		new /obj/effect/temporary(get_turf(a),5, 'icons/effects/effects.dmi', "repel_missiles")
+		new /obj/effect/temp_visual/temporary(get_turf(a),5, 'icons/effects/effects.dmi', "repel_missiles")
 		to_chat(user,medical_scan_results(H,1))

--- a/code/modules/spells/targeted/glimpse_of_eternity.dm
+++ b/code/modules/spells/targeted/glimpse_of_eternity.dm
@@ -18,9 +18,9 @@
 		if(L.faction != user.faction) //Worse for non-allies
 			L.eye_blind += 5
 			L.Stun(5)
-			new /obj/effect/temporary(get_turf(L), 5, 'icons/effects/effects.dmi', "electricity_constant")
+			new /obj/effect/temp_visual/temporary(get_turf(L), 5, 'icons/effects/effects.dmi', "electricity_constant")
 		else
 			L.eye_blind += 2
 			L.adjustBruteLoss(-10)
 			L.adjustFireLoss(-10)
-			new /obj/effect/temporary(get_turf(L), 5, 'icons/effects/effects.dmi', "green_sparkles")
+			new /obj/effect/temp_visual/temporary(get_turf(L), 5, 'icons/effects/effects.dmi', "green_sparkles")

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -50,7 +50,7 @@
 			M.mind.transfer_to(trans)
 		else
 			trans.key = M.key
-		new /obj/effect/temporary(get_turf(M), 5, 'icons/effects/effects.dmi', "summoning")
+		new /obj/effect/temp_visual/temporary(get_turf(M), 5, 'icons/effects/effects.dmi', "summoning")
 
 		M.forceMove(trans) //move inside the new dude to hide him.
 		M.status_flags |= GODMODE //don't want him to die or breathe or do ANYTHING

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -171,5 +171,5 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	target.confused += amt_confused
 	target.stuttering += amt_stuttering
 	if(effect_state)
-		var/obj/o = new /obj/effect/temporary(get_turf(target), effect_duration, 'icons/effects/effects.dmi', effect_state)
+		var/obj/o = new /obj/effect/temp_visual/temporary(get_turf(target), effect_duration, 'icons/effects/effects.dmi', effect_state)
 		o.color = effect_color


### PR DESCRIPTION
## About the Pull Request

Ports vlggms/tegustation-bay12/pull/415

Removes now unused /obj/effect/temporary, temporarily replacing it with its equivalent.
This fixes item pickup ghost and other "invisible" effects.

## Why It's Good For The Game

Fix!

## Changelog

:cl:
fix: All effects that were invisible should work now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
