### PR TITLE
Adds a d-class medical equipment locker in D-class medbay

### DIFF
--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -4599,6 +4599,7 @@
 /obj/effect/floor_decal/corner/b_green/mono,
 /obj/item/storage/box/lights/tubes,
 /obj/item/storage/box/bodybags,
+/obj/item/storage/chewables/candy/medicallollis,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost/storage)
 "kw" = (
@@ -17359,6 +17360,25 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/structure/closet{
+	name = "D-Class Medical Storage"
+	},
+/obj/item/clothing/suit/storage/toggle/labcoat,
+/obj/item/clothing/suit/storage/toggle/labcoat,
+/obj/item/clothing/suit/storage/toggle/labcoat,
+/obj/item/clothing/head/nursehat,
+/obj/item/clothing/head/nursehat,
+/obj/item/clothing/head/nursehat,
+/obj/item/clothing/glasses/hud/health/visor,
+/obj/item/clothing/glasses/hud/health/visor,
+/obj/item/clothing/glasses/hud/health/visor,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/device/scanner/health,
+/obj/item/storage/belt/medical/emt,
+/obj/item/storage/belt/medical/emt,
+/obj/item/storage/belt/medical/emt,
+/obj/item/storage/box/armband/med,
 /turf/simulated/floor/tiled/monotile/white,
 /area/site53/llcz/dclass/medicalpost/storage)
 "Pv" = (


### PR DESCRIPTION
## About the Pull Request

in my recent PR i added medical assignment for clclasses
however, i have realized the equipment locker in the backroom, includes a crowbar

so instead, i made it so the guards dont have to open the medical locker to give dclasses a labcoat, and instead them having their own locker with labcoat, analyzer and belts

![image](https://github.com/Foundation-19/Foundation-19/assets/118483925/46989648-1c85-4887-afaf-ebe576a20d2d)

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

gives medical assignment workers a little bit of gear that **does not let them fucking break out**

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Medical locker in dblock
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
