### PR TITLE
Fix issue with staffwarn player panel

### DIFF
--- a/code/modules/admin/player_panel/actions/punish.dm
+++ b/code/modules/admin/player_panel/actions/punish.dm
@@ -126,7 +126,7 @@
 		to_chat(user, SPAN_WARNING("You can't set staff warning on admins!"))
 		return
 
-	if(target.client.staffwarn)
+	if(!target.client.staffwarn)
 		if(tgui_alert(user.mob, "Are you sure you want to set staff warn?", "Confirmation", list("Yes","No")) == "Yes")
 			var/reason = tgui_input_text(user, "Staff warn message", "Staff Warn", "Problem Player")
 			if (!reason)


### PR DESCRIPTION
## About the Pull Request

someone forgot not operator

## Why It's Good For The Game

makes staffwarns properly settable/removable from the player panel instead of having to do varedit bullshit to set the staffwarns

## Changelog

:cl:
admin: Fixed staffwarn from player panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
