### PR TITLE
Removes old control room + mapping improvements

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -517,6 +517,8 @@
 /obj/machinery/door/firedoor,
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -642,6 +644,8 @@
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -897,6 +901,8 @@
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -1184,6 +1190,8 @@
 /area/site53/llcz/dclass/med_checkpoint)
 "cJ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2063,12 +2071,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/llcz/dclass/checkpointoverlook)
-"eB" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/recreationhallway)
 "eC" = (
 /obj/machinery/button/crematorium{
 	id_tag = "Reeducation Cremator";
@@ -2217,6 +2219,8 @@
 "eU" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -2446,6 +2450,8 @@
 	name = "Mining Checkpoint Lockdown"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -2736,6 +2742,8 @@
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -2966,6 +2974,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -3379,6 +3389,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -4190,6 +4202,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/button/blast_door{
@@ -5990,6 +6004,8 @@
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -6236,6 +6252,8 @@
 "ok" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -7450,16 +7468,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/site53/llcz/dclass/reeducation)
-"qW" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/site53/lhcz/hallway)
 "qX" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open{
@@ -7706,6 +7714,8 @@
 "rw" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8710,6 +8720,8 @@
 "tY" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9472,6 +9484,8 @@
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/white,
@@ -9629,6 +9643,8 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/camera/network/hcz,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -10303,6 +10319,8 @@
 "xy" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/glass/civilian{
@@ -10366,6 +10384,8 @@
 /area/site53/llcz/dclass/primaryhallway)
 "xH" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -10868,6 +10888,8 @@
 "zd" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11685,8 +11707,7 @@
 	RCon_tag = "Lower Heavy Containment Zone Bypass"
 	},
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
+	d2 = 6;
 	icon_state = "0-6"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -12005,6 +12026,8 @@
 	pixel_y = 32
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/white,
@@ -12803,6 +12826,8 @@
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
@@ -13209,6 +13234,8 @@
 "Fc" = (
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -16150,13 +16177,6 @@
 /obj/item/reagent_containers/glass/beaker/large,
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
-"Mm" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/effect/catwalk_plated/white,
-/turf/simulated/floor,
-/area/site53/llcz/dclass/cells)
 "Mo" = (
 /obj/machinery/camera/network/scp049{
 	dir = 1;
@@ -16657,13 +16677,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/uhcz/scp8containment)
-"NH" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/site53/lhcz/hallway)
 "NI" = (
 /obj/item/device/flashlight/lantern,
 /turf/simulated/floor/exoplanet/grass,
@@ -16891,12 +16904,6 @@
 	},
 /turf/simulated/floor,
 /area/site53/ulcz/scp173)
-"Ok" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/dclass/primaryhallway)
 "Ol" = (
 /obj/effect/floor_decal/sign/or1,
 /obj/effect/floor_decal/industrial/firstaid{
@@ -17215,6 +17222,8 @@
 "Pf" = (
 /obj/effect/catwalk_plated,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -18041,6 +18050,8 @@
 /area/site53/llcz/mining/miningops)
 "Rl" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18339,6 +18350,8 @@
 "RY" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -18503,6 +18516,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
@@ -18910,6 +18925,8 @@
 "Tw" = (
 /obj/machinery/door/airlock/glass/civilian,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/white,
@@ -19165,6 +19182,8 @@
 /area/site53/uhcz/scp8containment)
 "Uh" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/dark,
@@ -19517,6 +19536,8 @@
 "Vg" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -19913,6 +19934,8 @@
 "Wd" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -20268,6 +20291,8 @@
 "WZ" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/hcz,
@@ -20300,18 +20325,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/site53/uhcz/scp8containment)
-"Xd" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor,
-/area/site53/lhcz/hallway)
 "Xe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -29841,7 +29854,7 @@ Bb
 uf
 uf
 eZ
-Ok
+sj
 uf
 eZ
 uf
@@ -30869,7 +30882,7 @@ yA
 AN
 sM
 tV
-Mm
+yx
 zF
 vK
 sM
@@ -31126,7 +31139,7 @@ Du
 sM
 sM
 ws
-Mm
+yx
 zF
 ws
 sM
@@ -37546,7 +37559,7 @@ wD
 jy
 gG
 fr
-eB
+iR
 uL
 jF
 dg
@@ -66272,7 +66285,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -66529,7 +66542,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -67300,7 +67313,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -67814,7 +67827,7 @@ gq
 qn
 pp
 Px
-NH
+qJ
 mK
 qr
 qn
@@ -68071,7 +68084,7 @@ gq
 qn
 mK
 BI
-NH
+qJ
 BI
 mK
 qn
@@ -68328,7 +68341,7 @@ gq
 qn
 BI
 BI
-NH
+qJ
 BI
 BI
 bb
@@ -68585,7 +68598,7 @@ gq
 qn
 Wr
 BI
-NH
+qJ
 BI
 Yr
 qn
@@ -68842,7 +68855,7 @@ gq
 qn
 pp
 mK
-NH
+qJ
 mK
 qr
 qn
@@ -69356,7 +69369,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -69870,7 +69883,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -70127,7 +70140,7 @@ gq
 gq
 gq
 qn
-qW
+qL
 qn
 gq
 gq
@@ -70384,7 +70397,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -70641,7 +70654,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -70898,7 +70911,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -71143,7 +71156,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -71155,7 +71168,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -71400,7 +71413,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -71412,7 +71425,7 @@ gq
 gq
 gq
 qn
-qW
+qL
 qn
 gq
 gq
@@ -71669,7 +71682,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -72171,7 +72184,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -72183,7 +72196,7 @@ gq
 gq
 gq
 qn
-NH
+qJ
 qn
 gq
 gq
@@ -72685,7 +72698,7 @@ gq
 qn
 pp
 Px
-NH
+qJ
 mK
 qr
 qn
@@ -72697,7 +72710,7 @@ gq
 qn
 pp
 oQ
-NH
+qJ
 mK
 qr
 qn
@@ -72942,7 +72955,7 @@ qn
 qn
 Mq
 BI
-NH
+qJ
 BI
 mK
 qn
@@ -72954,7 +72967,7 @@ qn
 qn
 mK
 BI
-NH
+qJ
 BI
 OL
 qn
@@ -73199,7 +73212,7 @@ qo
 od
 td
 qo
-Xd
+nK
 td
 td
 WP

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -14,9 +14,13 @@
 	icon_state = "pipe-c"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating,
@@ -173,8 +177,7 @@
 "av" = (
 /obj/structure/bed/chair,
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/checkpoint)
@@ -966,6 +969,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -986,6 +991,8 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -1097,16 +1104,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/hallways)
-"cw" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/llcz/hallways)
 "cx" = (
 /obj/structure/closet/secure_closet/guard/specialistshotgun,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1211,8 +1208,7 @@
 /area/site53/llcz/dclass/entrance_checkpoint)
 "cM" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -1924,8 +1920,7 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -2803,8 +2798,7 @@
 "gi" = (
 /obj/machinery/microwave,
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
@@ -2913,8 +2907,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/structure/table/standard,
 /obj/machinery/button/blast_door{
@@ -2979,6 +2972,8 @@
 /area/site53/llcz/dclass/kitchenbotanybubble)
 "gH" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -3735,8 +3730,7 @@
 /area/site53/llcz/dclass/checkpoint)
 "iy" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -4047,8 +4041,7 @@
 /area/site53/llcz/hallways)
 "jh" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -4308,8 +4301,7 @@
 /area/site53/llcz/dclass/kitchen)
 "jM" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/structure/hygiene/sink{
 	dir = 4;
@@ -4412,8 +4404,7 @@
 /area/site53/llcz/dclass/checkpoint)
 "jY" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4493,8 +4484,7 @@
 /area/site53/llcz/dclass/luxurylibrary)
 "kh" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/structure/table/standard,
 /turf/simulated/floor/lino,
@@ -7579,6 +7569,8 @@
 /area/site53/llcz/hallways)
 "ri" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/catwalk_plated/dark,
@@ -7589,6 +7581,8 @@
 	dir = 8
 	},
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -7692,6 +7686,8 @@
 /area/site53/lowertram/archive)
 "ru" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/wood/walnut,
@@ -10568,6 +10564,8 @@
 /area/site53/llcz/dclass/kitchenbotanybubble)
 "yj" = (
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/effect/catwalk_plated/dark,
@@ -11975,8 +11973,7 @@
 /area/site53/llcz/dclass/med_checkpointoverlook)
 "BY" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "Shower checkpoint windows";
@@ -13837,8 +13834,7 @@
 /area/site53/lhcz/scp049containment)
 "GU" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/reeducation)
@@ -14377,8 +14373,7 @@
 "Ie" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 12
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/dclass/assignment)
@@ -17873,6 +17868,8 @@
 /area/site53/lhcz/scp049containment)
 "QN" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/catwalk_plated/dark,
@@ -38022,7 +38019,7 @@ Eh
 ua
 cQ
 cc
-cw
+fC
 cc
 cQ
 lG

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -2286,6 +2286,8 @@
 	name_tag = "#LIGHT CONTAINMENT ZONE SENSOR#"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -4670,6 +4672,8 @@
 /area/site53/upper_surface/serverfarmtunnel)
 "anP" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -12699,6 +12703,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -15404,12 +15410,6 @@
 /obj/effect/catwalk_plated/white,
 /turf/simulated/floor,
 /area/site53/ulcz/hallways)
-"aUi" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/llcz/entrance_checkpoint)
 "aUj" = (
 /obj/structure/table/steel_reinforced,
 /turf/simulated/floor/tiled/techmaint,
@@ -15422,6 +15422,8 @@
 /area/shuttle/escape_pod)
 "aUn" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -15696,9 +15698,13 @@
 /area/site53/lhcz/hczguardgear)
 "aVy" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -15708,6 +15714,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -16406,7 +16414,7 @@
 	icon_state = "bordercolor"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -16591,6 +16599,8 @@
 	name = "UHCZ Eastern Lockdown"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -17401,6 +17411,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -17412,6 +17424,8 @@
 	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL2"))
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -17424,6 +17438,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -17431,6 +17447,8 @@
 "baW" = (
 /obj/effect/floor_decal/industrial/outline/orange,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -18136,6 +18154,8 @@
 /area/site53/ulcz/hallways)
 "bdg" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -19533,6 +19553,8 @@
 "bip" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -19585,11 +19607,7 @@
 /obj/machinery/power/apc/hyper{
 	dir = 4
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/site53/lhcz/hczguardgear)
 "bix" = (
@@ -19690,6 +19708,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -20120,6 +20140,8 @@
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -20265,6 +20287,8 @@
 "bpz" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -20680,6 +20704,8 @@
 	name = "UHCZ Eastern Lockdown"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -20706,6 +20732,8 @@
 	icon_state = "bulb1"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -21037,12 +21065,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/scp263research)
-"cjx" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
 "cjG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21248,7 +21270,7 @@
 /area/site53/surface/bunker)
 "cvC" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -21507,6 +21529,8 @@
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -21693,16 +21717,11 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/uhcz/hallways)
-"cWh" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uhcz/hallways)
 "cWo" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
