### PR TITLE
Reduce light replacer recharge treshold

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -142,7 +142,7 @@
 
 /obj/item/device/lightreplacer/proc/Charge(mob/user, amount = 1)
 	charge += amount
-	if(charge > 6)
+	if(charge > 0.3)
 		AddUses(1)
 		charge = 0
 


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Minor change to minimal amount of charges necessary to refill one usage of the light replacer.

Change is only applicable for cyborgs as humans can't refill it with energy. Amount refilled from 1 sheet of glass not changed.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

For a robot with the light replacer, refilling it can only be done using a cyborg recharging station or in the case of an engineering robot, using its internal glass sheet reserves, which Janitorial robots have no access to.

Reduced full recharge time from ~13 minutes ( 32 lights in 25 seconds each ) to ~64 seconds ( 32 lights in ~2 seconds each )

## Changelog

:cl:
balance: Reduce light replacer recharge time
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
