### PR TITLE
Ports cinematic fix & tweak

### DIFF
--- a/code/datums/cinematic.dm
+++ b/code/datums/cinematic.dm
@@ -5,13 +5,15 @@ GLOBAL_DATUM_INIT(cinematic, /datum/cinematic, new)
 	//station_explosion used to be a variable for every mob's hud. Which was a waste!
 	//Now we have a general cinematic centrally held within the gameticker....far more efficient!
 	var/obj/screen/cinematic_screen = null
+	/// List of clients currently watching a cinematic
+	var/list/watching_clients = list()
 
 //Plus it provides an easy way to make cinematics for other events. Just use this as a template :)
-/datum/cinematic/proc/station_explosion_cinematic(station_missed=0, datum/game_mode/override)
+/datum/cinematic/proc/station_explosion_cinematic(station_missed = FALSE, datum/game_mode/override)
 	set waitfor = FALSE
 
 	if(cinematic_screen)
-		return	//already a cinematic in progress!
+		return //already a cinematic in progress!
 
 	if(!override)
 		override = SSticker.mode
@@ -20,30 +22,39 @@ GLOBAL_DATUM_INIT(cinematic, /datum/cinematic, new)
 	if(!override)
 		return
 
-	//initialise our cinematic screen object
+	watching_clients = list()
+
+	// Initialise our cinematic screen object
 	cinematic_screen = new(src)
 	cinematic_screen.icon = 'icons/effects/station_explosion.dmi'
 	cinematic_screen.icon_state = "station_intact"
 	cinematic_screen.plane = HUD_PLANE
 	cinematic_screen.layer = HUD_ABOVE_ITEM_LAYER
-	cinematic_screen.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	cinematic_screen.screen_loc = "1,0"
+	cinematic_screen.mouse_opacity = 0
+	cinematic_screen.screen_loc = "BOTTOM,LEFT+50%"
+	cinematic_screen.appearance_flags = APPEARANCE_UI | TILE_BOUND
 
-	//Let's not discuss how this worked previously.
-	var/list/viewers = list()
-	for(var/mob/living/M in GLOB.living_mob_list_)
-		if(M.client)
-			M.client.screen += cinematic_screen //show every client the cinematic
-			viewers[M.client] = M.stunned
-			M.stunned = 8000
-
-	override.nuke_act(cinematic_screen, station_missed) //cinematic happens here, as does mob death.
-	//If its actually the end of the round, wait for it to end.
-	//Otherwise if its a verb it will continue on afterwards.
-	sleep(30 SECONDS)
-
-	for(var/client/C in viewers)
+	for(var/client/C in GLOB.clients)
+		// Show every client the cinematic
+		C.screen += cinematic_screen
+		watching_clients += C
 		if(C.mob)
-			C.mob.stunned = viewers[C]
+			C.mob.stunned += 8000
+
+	// Cinematic happens here, as does mob death.
+	override.nuke_act(cinematic_screen, station_missed)
+	// If its actually the end of the round, wait for it to end.
+	// Otherwise if its a verb it will continue on afterwards.
+	sleep(20 SECONDS)
+
+	animate(cinematic_screen, alpha = 0, time = (2 SECONDS))
+
+	sleep(2 SECONDS)
+
+	for(var/client/C in watching_clients)
 		C.screen -= cinematic_screen
+		if(C.mob)
+			C.mob.stunned = max(0, C.mob.stunned - 8000)
+
+	watching_clients = list()
 	QDEL_NULL(cinematic_screen)


### PR DESCRIPTION
## About the Pull Request

Ports #vlggms/tegustation-bay12/pull/495

- Cinematics don't get permanently stuck on the screen;
- Cinematics are perfectly centered and fade out at the end.

## Why It's Good For The Game

- Fix!
- Neatly looking.

## Changelog

:cl:
tweak: Cinematics are now perfectly centered and fade out at the end.
fix: Cinematics no longer get stuck on the screen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