@@ -22024,6 +22043,8 @@
 	})
 "dpC" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -22035,9 +22056,13 @@
 /area/site53/uhcz/scp106observ)
 "drT" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -22402,6 +22427,8 @@
 /area/site53/lowertrams/brownline)
 "dMS" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -22716,6 +22743,8 @@
 	pixel_x = -7
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -22795,11 +22824,13 @@
 "eoN" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -23088,6 +23119,8 @@
 	name = "UHCZ Eastern Shutter"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -23131,6 +23164,8 @@
 "eJY" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -23926,6 +23961,8 @@
 "fFD" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -24060,11 +24097,7 @@
 /area/site53/lowertrams/hub)
 "fON" = (
 /obj/machinery/power/smes/buildable/max_cap_in_out,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -24195,6 +24228,8 @@
 /area/site53/ulcz/humanoidcontainment)
 "fSL" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -24216,6 +24251,8 @@
 "fTQ" = (
 /obj/machinery/light,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -24417,9 +24454,13 @@
 "ggM" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -24526,6 +24567,8 @@
 /area/site53/lowertrams/hub)
 "gkq" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/highsecurity{
@@ -24986,6 +25029,8 @@
 	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -25248,6 +25293,8 @@
 /area/site53/lowertrams/hub)
 "hbx" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -25322,6 +25369,8 @@
 /area/site53/llcz/entrance_checkpoint)
 "hhj" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel_grid,
@@ -25360,6 +25409,8 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/bluegrid,
@@ -25398,6 +25449,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -25429,6 +25482,8 @@
 	req_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -25663,6 +25718,8 @@
 /area/site53/llcz/scp066)
 "hzA" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled,
@@ -25824,11 +25881,7 @@
 /area/site53/uhcz/scp096)
 "hEa" = (
 /obj/machinery/power/smes/buildable/max_cap_in_out,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/bluegrid,
 /area/site53/science/aiccore)
 "hEk" = (
@@ -26368,12 +26421,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"ieh" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/hallways)
 "ieo" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
@@ -26402,6 +26449,8 @@
 /area/site53/uhcz/scp096)
 "ihv" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
@@ -26469,7 +26518,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -26512,6 +26561,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -26603,19 +26654,6 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
-"iqc" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
-"iql" = (
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/monotile/white,
-/area/site53/ulcz/office)
 "iqN" = (
 /obj/effect/floor_decal/industrial/hatch/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -26797,12 +26835,6 @@
 /obj/item/device/radio,
 /turf/simulated/floor/wood,
 /area/site53/ulcz/humanoidcontainment)
-"iCG" = (
-/obj/structure/cable/green{
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/site53/lhcz/hczguardgear)
 "iCX" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp096)
@@ -26869,11 +26901,7 @@
 /area/site53/uhcz/scp106containment)
 "iJi" = (
 /obj/machinery/power/smes/buildable/max_cap_in_out,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -26928,11 +26956,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106containment)
 "iNh" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -27557,6 +27581,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -27648,7 +27674,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -27713,9 +27739,13 @@
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -27813,11 +27843,7 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/upper_surface/serverfarmcontrol)
 "jJj" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -28297,6 +28323,8 @@
 	req_access = list("ACCESS_SECURITY_LEVEL3")
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -28379,6 +28407,8 @@
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
@@ -28711,14 +28741,6 @@
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/science/aiccore)
-"kJB" = (
-/obj/effect/catwalk_plated/dark,
-/obj/machinery/door/airlock/highsecurity,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "kKa" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/structure/cable{
@@ -28818,13 +28840,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/reswing/robotics)
-"kQL" = (
-/obj/effect/catwalk_plated/white,
-/obj/structure/cable/green{
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/site53/ulcz/hallways)
 "kRC" = (
 /obj/structure/closet,
 /obj/item/device/tape/random,
@@ -28917,9 +28932,13 @@
 /area/site53/llcz/entrance_checkpoint)
 "kVZ" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor,
@@ -28996,12 +29015,6 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
-"lcb" = (
-/obj/structure/cable/green{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/uhcz/scp096)
 "lcy" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "UHCZ Checkpoint Gate 2";
@@ -29251,6 +29264,8 @@
 /area/site53/surface/bunker)
 "lus" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled,
@@ -30231,6 +30246,8 @@
 /area/site53/ulcz/humanoidcontainment)
 "mrP" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
@@ -30918,6 +30935,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -31168,6 +31187,8 @@
 "nqc" = (
 /obj/effect/catwalk_plated/dark,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -31368,6 +31389,8 @@
 /area/site53/llcz/scp263research)
 "nAb" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -31699,6 +31722,8 @@
 /area/site53/uhcz/securitypost)
 "nRf" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/light{
@@ -32030,6 +32055,8 @@
 /area/site53/lowertrams/escape)
 "oni" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
@@ -32281,6 +32308,8 @@
 	req_access = list(list("ACCESS_SECURITY_LEVEL3","ACCESS_SCIENCE_LEVEL3"))
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -32608,6 +32637,8 @@
 /area/site53/uhcz/scp096)
 "oSH" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /turf/simulated/floor,
@@ -32622,6 +32653,8 @@
 /area/site53/llcz/checkequip)
 "oUj" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
@@ -33129,6 +33162,8 @@
 	},
 /obj/effect/catwalk_plated/white,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -33204,6 +33239,8 @@
 	pixel_x = -7
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -33236,6 +33273,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -33324,6 +33363,8 @@
 	dir = 8
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -33505,6 +33546,8 @@
 /area/site53/uhcz/scp106containment)
 "qbX" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
@@ -33819,7 +33862,7 @@
 /area/site53/uhcz/commanderoffice)
 "quy" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -34023,13 +34066,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor/reinforced,
 /area/site53/uhcz/generalpurpose3)
-"qJM" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "qKl" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -34126,6 +34162,8 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -34156,7 +34194,7 @@
 /area/site53/llcz/dclass/armory)
 "qSH" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -34443,6 +34481,8 @@
 /area/site53/uhcz/securitypost)
 "reW" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -34758,17 +34798,6 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/ulcz/hallways)
-"rwu" = (
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
-	},
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "rxJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -35075,13 +35104,11 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uhcz/securitypost)
 "rPM" = (
@@ -35507,6 +35534,8 @@
 	name = "UHCZ Checkpoint Access"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -35627,6 +35656,8 @@
 "suY" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -36220,6 +36251,8 @@
 	dir = 10
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -36340,6 +36373,8 @@
 /area/site53/engineering/containment_engineer)
 "tmC" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -36827,17 +36862,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/surface/bunker)
-"tQF" = (
-/obj/effect/catwalk_plated/dark,
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor,
-/area/site53/uhcz/hallways)
 "tRU" = (
 /obj/structure/table/standard,
 /obj/item/stamp/cmo{
@@ -37087,6 +37111,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -37798,6 +37824,8 @@
 	dir = 9
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -37881,6 +37909,8 @@
 "vkJ" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
@@ -38008,6 +38038,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
@@ -38146,6 +38178,8 @@
 /area/site53/ulcz/scp2427_3)
 "vwK" = (
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -38160,6 +38194,8 @@
 /area/site53/reswing/xenobiology)
 "vxq" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor,
@@ -39580,6 +39616,8 @@
 /area/site53/llcz/entrance_checkpoint)
 "wVj" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -39602,6 +39640,8 @@
 	name = "Office"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -39732,6 +39772,8 @@
 /area/site53/surface/bunker)
 "xeE" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -39850,6 +39892,8 @@
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile/white,
@@ -39922,6 +39966,8 @@
 /area/site53/llcz/entrance_checkpoint)
 "xoe" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techmaint,
@@ -40205,7 +40251,7 @@
 /area/site53/ulcz/scp2427_3)
 "xEi" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -40398,6 +40444,8 @@
 	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -40622,6 +40670,8 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -40648,9 +40698,13 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
@@ -40717,6 +40771,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /obj/machinery/hologram/holopad,
@@ -53495,7 +53551,7 @@ aWJ
 aGM
 aGM
 frk
-ieh
+aWJ
 pSE
 aGM
 aWJ
@@ -54995,8 +55051,8 @@ vXz
 dDl
 dDl
 pCH
-kQL
-kQL
+afp
+afp
 aPq
 aPp
 aPp
@@ -59101,11 +59157,11 @@ aLd
 aLd
 aLd
 rka
-iql
-iql
-iql
+aMj
+aMj
+aMj
 wVr
-cjx
+tNo
 hyd
 aGM
 aVS
@@ -59127,12 +59183,12 @@ vSL
 uJG
 hcV
 jOV
-aUi
+qhP
 jOV
 jOV
 vCX
 jOV
-aUi
+qhP
 aVb
 jOV
 vCX
@@ -80677,12 +80733,12 @@ rkv
 obI
 fSL
 fFD
-iqc
-iqc
+akt
+akt
 ggM
-iqc
-iqc
-iqc
+akt
+akt
+akt
 aYw
 hbx
 bPM
@@ -80936,7 +80992,7 @@ jJj
 bIm
 xKh
 ajR
-qJM
+ajT
 ajR
 aBA
 aBT
@@ -81193,7 +81249,7 @@ aKM
 bIm
 aBA
 fEW
-qJM
+ajT
 fEW
 aBA
 aBo
@@ -81450,7 +81506,7 @@ aKM
 bIm
 aBo
 aBo
-kJB
+ake
 aBo
 aBo
 aBo
@@ -81491,7 +81547,7 @@ pOk
 gID
 rrU
 quy
-iCG
+qjN
 rrU
 rrU
 gWM
@@ -81707,7 +81763,7 @@ aKM
 bIm
 azA
 aBo
-qJM
+ajT
 aBo
 uce
 uce
@@ -82478,14 +82534,14 @@ azA
 azA
 azA
 aBo
-qJM
+ajT
 aBo
 aBo
 aBo
 aBo
 aBo
 aBo
-rwu
+wpa
 aBo
 azA
 ass
@@ -82735,7 +82791,7 @@ azA
 azA
 azA
 aBo
-qJM
+ajT
 aBo
 azA
 azA
@@ -82992,14 +83048,14 @@ aBo
 aBo
 aBo
 aBo
-tQF
+akb
 aBo
 azA
 azA
 azA
 azA
 aBo
-qJM
+ajT
 aBo
 azA
 azA
@@ -83256,7 +83312,7 @@ azA
 azA
 azA
 aBo
-qJM
+ajT
 aBo
 azA
 azA
@@ -83513,7 +83569,7 @@ azA
 azA
 azA
 aBo
-rwu
+wpa
 aBo
 azA
 azA
@@ -83770,7 +83826,7 @@ azA
 azA
 azA
 aBo
-qJM
+ajT
 aBo
 azA
 azA
@@ -84027,7 +84083,7 @@ azA
 azA
 azA
 aBo
-qJM
+ajT
 aBo
 azA
 azA
@@ -84284,7 +84340,7 @@ azA
 aBo
 aBo
 aBo
-kJB
+ake
 aBo
 aBo
 aBo
@@ -84541,7 +84597,7 @@ aBo
 aBo
 aBA
 aBA
-qJM
+ajT
 xMB
 aBA
 aBo
@@ -84798,7 +84854,7 @@ aip
 aBo
 aYC
 ajR
-qJM
+ajT
 ajR
 sTF
 aBo
@@ -92546,7 +92602,7 @@ azA
 aBo
 pFN
 cXy
-cWh
+bct
 bas
 aBA
 aBo
@@ -92803,7 +92859,7 @@ aBo
 aBo
 lQU
 bas
-cWh
+bct
 bas
 eFA
 aBo
@@ -95373,7 +95429,7 @@ vPv
 ajS
 uvn
 tXn
-lcb
+udQ
 pNQ
 bDp
 bdi

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -1315,6 +1315,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/plating,
@@ -1324,7 +1325,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/lowertrams/hub)
 "aeB" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/space)
 "aeD" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -1621,6 +1624,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/emitter/gyrotron/anchored{
@@ -3054,6 +3058,7 @@
 "ajI" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable/preset/admin,
@@ -4438,6 +4443,7 @@
 /obj/structure/dispenser,
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -5720,8 +5726,7 @@
 /area/site53/science/aicobservation)
 "aqD" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_x = -11
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp106observ)
@@ -6040,8 +6045,7 @@
 /area/site53/uhcz/scp106maintup)
 "arj" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6277,8 +6281,7 @@
 /area/site53/engineering/auxstorage)
 "arI" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
@@ -7835,8 +7838,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
@@ -8187,6 +8189,7 @@
 	dir = 4
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -8367,6 +8370,7 @@
 "axb" = (
 /obj/machinery/power/smes/batteryrack,
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -8539,6 +8543,7 @@
 	dir = 6
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -9428,6 +9433,7 @@
 "aAb" = (
 /obj/machinery/power/smes/buildable/preset/on_full,
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
@@ -9443,6 +9449,7 @@
 "aAe" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
@@ -10745,8 +10752,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 8;
@@ -12892,8 +12898,7 @@
 /area/site53/uhcz/scp247observation)
 "aLE" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/hub)
@@ -14277,8 +14282,7 @@
 /area/site53/lowertrams/escape)
 "aPN" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_x = -11
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/mono,
 /obj/structure/bed/chair,
@@ -14294,8 +14298,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	pixel_x = -11
+	dir = 8
 	},
 /obj/effect/floor_decal/corner/green/mono,
 /turf/simulated/floor/tiled/monotile,
@@ -14777,6 +14780,7 @@
 	icon_state = "0-4"
 	},
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -15069,7 +15073,9 @@
 /turf/simulated/floor,
 /area/site53/surface/explorers/surrounding)
 "aSK" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/surface/explorers/surrounding)
 "aSL" = (
 /obj/machinery/door/airlock/hatch/maintenance{
@@ -16488,8 +16494,7 @@
 /area/site53/lowertrams/hub)
 "aYl" = (
 /obj/machinery/light{
-	dir = 8;
-	pixel_x = -11
+	dir = 8
 	},
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/green/mono,
@@ -18246,6 +18251,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/structure/closet/l3closet/janitor,
@@ -20160,8 +20166,7 @@
 "bkw" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/entrance_checkpoint)
@@ -21132,6 +21137,8 @@
 	icon_state = "1-2"
 	},
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -22173,6 +22180,8 @@
 /area/site53/ulcz/humanoidcontainment)
 "dBg" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
@@ -23062,6 +23071,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/brown/mono,
@@ -25494,6 +25505,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -26079,18 +26092,6 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/chapel)
-"hTc" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -11
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/site53/science/aiccore)
 "hTe" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white,
@@ -29526,8 +29527,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/cable{
@@ -30396,6 +30396,7 @@
 	},
 /obj/effect/floor_decal/corner/red/mono,
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -30527,6 +30528,8 @@
 "mEO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -31414,8 +31417,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/securitypost)
@@ -32015,6 +32017,7 @@
 	dir = 1
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/structure/catwalk,
@@ -33704,6 +33707,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/brown/mono,
@@ -35028,8 +35033,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	pixel_x = -11
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -35469,6 +35473,7 @@
 	dir = 10
 	},
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
@@ -36288,8 +36293,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /obj/machinery/camera/network/hcz{
 	dir = 1
@@ -36947,8 +36951,7 @@
 /area/site53/reswing/xenobiology)
 "uaW" = (
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp457containment)
@@ -39906,7 +39909,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/engineering/containment_engineer)
 "xna" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/uhcz/scp247containment)
 "xnq" = (
 /obj/machinery/door/airlock/glass/security{
@@ -40099,8 +40104,7 @@
 	name = "LCZ Junior Guard"
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/border{
 	dir = 4
@@ -40539,8 +40543,7 @@
 	req_access = list("ACCESS_ENGINEERING_LEVEL2")
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/storage)
@@ -40669,8 +40672,7 @@
 	dir = 6
 	},
 /obj/machinery/light{
-	dir = 4;
-	pixel_x = 11
+	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/engineering/primaryhallway)
@@ -70595,7 +70597,7 @@ afd
 nHl
 wDh
 wDh
-hTc
+kCa
 wDh
 wDh
 wDh

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -40127,8 +40127,8 @@ bZ
 cg
 ux
 ux
-rm
-rm
+xP
+xP
 mk
 Mx
 UI

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -3,10 +3,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /turf/unsimulated/mineral,
 /area/site53/uez/bridge)
-"ab" = (
-/obj/structure/stairs/north,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
 "ac" = (
 /obj/machinery/light{
 	dir = 1;
@@ -63,49 +59,14 @@
 /turf/simulated/open,
 /area/site53/uez/bridge)
 "am" = (
-/obj/machinery/light,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
-"an" = (
-/obj/machinery/power/apc/hyper{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
-"ao" = (
-/obj/machinery/door/airlock/command{
-	name = "Main Control Room";
-	req_access = list("ACCESS_ADMIN_LEVEL1")
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
-"ap" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/obj/machinery/light/small,
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/mcrsubstation)
 "aq" = (
 /obj/effect/floor_decal/industrial/loading{
 	dir = 4
@@ -216,8 +177,7 @@
 "aE" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 11
+	icon_state = "tube1"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -1069,9 +1029,6 @@
 	icon_state = "0-10"
 	},
 /turf/simulated/floor/plating,
-/area/site53/maintenance/surfaceeast)
-"cq" = (
-/turf/unsimulated/mineral,
 /area/site53/maintenance/surfaceeast)
 "cr" = (
 /obj/structure/table/reinforced,
@@ -2424,10 +2381,6 @@
 /obj/item/storage/box/cups,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
-"gd" = (
-/obj/structure/disposalpipe/down,
-/turf/unsimulated/mineral,
-/area/space)
 "ge" = (
 /obj/machinery/door/airlock/medical{
 	name = "Surgical Ward";
@@ -2546,13 +2499,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/maintenance/surfacewest)
-"gA" = (
-/obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/mcrsubstation)
 "gB" = (
 /obj/structure/ladder/up,
 /turf/simulated/floor/tiled/techfloor,
@@ -2813,8 +2759,9 @@
 	dir = 6
 	},
 /obj/machinery/power/apc{
-	dir = 4;
-	name = "west bump"
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /obj/structure/cable/green{
 	d2 = 8;
@@ -3311,15 +3258,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/entrancezone/hallway)
-"iJ" = (
-/obj/machinery/door/airlock/engineering,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/mcrsubstation)
 "iK" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -3429,29 +3367,6 @@
 /obj/item/paper_bin,
 /turf/simulated/floor/wood/walnut,
 /area/site53/medical/mentalhealth/office)
-"iZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/mcrsubstation)
-"ja" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 16;
-	d2 = 0;
-	icon_state = "16-0"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/mcrsubstation)
 "jb" = (
 /obj/machinery/light/spot{
 	dir = 8;
@@ -5572,7 +5487,9 @@
 /turf/simulated/floor/wood/walnut,
 /area/site53/surface/surface)
 "rm" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/surface/surface)
 "ro" = (
 /obj/machinery/light,
@@ -6027,6 +5944,22 @@
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/titanium,
 /area/site53/maintenance/surfacewest)
+"tC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/railing/mapped{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/upper_surface/maincontrolroomstairs)
 "tD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6668,6 +6601,11 @@
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/surface/surface)
+"xP" = (
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
+/area/space)
 "yg" = (
 /obj/effect/floor_decal/corner/purple/mono,
 /obj/machinery/light{
@@ -6747,7 +6685,9 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/equipstorage)
 "yE" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/medical/surgery/hall)
 "yG" = (
 /obj/structure/cable/green{
@@ -6980,7 +6920,9 @@
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/infirmary)
 "Ae" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/medical/mentalhealth/isolation)
 "Ah" = (
 /obj/machinery/door/airlock/glass/civilian{
@@ -7580,6 +7522,14 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/exoplanet/grass,
 /area/site53/surface/surface)
+"FR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/mcrsubstation)
 "Ga" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/techfloor,
@@ -7836,8 +7786,9 @@
 /obj/effect/paint_stripe/paleblue,
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/power/apc{
-	dir = 4;
-	name = "west bump"
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7865,6 +7816,13 @@
 	},
 /turf/simulated/floor/wood/walnut,
 /area/site53/lowertrams/restaurantkitchenarea)
+"It" = (
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/upper_surface/maincontrolroomstairs)
 "Iy" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -7942,14 +7900,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op1)
-"Jy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/site53/uez/mcrsubstation)
 "JD" = (
 /obj/machinery/light{
 	dir = 4
@@ -8358,9 +8308,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -8487,7 +8434,9 @@
 /area/site53/medical/equipstorage)
 "Qa" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/surface/surface)
 "Qe" = (
 /turf/simulated/wall/wood,
@@ -8572,6 +8521,15 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/surgery/op1)
+"QG" = (
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/mcrsubstation)
 "QQ" = (
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/light/small{
@@ -9071,7 +9029,9 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/medical/isolation)
 "Vz" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/medical/infirmary)
 "VA" = (
 /obj/structure/table/woodentable/ebony,
@@ -9313,6 +9273,12 @@
 	},
 /turf/simulated/floor/carpet/orange,
 /area/site53/medical/mentalhealth/office)
+"XZ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/site53/uez/mcrsubstation)
 "Yh" = (
 /obj/machinery/floodlight{
 	anchored = 1;
@@ -37107,7 +37073,7 @@ dA
 dA
 dA
 bk
-EA
+gm
 gm
 gm
 dh
@@ -37364,7 +37330,7 @@ dA
 dA
 dA
 bk
-bk
+EA
 gm
 gm
 dh
@@ -38135,11 +38101,11 @@ Ra
 Ra
 Ra
 cQ
-aN
-aN
-aN
-aR
-aN
+bk
+gm
+gm
+Gg
+EA
 bk
 dA
 dA
@@ -38392,10 +38358,10 @@ bk
 bk
 bk
 bk
-aN
-ab
-aj
-am
+bk
+gm
+gm
+di
 aN
 pG
 pG
@@ -38627,32 +38593,32 @@ dA
 Ce
 dw
 Ce
-oS
-oS
-oS
-oS
-oS
-oS
-oS
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 tb
 Gg
 bk
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-aN
-aN
-aN
-an
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+xP
+bk
+gm
+gm
+Gg
 aN
 aA
 cX
@@ -38884,20 +38850,20 @@ Ce
 Ce
 dw
 Ce
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 tb
 di
 bk
-dA
-dA
-dA
+xP
+xP
+xP
 hp
 hp
 hp
@@ -38905,11 +38871,11 @@ hp
 hp
 hp
 hp
-dA
+xP
 qL
 qL
-aN
-ao
+qL
+aR
 aN
 aB
 cY
@@ -39141,20 +39107,20 @@ bq
 GO
 XO
 Ce
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 tb
 Gg
 bk
-dA
-dA
-dA
+xP
+xP
+xP
 hp
 aI
 fa
@@ -39162,7 +39128,7 @@ fa
 fa
 fa
 hp
-dA
+xP
 qL
 aI
 tO
@@ -39398,14 +39364,14 @@ Ce
 Ce
 Ce
 Ce
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 XJ
 dp
 hp
@@ -39423,8 +39389,8 @@ pu
 qL
 fa
 tO
-uV
-aj
+tC
+It
 au
 pG
 lL
@@ -39650,19 +39616,19 @@ ed
 cp
 ES
 MX
-oS
-oS
-oS
-oS
-oS
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 XJ
 dq
 dD
@@ -39912,14 +39878,14 @@ mk
 Od
 mk
 mk
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 XJ
 dr
 dD
@@ -40161,22 +40127,22 @@ bZ
 cg
 ux
 ux
-cq
-cq
+rm
+rm
 mk
 Mx
 UI
 UI
 qA
 mk
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 XJ
 dr
 dD
@@ -40426,14 +40392,14 @@ IG
 Vn
 XD
 mk
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 XJ
 dC
 dD
@@ -40447,7 +40413,7 @@ fa
 fa
 fa
 hp
-dA
+rm
 qL
 aI
 tO
@@ -40683,14 +40649,14 @@ oq
 Gv
 vn
 mk
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 db
 dD
 dD
@@ -40704,11 +40670,11 @@ hp
 hp
 hp
 hp
-dA
+rm
 qL
 qL
-aN
-ao
+qL
+aV
 aN
 cj
 gu
@@ -40940,14 +40906,14 @@ Go
 QT
 Az
 mk
-oS
 rm
 rm
 rm
 rm
 rm
 rm
-oS
+rm
+rm
 XJ
 dE
 dD
@@ -40955,17 +40921,17 @@ dD
 eP
 hp
 hp
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-aN
-aN
-aN
-ap
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+fF
+gq
+gq
+hr
 aN
 aA
 gv
@@ -41197,14 +41163,14 @@ wJ
 xs
 BY
 mk
-oS
-oS
-oS
-oS
 rm
 rm
 rm
-oS
+rm
+rm
+rm
+rm
+rm
 XJ
 hp
 hp
@@ -41212,16 +41178,16 @@ hp
 hp
 hp
 hp
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-aN
-ab
-aj
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+fF
+gq
+gq
 am
 aN
 pG
@@ -41461,28 +41427,28 @@ HG
 rm
 rm
 rm
-oS
-oS
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-aN
-aN
-aN
-aV
-aN
-gd
-dA
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+fF
+gB
+gq
+hr
+gq
+gq
+fF
 dA
 dA
 dA
@@ -41719,27 +41685,27 @@ rm
 rm
 rm
 rm
-oS
-oS
-oS
-oS
-oS
-oS
-oS
-oS
-oS
-oS
-oS
-oS
-dA
-dA
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 fF
+XZ
 gq
-gA
 hr
+gq
+gq
 fF
-dA
-dA
 dA
 dA
 dA
@@ -41987,16 +41953,16 @@ rm
 rm
 rm
 rm
-oS
-dA
-dA
+rm
+rm
+rm
 fF
 gq
 gq
-hr
+Im
+FR
+QG
 fF
-dA
-dA
 dA
 dA
 dA
@@ -42244,16 +42210,16 @@ rm
 rm
 rm
 rm
-oS
-dA
-dA
+rm
+rm
+rm
 fF
 fF
 fF
-iJ
 fF
-dA
-dA
+fF
+fF
+fF
 dA
 dA
 dA
@@ -42501,15 +42467,15 @@ rm
 rm
 rm
 rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
-dA
-dA
-dA
-dA
-fF
-hr
-fF
-dA
 dA
 dA
 dA
@@ -42758,16 +42724,16 @@ rm
 rm
 rm
 rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 dA
-fF
-fF
-fF
-fF
-iJ
-fF
-fF
-fF
 dA
 dA
 dA
@@ -43015,16 +42981,16 @@ rm
 rm
 rm
 rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 dA
-fF
-gq
-gq
-gA
-Im
-iZ
-Jy
-fF
 dA
 dA
 dA
@@ -43267,21 +43233,21 @@ rm
 rm
 rm
 rm
-oS
-oS
-oS
-oS
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 dA
-fF
-gq
-gq
-gB
-gq
-gq
-ja
-fF
 dA
 dA
 oS
@@ -43524,21 +43490,21 @@ rm
 rm
 rm
 rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 dA
-dA
-dA
-dA
-dA
-dA
-fF
-fF
-fF
-fF
-fF
-fF
-fF
-fF
 dA
 dA
 oS
@@ -43781,19 +43747,19 @@ rm
 rm
 rm
 rm
-oS
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-oS
-oS
-oS
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 oS
 oS
 dA
@@ -44038,16 +44004,16 @@ rm
 rm
 rm
 rm
-oS
-dA
-dA
-dA
-dA
-dA
-dA
-oS
-oS
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 rm
 rm
 rm
@@ -44295,14 +44261,14 @@ rm
 rm
 rm
 rm
-oS
-dA
-dA
-dA
-oS
-oS
-oS
-oS
+rm
+rm
+rm
+rm
+rm
+rm
+rm
+rm
 rm
 rm
 rm
@@ -44552,11 +44518,11 @@ rm
 rm
 rm
 rm
-oS
-dA
-dA
-oS
-oS
+rm
+rm
+rm
+rm
+rm
 rm
 rm
 rm
@@ -44808,11 +44774,11 @@ rm
 rm
 rm
 rm
-oS
-oS
-oS
-oS
-oS
+rm
+rm
+rm
+rm
+rm
 rm
 rm
 WF
@@ -45065,9 +45031,9 @@ rm
 rm
 rm
 rm
-oS
-oS
-oS
+rm
+rm
+rm
 DE
 DE
 DE
@@ -45322,9 +45288,9 @@ rm
 rm
 rm
 rm
-oS
-oS
-oS
+rm
+rm
+rm
 DE
 UN
 DE
@@ -45579,9 +45545,9 @@ rm
 rm
 rm
 rm
-oS
-oS
-oS
+rm
+rm
+rm
 DE
 Qn
 DE
@@ -45836,7 +45802,7 @@ rm
 rm
 rm
 rm
-oS
+rm
 DE
 DE
 DE
@@ -46093,7 +46059,7 @@ rm
 rm
 rm
 rm
-oS
+rm
 DE
 Io
 vZ
@@ -46349,8 +46315,8 @@ rm
 rm
 rm
 rm
-oS
-oS
+rm
+rm
 DE
 YI
 Qk
@@ -46606,7 +46572,7 @@ rm
 rm
 rm
 rm
-oS
+rm
 rm
 DE
 sL
@@ -47885,7 +47851,7 @@ oS
 rm
 rm
 rm
-oS
+rm
 rm
 rm
 rm
@@ -48141,9 +48107,9 @@ dA
 oS
 rm
 rm
-oS
-oS
-oS
+rm
+rm
+rm
 rm
 bS
 xx
@@ -48396,10 +48362,10 @@ dA
 dA
 dA
 oS
-oS
 rm
 rm
-oS
+rm
+rm
 rm
 rm
 bS
@@ -48652,9 +48618,9 @@ dA
 dA
 dA
 dA
-dA
 oS
-oS
+rm
+rm
 rm
 rm
 rm
@@ -48909,8 +48875,8 @@ dA
 dA
 dA
 dA
-dA
 oS
+rm
 rm
 rm
 bO
@@ -49167,7 +49133,7 @@ dA
 dA
 dA
 oS
-oS
+rm
 rm
 bO
 YK

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -437,7 +437,7 @@
 	},
 /obj/structure/cable/green{
 	d1 = 4;
-	d2 = 8;
+	d2 = 10;
 	icon_state = "4-10"
 	},
 /obj/machinery/door/blast/regular{
@@ -813,7 +813,7 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 6;
 	d2 = 8;
 	icon_state = "6-8"
 	},
@@ -1024,8 +1024,7 @@
 	RCon_tag = "Medical Substation"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d2 = 10;
 	icon_state = "0-10"
 	},
 /turf/simulated/floor/plating,
@@ -1183,8 +1182,8 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 5;
+	d2 = 9;
 	icon_state = "5-9"
 	},
 /obj/machinery/light/small,
@@ -4318,8 +4317,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
+	d1 = 2;
+	d2 = 5;
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -4642,6 +4641,8 @@
 	dir = 6
 	},
 /obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -4752,6 +4753,8 @@
 	name = "Ethics Representitive"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -5542,6 +5545,8 @@
 /area/site53/surface/surface)
 "rx" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/brigdoor/northright,
@@ -7420,11 +7425,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/plating,
 /area/site53/maintenance/surfaceeast)
 "ET" = (
@@ -7790,11 +7791,7 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "0-1"
-	},
+/obj/structure/cable/green,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/medical/exam_room)
 "Ik" = (
@@ -9172,7 +9169,7 @@
 /area/site53/surface/surface)
 "Xb" = (
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -9376,6 +9373,8 @@
 /area/site53/surface/surface)
 "Zh" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -9,7 +9,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "ad" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -20,7 +20,7 @@
 "ae" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "af" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
@@ -49,10 +49,10 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "aj" = (
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "al" = (
 /obj/structure/disposalpipe/down,
 /obj/structure/lattice,
@@ -85,10 +85,10 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "as" = (
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "at" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -96,7 +96,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "au" = (
 /obj/machinery/light,
 /obj/structure/closet/crate/bin{
@@ -104,7 +104,7 @@
 	name = "trash bin"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "av" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/multi_tile/glass/medical{
@@ -132,7 +132,7 @@
 	},
 /obj/machinery/door/airlock/multi_tile/glass/civilian,
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "ax" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -140,25 +140,25 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "ay" = (
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "az" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "aA" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "aB" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/leafybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "aC" = (
 /obj/machinery/door/blast/regular{
 	begins_closed = 0;
@@ -255,7 +255,7 @@
 "aN" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/prepainted,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "aO" = (
 /obj/structure/cryofeed{
 	dir = 4
@@ -291,7 +291,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "aS" = (
 /obj/structure/cryofeed,
 /obj/machinery/cryopod{
@@ -329,7 +329,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "aW" = (
 /obj/effect/landmark{
 	name = "Observer-Start"
@@ -968,7 +968,7 @@
 "cj" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "ck" = (
 /obj/effect/paint_stripe/gray,
 /turf/unsimulated/mineral,
@@ -1298,12 +1298,12 @@
 	dir = 8
 	},
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "cY" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "cZ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -1770,7 +1770,7 @@
 	name = "Exterior Lockdown Blast Door"
 	},
 /turf/simulated/floor/plating,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "eq" = (
 /obj/machinery/camera/network/medbay{
 	c_tag = "Mental Isolation 4";
@@ -2147,7 +2147,7 @@
 	pixel_y = -20
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "fr" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -2462,13 +2462,13 @@
 "gt" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "gu" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "gv" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -2476,7 +2476,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "gw" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/down{
@@ -4420,7 +4420,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "lK" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -4434,7 +4434,7 @@
 	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "lM" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
@@ -4451,7 +4451,7 @@
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "lW" = (
 /obj/effect/floor_decal/corner/red/border{
 	dir = 8
@@ -4491,13 +4491,13 @@
 	name = "Exterior Lockdown Blast Door"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "mb" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "mc" = (
 /obj/effect/paint_stripe/gunmetal,
 /turf/simulated/wall/prepainted,
@@ -4523,11 +4523,11 @@
 	name = "Exterior Lockdown Blast Door"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "mi" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "mj" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -4537,7 +4537,7 @@
 	name = "scp420j"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "mk" = (
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/titanium,
@@ -4547,7 +4547,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "mm" = (
 /obj/machinery/light,
 /obj/structure/closet,
@@ -4559,7 +4559,7 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "mn" = (
 /obj/structure/hygiene/sink{
 	dir = 1;
@@ -5067,7 +5067,7 @@
 /obj/structure/flora/ausbushes/stalkybush,
 /obj/structure/flora/ausbushes/pointybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "pb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/orange/bordercorner{
@@ -5166,7 +5166,7 @@
 	name = "Exterior Lockdown Blast Door"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "pr" = (
 /obj/effect/paint_stripe/gray,
 /obj/machinery/status_display,
@@ -5176,7 +5176,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "pu" = (
 /obj/effect/paint_stripe/gray,
 /obj/machinery/status_display,
@@ -5225,7 +5225,7 @@
 "pG" = (
 /obj/effect/paint_stripe/gray,
 /turf/simulated/wall/prepainted,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "pH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -5281,7 +5281,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "qf" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5289,7 +5289,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "qp" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -5502,7 +5502,7 @@
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/marine,
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/marine,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "rp" = (
 /obj/structure/flora/bush,
 /obj/structure/flora/grass/brown,
@@ -5619,7 +5619,7 @@
 	name = "Exterior Lockdown Blast Door"
 	},
 /turf/simulated/floor/plating,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "rN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
@@ -5959,7 +5959,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "tD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -6153,7 +6153,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "uW" = (
 /obj/structure/sign/warning/moving_parts{
 	pixel_y = -32
@@ -6369,7 +6369,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "vC" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/leafybush,
@@ -6378,7 +6378,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/grass,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "vD" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 28
@@ -7451,7 +7451,7 @@
 	pixel_y = -20
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "Fl" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7755,7 +7755,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "HW" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 8
@@ -7822,7 +7822,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "Iy" = (
 /obj/structure/table/woodentable/ebony,
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
@@ -7925,7 +7925,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "Kc" = (
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/prepainted,
@@ -8071,7 +8071,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "Lm" = (
 /obj/structure/railing/mapped{
 	dir = 1
@@ -8090,7 +8090,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "Lp" = (
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/isolation)
@@ -8142,7 +8142,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "Mg" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 9
@@ -8449,7 +8449,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/tramhubhallwayentry)
+/area/site53/upper_surface/entrancehallway)
 "Qh" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel_grid,
@@ -9093,7 +9093,7 @@
 "Wl" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroomstairs)
+/area/site53/upper_surface/innerentrancehallway)
 "Wo" = (
 /obj/effect/floor_decal/corner/paleblue/half,
 /obj/machinery/vending/medical{

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -4412,11 +4412,6 @@
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
 "rJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -8583,6 +8578,9 @@
 "ZO" = (
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
+"ZS" = (
+/turf/simulated/floor/plating,
+/area/site53/maintenance/upper_surface)
 "ZZ" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/brown/half,
@@ -34700,7 +34698,7 @@ xv
 xv
 xv
 rJ
-fz
+ZS
 fz
 xv
 hZ

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -582,6 +582,8 @@
 	name = "SD Office Outter Lockdown"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -761,6 +763,8 @@
 	name = "Administrative Offices Lockdown"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -771,6 +775,8 @@
 	name = "inner SD lockdown"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -916,6 +922,8 @@
 	name = "Administrative Offices Lockdown"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -930,6 +938,8 @@
 "cU" = (
 /obj/structure/bed/chair/office,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -947,6 +957,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -1015,6 +1027,8 @@
 	name = "Director Office Checkpoint Windows"
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
@@ -1102,12 +1116,6 @@
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/standard,
 /turf/simulated/floor/carpet/purple,
-/area/site53/uez/hallway)
-"do" = (
-/obj/structure/cable/green{
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/lino,
 /area/site53/uez/hallway)
 "dp" = (
 /obj/structure/bed/chair{
@@ -1207,6 +1215,8 @@
 /area/site53/uez/conference)
 "dG" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -1691,6 +1701,8 @@
 	dir = 1
 	},
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/button/blast_door{
@@ -3617,7 +3629,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/cable/green{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
@@ -4399,6 +4411,24 @@
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
+"rJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24;
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/site53/maintenance/upper_surface)
 "rN" = (
 /obj/machinery/light{
 	dir = 4
@@ -4723,6 +4753,8 @@
 /area/site53/uez/commandpanicbunker)
 "vj" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -5929,6 +5961,8 @@
 /area/site53/uez/commandpanicbunker)
 "Ex" = (
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/effect/catwalk_plated/dark,
@@ -6763,6 +6797,19 @@
 /obj/effect/floor_decal/corner/black/full,
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
+"LV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/site53/maintenance/upper_surface)
 "LX" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -7209,6 +7256,8 @@
 "Pt" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood/mahogany,
@@ -7289,6 +7338,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
@@ -8098,6 +8149,8 @@
 /area/site53/uez/commandpanicbunker)
 "Wq" = (
 /obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue,
@@ -34388,8 +34441,8 @@ hk
 hk
 hk
 hk
-hk
-hk
+xv
+xv
 xv
 fz
 xv
@@ -34646,8 +34699,8 @@ xv
 xv
 xv
 xv
-xv
-xv
+rJ
+fz
 fz
 xv
 hZ
@@ -34903,7 +34956,7 @@ Fn
 hN
 Fn
 Fn
-Fn
+LV
 Fn
 kU
 xv
@@ -41750,7 +41803,7 @@ fT
 bK
 bK
 gQ
-do
+fT
 cn
 bK
 bK

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -1,8 +1,17 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/effect/paint_stripe/blue,
-/turf/simulated/wall/r_wall/prepainted,
-/area/site53/upper_surface/maincontrolroom)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "west bump";
+	pixel_x = -24;
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/mcrsubstation)
 "ac" = (
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/titanium,
@@ -29,10 +38,6 @@
 "af" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/bridge)
-"ag" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/prepainted,
-/area/site53/surface/surface)
 "ah" = (
 /obj/effect/paint_stripe/orange,
 /turf/simulated/wall/prepainted,
@@ -106,32 +111,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/bridge)
-"aq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/flora/pottedplant/minitree,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"ar" = (
-/obj/item/device/radio/intercom{
-	frequency = 1017;
-	name = "intercom (Trams)";
-	pixel_y = 32
-	},
-/obj/item/modular_computer/console/preset/cardslot/command,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "as" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -167,16 +146,6 @@
 "aw" = (
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/uez/hallway)
-"ax" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"ay" = (
-/obj/machinery/camera/autoname{
-	network = list("Entrance Zone Network")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "az" = (
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -278,15 +247,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/canteen)
-"aK" = (
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"aL" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "aM" = (
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
@@ -316,30 +276,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
-"aQ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/flora/pottedplant/minitree,
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"aR" = (
-/obj/item/modular_computer/console/preset/cardslot/command{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "aS" = (
 /obj/effect/paint_stripe/red,
 /obj/machinery/door/airlock/security{
@@ -354,15 +290,17 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
-"aT" = (
-/obj/structure/bed/chair/office/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
 "aU" = (
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch/maintenance{
+	name = "Maintenance"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/mcrsubstation)
 "aV" = (
 /obj/machinery/camera/autoname{
 	network = list("Entrance Zone Network")
@@ -378,30 +316,9 @@
 	},
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
-"aW" = (
-/obj/item/modular_computer/console/preset/cardslot/command{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"aX" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "aY" = (
 /turf/simulated/wall/r_wall/prepainted,
 /area/site53/upper_surface/commstower)
-"aZ" = (
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
-"ba" = (
-/obj/effect/paint_stripe/red,
-/turf/simulated/wall/r_wall/prepainted,
-/area/site53/surface/surface)
 "bb" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -415,18 +332,10 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	pixel_x = -12
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/bridge)
-"bd" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "be" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/shutters{
@@ -435,64 +344,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
-"bf" = (
-/obj/effect/floor_decal/corner/blue/bordercorner,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"bg" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/standard,
-/obj/machinery/photocopier{
-	pixel_y = 3
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"bh" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/item/modular_computer/console/preset/cardslot/command{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"bi" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/machinery/papershredder,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"bj" = (
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"bk" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "bl" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
-"bm" = (
-/obj/effect/floor_decal/corner/blue/border,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "bn" = (
 /turf/simulated/floor/carpet/brown,
 /area/site53/uez/hallway)
-"bo" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "bp" = (
 /obj/machinery/door/blast/regular{
 	dir = 4;
@@ -533,64 +393,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/bridge)
 "bu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"bv" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"bw" = (
-/obj/machinery/door/airlock/glass/command{
-	name = "Main Control Room";
-	req_access = list("ACCESS_ADMIN_LEVEL1")
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "controlroom";
-	name = "Control Room Lockdown Blast Door"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
+/turf/simulated/floor/plating,
+/area/site53/uez/mcrsubstation)
 "bx" = (
 /obj/structure/ladder,
 /turf/simulated/floor/plating,
 /area/site53/uez/mcrsubstation)
-"by" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	req_access = list("ACCESS_SECURITY_LEVEL1")
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
-"bz" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+"bA" = (
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/mcrsubstation)
-"bA" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "bB" = (
 /obj/machinery/door/airlock/hatch/maintenance{
 	name = "Maintenance";
@@ -615,12 +429,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/hallway)
-"bD" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "bE" = (
 /obj/effect/floor_decal/corner/blue/border{
 	dir = 1
@@ -873,15 +681,6 @@
 /obj/structure/table/woodentable_reinforced/mahogany,
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/hallway)
-"cp" = (
-/obj/machinery/door/blast/regular/open{
-	icon_state = "pdoor0";
-	id_tag = "controlroom";
-	name = "Control Room Lockdown Blast Door"
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/site53/upper_surface/maincontrolroom)
 "cq" = (
 /obj/structure/bed/chair/office/light,
 /obj/effect/landmark/start{
@@ -1059,7 +858,7 @@
 /area/site53/uez/substation)
 "cK" = (
 /obj/effect/paint_stripe/yellow,
-/turf/simulated/wall/titanium,
+/turf/simulated/wall/r_wall/prepainted,
 /area/site53/uez/substation)
 "cL" = (
 /turf/simulated/floor/plating,
@@ -1072,19 +871,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/substation)
-"cN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/mcrsubstation)
 "cO" = (
 /obj/machinery/power/smes/buildable/preset/ds90/substation_full{
 	RCon_tag = "Upper Entrance Zone Substation"
@@ -1359,32 +1145,22 @@
 /turf/simulated/floor/plating,
 /area/site53/uez/substation)
 "dv" = (
-/obj/effect/paint_stripe/yellow,
-/turf/simulated/wall/prepainted,
-/area/site53/uez/maintenance)
-"dw" = (
-/obj/machinery/light{
-	dir = 4
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24;
+	req_access = list("ACCESS_SECURITY_LEVEL1")
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/maintenance)
 "dx" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/hallway)
-"dy" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/papershredder,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 9
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "dz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -1397,19 +1173,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
-"dA" = (
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/obj/machinery/button/blast_door{
-	id_tag = "controlroom";
-	name = "Control Room Lockdown button";
-	req_access = list("ACCESS_ADMIN_LEVEL1")
-	},
-/obj/item/crowbar/emergency_forcing_tool,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "dB" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/carpet/blue,
@@ -1697,17 +1460,6 @@
 /obj/structure/flora/grass/green,
 /turf/simulated/floor/exoplanet/snow,
 /area/site53/uez/hallway)
-"es" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Main Control Room";
-	send_access = list("ACCESS_ADMIN_LEVEL1")
-	},
-/obj/structure/table/standard,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "et" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/machinery/door/blast/regular/open{
@@ -2036,6 +1788,7 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable{
+	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/carpet/purple,
@@ -2142,25 +1895,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
-"fA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
-"fB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/hatch/maintenance{
-	name = "Maintenance"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
 "fC" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/r_wall/prepainted,
@@ -2169,81 +1903,10 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/uez/hallway)
-"fF" = (
-/obj/structure/filingcabinet,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"fG" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/structure/window/basic/full{
-	anchored = 0;
-	health_current = 5;
-	name = "Safety Glass"
-	},
-/obj/effect/floor_decal/industrial/warning/full,
-/obj/machinery/button/blast_door{
-	anchored = 0;
-	id_tag = "facilitylockdown";
-	name = "Facility Lockdown button";
-	req_access = list("ACCESS_ADMIN_LEVEL4")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "fH" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/tiled/techmaint,
 /area/site53/uez/hallway)
-"fI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
-"fJ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24;
-	req_access = list("ACCESS_SECURITY_LEVEL1")
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/mcrsubstation)
-"fK" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/mcrsubstation)
 "fL" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -2306,37 +1969,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
-"fQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
-"fR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
-"fS" = (
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/mcrsubstation)
 "fT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -2376,19 +2008,6 @@
 /obj/machinery/vending/snack,
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
-"fZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/photocopier,
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 5
-	},
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "ga" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
@@ -2397,31 +2016,19 @@
 /obj/item/pen,
 /turf/simulated/floor/tiled,
 /area/site53/uez/hallway)
-"gb" = (
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"gc" = (
-/obj/structure/bed/chair/office/light,
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"ge" = (
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "gf" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/mcrsubstation)
 "gg" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled,
@@ -2745,56 +2352,27 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
-"hE" = (
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
+"hH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera/autoname{
-	network = list("Entrance Zone Network")
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"hF" = (
-/obj/machinery/power/apc{
-	dir = 1
+/turf/simulated/floor/plating,
+/area/site53/uez/mcrsubstation)
+"hJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"hG" = (
-/obj/item/device/radio/intercom{
-	frequency = 1017;
-	name = "intercom (Trams)";
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"hH" = (
-/obj/effect/floor_decal/corner/blue/bordercorner{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"hI" = (
-/obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
-/obj/structure/table/standard,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"hK" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
+/turf/simulated/floor/plating,
+/area/site53/uez/mcrsubstation)
 "hL" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
@@ -2812,17 +2390,6 @@
 /obj/machinery/light/small{
 	dir = 8;
 	icon_state = "bulb1"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
-"hO" = (
-/obj/machinery/door/airlock/hatch/maintenance{
-	name = "Maintenance"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -2873,20 +2440,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
-"hT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	frequency = 1017;
-	name = "intercom (Trams)";
-	pixel_y = 32
-	},
-/obj/effect/floor_decal/corner/blue/border{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "hU" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/blue/border{
@@ -2906,14 +2459,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"hW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
 "hX" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -2952,13 +2497,9 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
 "id" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/site53/uez/mcrsubstation)
 "ie" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3060,15 +2601,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"io" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
 "ip" = (
 /obj/machinery/papershredder,
 /obj/effect/floor_decal/corner/brown/half{
@@ -3085,9 +2617,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
 "ir" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -3096,6 +2625,10 @@
 	},
 /obj/effect/floor_decal/corner/brown/half{
 	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
@@ -3134,14 +2667,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"ix" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "iy" = (
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
@@ -3169,25 +2694,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
-"iC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/hatch/maintenance{
-	name = "MCR Substation";
-	req_access = list("ACCESS_ADMIN_LEVEL1")
-	},
-/obj/machinery/door/blast/regular/open{
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "controlroom";
-	name = "Control Room Lockdown Blast Door"
-	},
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/site53/upper_surface/maincontrolroom)
 "iD" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/standard,
@@ -3200,10 +2706,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"iF" = (
-/obj/structure/bed/chair/office/light,
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
 "iG" = (
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
@@ -3237,31 +2739,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/maintenance)
-"iK" = (
-/obj/machinery/light,
-/obj/structure/flora/pottedplant/minitree,
-/obj/structure/railing/mapped,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"iL" = (
-/obj/item/modular_computer/console/preset/cardslot/command{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"iM" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "iN" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/corner/brown/half{
@@ -3269,10 +2746,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"iO" = (
-/obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "iP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3284,13 +2757,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"iQ" = (
-/obj/machinery/light,
-/obj/item/modular_computer/console/preset/cardslot/command{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "iR" = (
 /obj/effect/landmark/start{
 	name = "Logistics Officer"
@@ -3300,10 +2766,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
-"iS" = (
-/obj/structure/flora/pottedplant/flower,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "iT" = (
 /obj/machinery/photocopier/faxmachine{
 	department = "Logistics Breakroom";
@@ -3363,10 +2825,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"ja" = (
-/obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
 "jb" = (
 /obj/structure/closet/crate/bin{
 	anchored = 1;
@@ -3381,28 +2839,6 @@
 /obj/effect/floor_decal/corner/brown/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"jd" = (
-/obj/machinery/light,
-/obj/structure/flora/pottedplant/minitree,
-/obj/structure/railing/mapped{
-	dir = 8
-	},
-/obj/structure/railing/mapped{
-	dir = 4
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/monotile,
-/area/site53/upper_surface/maincontrolroom)
-"je" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/simulated/open,
-/area/site53/upper_surface/maincontrolroom)
 "jf" = (
 /obj/machinery/light{
 	dir = 1
@@ -3468,9 +2904,6 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsbreak)
-"jn" = (
-/turf/simulated/open,
-/area/site53/upper_surface/maincontrolroom)
 "jo" = (
 /obj/structure/flora/pottedplant/minitree{
 	pixel_y = 8
@@ -3512,16 +2945,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"js" = (
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/site53/upper_surface/maincontrolroom)
-"jt" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/open,
-/area/site53/upper_surface/maincontrolroom)
 "ju" = (
 /obj/item/modular_computer/console/preset/aislot/sysadmin,
 /obj/effect/floor_decal/corner/orange/border{
@@ -3577,16 +3000,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"jz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/open,
-/area/site53/upper_surface/maincontrolroom)
-"jA" = (
-/obj/machinery/light,
-/turf/simulated/open,
-/area/site53/upper_surface/maincontrolroom)
 "jB" = (
 /obj/effect/floor_decal/corner/orange/bordercorner,
 /obj/structure/filingcabinet/chestdrawer,
@@ -3687,32 +3100,12 @@
 "jO" = (
 /turf/unsimulated/mask,
 /area/site53/upper_surface/commstower)
-"jP" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/effect/paint_stripe/red,
-/obj/machinery/door/blast/regular/open{
-	dir = 2;
-	icon_state = "pdoor0";
-	id_tag = "controlroom";
-	name = "Control Room Lockdown Blast Door"
-	},
-/obj/structure/barricade,
-/turf/simulated/floor/plating,
-/area/site53/upper_surface/maincontrolroom)
 "jQ" = (
 /obj/effect/floor_decal/corner/orange/border{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/upper_surface/commstower)
-"jR" = (
-/obj/machinery/door/airlock/command{
-	name = "Old Control Room";
-	req_access = list("ACCESS_ADMIN_LEVEL1")
-	},
-/obj/structure/barricade,
-/turf/simulated/floor/tiled,
-/area/site53/upper_surface/maincontrolroom)
 "jT" = (
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
@@ -4773,6 +4166,8 @@
 /area/site53/uez/conference)
 "qm" = (
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/purple,
@@ -5979,6 +5374,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/site53/uez/hallway)
+"zV" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/site53/uez/maintenance)
 "zW" = (
 /obj/structure/bed/chair/comfy/brown{
 	dir = 8;
@@ -6126,6 +5534,8 @@
 "Ba" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/purple,
@@ -6334,6 +5744,16 @@
 "CT" = (
 /turf/simulated/floor/carpet/red,
 /area/site53/uez/commandpanicbunker)
+"CV" = (
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/bridge)
 "De" = (
 /obj/structure/table/steel,
 /obj/item/storage/firstaid/combat,
@@ -6397,22 +5817,6 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/logistics/logisticsofficer)
-"Dx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	icon_state = "bulb1"
-	},
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
 "Dy" = (
 /obj/item/modular_computer/laptop/preset/custom_loadout/advanced,
 /obj/structure/table/steel,
@@ -6773,6 +6177,11 @@
 /obj/item/folder/blue,
 /turf/simulated/floor/carpet/blue,
 /area/site53/uez/repoffice/internaltribunal)
+"Hd" = (
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
+/area/space)
 "He" = (
 /obj/item/modular_computer/console/preset/cardslot/command_sec{
 	dir = 4
@@ -7041,10 +6450,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/uez/commandpanicbunker)
-"JT" = (
-/obj/effect/paint_stripe/yellow,
-/turf/simulated/wall/titanium,
-/area/site53/uez/maintenance)
 "JY" = (
 /obj/structure/bed,
 /obj/structure/curtain/open/bed,
@@ -7172,10 +6577,11 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
+/obj/structure/catwalk,
 /obj/structure/cable{
+	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor,
 /area/site53/uez/commandpanicbunker)
 "KP" = (
@@ -7473,6 +6879,11 @@
 /obj/item/implanter,
 /turf/simulated/floor/wood/mahogany,
 /area/site53/uez/hallway)
+"MY" = (
+/obj/structure/railing/mapped,
+/obj/machinery/light,
+/turf/simulated/floor/tiled/monotile,
+/area/site53/uez/bridge)
 "MZ" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /turf/simulated/floor/tiled/monotile,
@@ -7879,6 +7290,8 @@
 /obj/structure/table/woodentable_reinforced/mahogany,
 /obj/machinery/photocopier,
 /obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -8730,7 +8143,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)
 "WQ" = (
-/turf/simulated/mineral,
+/turf/simulated/mineral{
+	initial_gas = list("oxygen"=21.8366,"nitrogen"=82.1472)
+	},
 /area/site53/surface/surface)
 "WR" = (
 /obj/structure/cryofeed,
@@ -35966,17 +35381,17 @@ hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
 jH
 jo
 jx
@@ -36223,17 +35638,17 @@ hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ba
-ba
-ba
-ba
-ba
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+WQ
+WQ
+WQ
 jH
 hQ
 yB
@@ -36480,17 +35895,17 @@ hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ba
+WQ
+WQ
+WQ
 hZ
 hZ
 hZ
-ba
-ba
-ba
+hZ
+hZ
+hZ
+hZ
+WQ
 jH
 kT
 kr
@@ -36711,21 +36126,21 @@ hk
 hk
 hk
 hk
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -36737,11 +36152,11 @@ hk
 fC
 hL
 fC
-hk
-hk
-hk
-hk
-ba
+WQ
+WQ
+WQ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -36968,21 +36383,21 @@ hk
 hk
 hk
 hk
-aa
-aq
-aR
-aX
-aK
-aK
-aK
-bD
-aK
-aK
-aK
-aX
-aR
-iK
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -36994,11 +36409,11 @@ hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -37225,21 +36640,21 @@ hk
 hk
 hk
 hk
-aa
-ar
-aT
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-iF
-iL
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 hk
 hk
@@ -37251,11 +36666,11 @@ hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -37482,37 +36897,37 @@ hk
 hk
 hk
 hk
-aa
-ax
-aU
-aU
-bf
-bo
-bv
-bv
-bv
-bo
-ge
-aU
-aU
-ax
-aa
 hk
 hk
-aa
-aa
-aa
-aa
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -37739,37 +37154,37 @@ hk
 hk
 hk
 hk
-aa
-ay
-aU
-aU
-bg
-aa
-aa
-aa
-aa
-aa
-gf
-aU
-aU
-iM
-aa
 hk
 hk
-aa
-jz
-jn
-jn
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -37790,7 +37205,7 @@ jT
 ki
 kj
 kH
-jH
+eH
 hZ
 hZ
 hZ
@@ -37996,37 +37411,37 @@ hk
 hk
 hk
 hk
-aa
-aK
-aU
-aZ
-bh
-aa
-aK
-aK
-aK
-aa
-hE
-aU
-aU
-iO
-aa
-aa
-aa
-aa
-jn
-jn
-jA
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -38047,7 +37462,7 @@ jT
 ki
 Ct
 kI
-jH
+eH
 hZ
 hZ
 hZ
@@ -38060,16 +37475,16 @@ hZ
 hZ
 WQ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
 hk
 hk
 hk
@@ -38253,37 +37668,37 @@ hk
 hk
 hk
 hk
-aa
-aK
-aU
-aU
-bh
-aa
-aL
-aK
-aK
-aa
-hF
-hW
-aZ
-iL
-cp
-je
-jn
-js
-jn
-jn
-jn
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -38304,7 +37719,7 @@ jT
 ki
 Sv
 kb
-jH
+eH
 hZ
 hZ
 hZ
@@ -38326,7 +37741,7 @@ WQ
 WQ
 WQ
 WQ
-hk
+WQ
 hk
 hk
 hk
@@ -38510,37 +37925,37 @@ hk
 hk
 hk
 hk
-aa
-aK
-aU
-aZ
-bh
-aa
-aK
-aa
-aa
-aa
-hG
-id
-iF
-iL
-cp
-jn
-jn
-js
-js
-js
-jn
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -38561,7 +37976,7 @@ jH
 kq
 ki
 jM
-jH
+eH
 hZ
 hZ
 hZ
@@ -38767,37 +38182,37 @@ hk
 hk
 hk
 hk
-aa
-aK
-aU
-aU
-bi
-aa
-bw
-aa
-dy
-bA
-hH
-id
-aZ
-iQ
-cp
-js
-js
-js
-jn
-jn
-jA
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -38818,7 +38233,7 @@ eH
 kN
 kr
 jM
-jH
+eH
 hZ
 hZ
 hZ
@@ -39024,37 +38439,37 @@ ai
 ai
 ai
 ai
-aa
-aK
-aU
-aU
-bj
-aa
-aL
-cp
-dA
-gb
-ax
-id
-aU
-iS
-cp
-jn
-jn
-js
-jn
-jn
-jn
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -39075,7 +38490,7 @@ eH
 kN
 kr
 kc
-jH
+eH
 hZ
 hZ
 hZ
@@ -39257,11 +38672,11 @@ ac
 am
 af
 af
-av
-av
-av
-av
 bc
+av
+av
+av
+av
 av
 av
 av
@@ -39271,7 +38686,7 @@ av
 av
 av
 KY
-bc
+av
 av
 av
 av
@@ -39280,38 +38695,38 @@ bc
 av
 av
 aN
-hr
-aa
-aL
-aU
-aU
-aU
-jR
-aK
-cp
-es
-gc
-hI
-id
-aU
-ax
-cp
-jn
-jn
-jn
-jn
-jn
-jn
-aa
+ai
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 hL
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -39332,7 +38747,7 @@ kd
 kN
 kr
 kY
-jH
+eH
 hZ
 hZ
 hZ
@@ -39518,7 +38933,7 @@ az
 az
 az
 az
-az
+CV
 az
 pN
 az
@@ -39528,7 +38943,7 @@ az
 az
 az
 az
-az
+CV
 az
 az
 az
@@ -39537,38 +38952,38 @@ az
 az
 af
 aO
-hr
-jP
-aK
-aU
-aU
-aU
-jR
-aK
-cp
-fF
-aK
-hK
-io
-aU
-ax
-cp
-jn
-jn
-jn
-jn
-jn
-jn
-aa
+ai
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -39589,7 +39004,7 @@ eH
 kl
 kr
 kB
-jH
+eH
 hZ
 hZ
 hZ
@@ -39794,38 +39209,38 @@ hr
 hr
 aB
 aO
-hr
-jP
-aK
-aU
-aU
-bf
-aa
-aL
-cp
-fG
-gb
-ax
-id
-aU
-iS
-cp
-jn
-jn
-js
-jn
-jn
-jn
-aa
+ai
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -39846,7 +39261,7 @@ Ts
 kr
 kr
 kO
-jH
+eH
 hZ
 hZ
 hZ
@@ -40029,60 +39444,60 @@ ai
 ai
 ai
 ai
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
 ai
 aA
 aD
 aB
-aO
-hr
-jP
-aK
-aU
-aU
-bk
-aa
-bw
-aa
-fZ
-bv
-ge
-id
-aZ
-iQ
-cp
-js
-js
-js
-jn
-jn
-jA
-aa
+MY
+ai
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -40103,7 +39518,7 @@ eH
 AY
 EH
 kQ
-jH
+eH
 hZ
 hZ
 hZ
@@ -40282,64 +39697,64 @@ fl
 fl
 fl
 ac
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
 ai
 bt
 af
 af
 aO
-hr
-jP
-aK
-aU
-aZ
-bh
-aa
-aK
-aa
-aa
-aa
-gf
-id
-iF
-iL
-cp
-jn
-jn
-js
-js
-js
-jn
-aa
+ai
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -40357,9 +39772,9 @@ eH
 eH
 kD
 jH
-jH
-jH
-jH
+eH
+eH
+eH
 ah
 hZ
 hZ
@@ -40539,64 +39954,61 @@ gl
 gv
 gE
 cl
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
 ai
 bt
 af
 af
 aO
-hr
-jP
-aK
-aU
-aU
-bh
-aa
-aL
-aK
-aK
-aa
-hT
-id
-aZ
-iL
-cp
-jt
-jn
-js
-jn
-jn
-jn
-aa
+ai
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
 hk
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
 hZ
 hZ
 hZ
@@ -40617,7 +40029,10 @@ hZ
 hZ
 hZ
 hZ
-ag
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -40796,64 +40211,61 @@ go
 gy
 gF
 ac
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
 ai
 aC
 aE
 aB
 au
 ai
-aa
-aL
-aU
-aZ
-bh
-aa
-aK
-aK
-aK
-aa
-hE
-id
-aU
-ja
-aa
-aa
-aa
-aa
-jn
-jn
-jA
-aa
 hk
+hk
+hk
+hk
+hk
+hk
+ak
+ak
+ak
+ak
+ak
+ak
+ak
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
 fC
 fz
 fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
 hZ
 hZ
 hZ
@@ -40874,7 +40286,10 @@ hZ
 hZ
 hZ
 hZ
-ag
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -41053,64 +40468,61 @@ gp
 gz
 gG
 ac
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
+Hd
 ai
 ai
 ai
 af
 ai
 ai
-aa
-ay
-aU
-aU
-bm
-aa
-aa
-aa
-aa
+hk
+hk
+hk
+hk
+hk
+hk
+ak
+bx
+bu
 aa
 gf
-id
+an
 aU
-iM
-aa
-hk
-hk
-aa
-jt
-jn
-jn
-aa
-hk
+fw
+fw
+fw
+fw
+hS
+fw
+fw
+fw
+fw
+fw
+fw
+iI
 fC
-fz
-fC
-hk
-hk
-hk
-hk
-ag
+WQ
+WQ
 hZ
 hZ
 hZ
@@ -41131,7 +40543,10 @@ hZ
 hZ
 hZ
 hZ
-ag
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -41310,64 +40725,61 @@ ac
 ac
 ac
 ac
-JT
-JT
-JT
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
 fx
-dv
-dv
-aa
-ax
-aU
-aU
-bj
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+ak
+bA
 bu
-bA
-bA
-bA
 bu
 hH
 id
-aU
-ax
-aa
-hk
-hk
-aa
-aa
-aa
-aa
-aa
-hk
+ak
 fC
-fz
 fC
-hk
-hk
-hk
-hk
-ag
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+WQ
+WQ
 hZ
 hZ
 hZ
@@ -41388,7 +40800,10 @@ hZ
 hZ
 hZ
 hZ
-ag
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -41591,24 +41006,22 @@ fw
 fw
 fw
 fw
+zV
+fw
+fP
 fw
 fw
-fQ
-aa
-ar
-aT
+fw
+fw
+fw
+fw
 aU
-aU
-aU
-aU
-aU
-aU
-aU
-aU
-id
-iF
-iL
-aa
+an
+an
+an
+hJ
+cP
+ak
 hk
 hk
 hk
@@ -41617,14 +41030,13 @@ hk
 hk
 hk
 hk
-fC
-fz
-fC
 hk
 hk
-hk
-hk
-ag
+WQ
+WQ
+WQ
+WQ
+WQ
 hZ
 hZ
 hZ
@@ -41645,7 +41057,10 @@ hZ
 hZ
 hZ
 hZ
-ag
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -41825,63 +41240,60 @@ cK
 cK
 fs
 cK
-JT
-JT
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
+fC
 cL
-fz
-aa
-aQ
-aW
-bd
-aK
-aK
-aK
-dw
-aK
-aK
-aK
-ix
-aW
-jd
-aa
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+dv
 fC
-hL
 fC
+fC
+fC
+fC
+fC
+fC
+fC
+ak
+ak
+ak
+ak
+ak
+ak
+ak
 hk
 hk
 hk
 hk
-ag
+hk
+hk
+hk
+hk
+hk
+hk
+WQ
+WQ
+WQ
+WQ
+WQ
 hZ
 hZ
 hZ
@@ -41902,7 +41314,10 @@ hZ
 hZ
 hZ
 hZ
-ag
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -42103,63 +41518,63 @@ hk
 hk
 hk
 hk
-hk
-hk
-dv
-by
-fI
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-iC
-aa
-aa
-aa
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
 fC
-fz
+fC
+fC
 fC
 hk
 hk
 hk
 hk
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
-ag
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+hk
+WQ
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -42362,35 +41777,6 @@ hk
 hk
 hk
 hk
-dv
-cL
-fA
-Dx
-fw
-fw
-fw
-fw
-fw
-fR
-fB
-fw
-fw
-fw
-fI
-cL
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fz
-fC
 hk
 hk
 hk
@@ -42416,6 +41802,35 @@ hk
 hk
 hk
 hk
+hk
+WQ
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -42619,35 +42034,6 @@ hk
 hk
 hk
 hk
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-dv
-fC
-fJ
-an
-fK
-cN
-an
-hO
-fw
-hS
-fw
-fw
-fw
-hS
-fw
-fw
-fw
-fw
-iI
-fC
 hk
 hk
 hk
@@ -42673,6 +42059,35 @@ hk
 hk
 hk
 hk
+hk
+WQ
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -42886,25 +42301,6 @@ hk
 hk
 hk
 hk
-ak
-bx
-fS
-bz
-cP
-fS
-ak
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
 hk
 hk
 hk
@@ -42921,15 +42317,34 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -43143,13 +42558,6 @@ hk
 hk
 hk
 hk
-ak
-ak
-ak
-ak
-ak
-ak
-ak
 hk
 hk
 hk
@@ -43167,26 +42575,33 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -43417,33 +42832,33 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -43674,33 +43089,33 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -43931,33 +43346,33 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -44188,33 +43603,33 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -44446,32 +43861,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -44703,32 +44118,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -44960,32 +44375,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -45217,32 +44632,32 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -45475,31 +44890,31 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -45733,42 +45148,42 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
 WQ
 WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -45991,42 +45406,42 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
 WQ
 WQ
 WQ
-WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -46249,42 +45664,42 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
 WQ
 WQ
-hk
-hk
 WQ
-WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -46507,47 +45922,47 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
-hZ
 WQ
 WQ
-hk
-hk
-hk
-hk
 WQ
 WQ
 hZ
 hZ
 hZ
-WQ
-WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 WQ
 WQ
 WQ
@@ -46765,47 +46180,47 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
 hZ
 hZ
 hZ
 hZ
 hZ
 hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 WQ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
 WQ
 WQ
-WQ
-WQ
-WQ
-hk
-hk
 hk
 hk
 hk
@@ -47023,25 +46438,36 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
@@ -47049,17 +46475,6 @@ hZ
 hZ
 WQ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
 hk
 hk
 hk
@@ -47282,41 +46697,41 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 hZ
 WQ
 WQ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
 hk
 hk
 hk
@@ -47541,38 +46956,38 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 hZ
 WQ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
 hk
 hk
 hk
@@ -47800,35 +47215,35 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
+hZ
 hZ
 WQ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
 hk
 hk
 hk
@@ -48060,30 +47475,30 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hZ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
 hk
 hk
 hk
@@ -48319,25 +47734,25 @@ hk
 hk
 hk
 hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
 WQ
 WQ
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
-hk
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
+WQ
 hk
 hk
 hk

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -1894,7 +1894,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "fC" = (
 /obj/effect/paint_stripe/yellow,
 /turf/simulated/wall/r_wall/prepainted,
@@ -2381,7 +2381,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "hM" = (
 /obj/effect/paint_stripe/brown,
 /turf/simulated/wall/r_wall/prepainted,
@@ -2397,7 +2397,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "hP" = (
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -2427,7 +2427,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "hS" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -2439,7 +2439,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "hU" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/blue/border{
@@ -2717,7 +2717,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "iI" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -2729,7 +2729,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "iJ" = (
 /obj/machinery/light/small,
 /obj/structure/cable{
@@ -2738,7 +2738,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "iN" = (
 /obj/machinery/vending/coffee,
 /obj/effect/floor_decal/corner/brown/half{
@@ -3497,7 +3497,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating,
-/area/site53/uez/maintenance)
+/area/site53/maintenance/upper_surface)
 "kX" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 1;
@@ -5025,6 +5025,10 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/tiled/techfloor,
 /area/site53/uez/commandpanicbunker)
+"xv" = (
+/obj/effect/paint_stripe/yellow,
+/turf/simulated/wall/r_wall/prepainted,
+/area/site53/maintenance/upper_surface)
 "xw" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
@@ -5975,6 +5979,14 @@
 /obj/effect/paint_stripe/blue,
 /turf/simulated/wall/titanium,
 /area/site53/uez/commandpanicbunker)
+"Fn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/site53/maintenance/upper_surface)
 "Fo" = (
 /obj/structure/table/standard,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -31551,16 +31563,16 @@ hk
 hk
 hk
 hk
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
 ia
 ib
 iy
@@ -31808,16 +31820,16 @@ hk
 hk
 hk
 hk
-fC
+xv
 iH
 hR
-fw
-fw
-fw
+Fn
+Fn
+Fn
 hR
-fw
-fw
-fw
+Fn
+Fn
+Fn
 bB
 ic
 iy
@@ -32065,16 +32077,16 @@ hk
 hk
 hk
 hk
-fC
+xv
 hL
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
 ia
 Sh
 if
@@ -32322,9 +32334,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 kx
 hZ
 hZ
@@ -32579,9 +32591,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -32836,9 +32848,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -33093,9 +33105,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 hL
-fC
+xv
 kx
 hZ
 hZ
@@ -33350,9 +33362,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 kx
 hZ
 hZ
@@ -33607,9 +33619,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 kx
 kx
 kx
@@ -33864,9 +33876,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -34121,9 +34133,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -34378,9 +34390,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -34607,37 +34619,37 @@ hk
 hk
 hk
 hk
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -34864,37 +34876,37 @@ hk
 hk
 hk
 hk
-fC
+xv
 iH
 hN
-fw
-fw
-fw
-fw
-fw
-fw
-fw
+Fn
+Fn
+Fn
+Fn
+Fn
+Fn
+Fn
 hN
-fw
-fw
-fw
-fw
+Fn
+Fn
+Fn
+Fn
 hN
-fw
-fw
-fw
-fw
-fw
-fw
-fw
-fw
+Fn
+Fn
+Fn
+Fn
+Fn
+Fn
+Fn
+Fn
 hN
-fw
-fw
-fw
-fw
+Fn
+Fn
+Fn
+Fn
 kU
-fC
+xv
 hZ
 hZ
 hZ
@@ -35121,20 +35133,20 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
 jH
 jH
 jH
@@ -35151,7 +35163,7 @@ jH
 jH
 jH
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -35378,9 +35390,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 WQ
@@ -35408,7 +35420,7 @@ Oc
 jy
 jH
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -35635,9 +35647,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 WQ
@@ -35665,7 +35677,7 @@ kr
 kO
 jH
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -35892,9 +35904,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 WQ
@@ -35922,7 +35934,7 @@ kr
 Tg
 jH
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -36149,9 +36161,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 hL
-fC
+xv
 WQ
 WQ
 WQ
@@ -36179,7 +36191,7 @@ kr
 jq
 jH
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -36406,9 +36418,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -36436,7 +36448,7 @@ kr
 ko
 jH
 fz
-fC
+xv
 hZ
 hZ
 hZ
@@ -36663,9 +36675,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -36693,7 +36705,7 @@ kr
 kF
 kR
 iJ
-fC
+xv
 hZ
 hZ
 hZ
@@ -36920,9 +36932,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -36949,8 +36961,8 @@ jp
 mn
 kK
 jH
-fC
-fC
+xv
+xv
 hZ
 hZ
 hZ
@@ -37177,9 +37189,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -37434,9 +37446,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -37691,9 +37703,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 hZ
 hZ
@@ -37948,9 +37960,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 hZ
 hZ
@@ -38205,9 +38217,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 hZ
 hZ
@@ -38462,9 +38474,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 hZ
 hZ
@@ -38719,9 +38731,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 hL
-fC
+xv
 WQ
 hZ
 hZ
@@ -38976,9 +38988,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 hZ
 hZ
@@ -39233,9 +39245,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 hZ
 hZ
@@ -39490,9 +39502,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 hZ
 hZ
@@ -39747,9 +39759,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -40004,9 +40016,9 @@ hk
 hk
 hk
 hk
-fC
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -40251,19 +40263,19 @@ ak
 ak
 ak
 ak
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
 fz
-fC
+xv
 WQ
 WQ
 hZ
@@ -40508,19 +40520,19 @@ aa
 gf
 an
 aU
-fw
-fw
-fw
-fw
+Fn
+Fn
+Fn
+Fn
 hS
-fw
-fw
-fw
-fw
-fw
-fw
+Fn
+Fn
+Fn
+Fn
+Fn
+Fn
 iI
-fC
+xv
 WQ
 WQ
 hZ
@@ -40765,19 +40777,19 @@ bu
 hH
 id
 ak
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
-fC
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
+xv
 WQ
 WQ
 hZ

--- a/maps/site53/site53areas.dm
+++ b/maps/site53/site53areas.dm
@@ -190,12 +190,6 @@
 
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
-/area/site53/upper_surface/tramhubhallwayentry
-	name = "\improper Site 53 Entrance"
-	icon_state = "hallC1"
-//	holomap_color = HOLOMAP_AREACOLOR_HALLWAYS
-	area_flags = AREA_FLAG_RAD_SHIELDED
-
 /area/site53/surface/bunker
 	name = "\improper Secure Bunker"
 	icon_state = "centcom"
@@ -215,16 +209,16 @@
 
 // Site 53 upper surface area's
 
-/area/site53/upper_surface/maincontrolroom
-	name = "\improper Main Control Room"
-	icon_state = "bridge"
-//	holomap_color = HOLOMAP_AREACOLOR_COMMAND
+/area/site53/upper_surface/entrancehallway
+	name = "\improper Site 53 Entrance"
+	icon_state = "hallC1"
+//	holomap_color = HOLOMAP_AREACOLOR_HALLWAYS
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
-/area/site53/upper_surface/maincontrolroomstairs
-	name = "\improper Main Control Room Stairs"
-	icon_state = "bridge"
-//	holomap_color = HOLOMAP_AREACOLOR_COMMAND
+/area/site53/upper_surface/innerentrancehallway
+	name = "\improper Site 53 Inner Entrance"
+	icon_state = "hallC1"
+//	holomap_color = HOLOMAP_AREACOLOR_HALLWAYS
 	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/site53/upper_surface/commstower
@@ -246,6 +240,10 @@
 	name = "\improper Server Farm Tunnel"
 	icon_state = "checkpoint1"
 //	holomap_color = HOLOMAP_AREACOLOR_SECURITY
+
+/area/site53/maintenance/upper_surface
+	name = "\improper Upper Surface Maintenance"
+	icon_state = "maint_exterior"
 
 /area/site53/lowertram/archive
 	name = "\improper Archive"


### PR DESCRIPTION
## About the Pull Request

Removes the old control room that's boarded off. Some improvements to nearby areas (the walkway has better lighting, the comms tower has more visibility + less random walls, and more mineable rocks). A few faulty prefabs were phased out (e.g. cables that didn't actually have their cabling set)

Closes #1309.

## Why It's Good For The Game

Squashing bugs good, getting rid of 100% useless rooms good, general mapping improvements good.

## Changelog

:cl:
add: Added more mineable rocks between the outdoor bar and EZ offices.
add: Improved lighting in the walkway between EZ and the main site body.
add: Added more windows to the control room + more mineable rocks and a more open upper outdoors area.
del: Removed the old, unused control room.
fix: Faulty roundstart cabling and APCs fixed.
/:cl: