### PR TITLE
MTF + GOC fixes + additions.

### DIFF
--- a/code/datums/outfits/jobs/goc.dm
+++ b/code/datums/outfits/jobs/goc.dm
@@ -1,5 +1,5 @@
 /decl/hierarchy/outfit/goc
-	uniform = /obj/item/clothing/head/solgov/utility/marine/urban
+	uniform = /obj/item/clothing/under/solgov/utility/marine/urban
 	suit = /obj/item/clothing/suit/armor/goc
 	suit_store = null
 	head = /obj/item/clothing/head/helmet/scp/goc

--- a/code/datums/outfits/jobs/mtf.dm
+++ b/code/datums/outfits/jobs/mtf.dm
@@ -14,7 +14,7 @@
 	name = OUTFIT_JOB_NAME("MTF Epsilon-11 Agent")
 	uniform = /obj/item/clothing/under/ert
 	suit = /obj/item/clothing/suit/armor/pcarrier/green/scp/mtf_epsilon
-	head = /obj/item/clothing/head/helmet/site53/guard/mtf_epsilon
+	head = /obj/item/clothing/head/helmet/ballistic
 	mask = /obj/item/clothing/mask/balaclava/tactical
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
@@ -24,14 +24,15 @@
 	l_hand = /obj/item/material/hatchet/tacknife
 	l_pocket = /obj/item/grenade/flashbang
 	r_pocket = /obj/item/grenade/flashbang
-	belt = /obj/item/gun/projectile/silenced
+	id_type = /obj/item/card/id/mtf/ninetail
+	belt = /obj/item/storage/belt/holster/security/fullmk9 
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 2,/obj/item/grenade/frag = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/ammo_magazine/c45m = 2,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/mtf/epsilon_11/breacher
 	name = OUTFIT_JOB_NAME("MTF Epsilon-11 Breacher")
 	uniform = /obj/item/clothing/under/ert
 	suit = /obj/item/clothing/suit/armor/pcarrier/green/scp/mtf_epsilon
-	head = /obj/item/clothing/head/helmet/site53/guard/mtf_epsilon
+	head = /obj/item/clothing/head/helmet/ballistic
 	mask = /obj/item/clothing/mask/balaclava/tactical
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
@@ -41,14 +42,15 @@
 	l_hand = /obj/item/material/hatchet
 	l_pocket = /obj/item/grenade/flashbang
 	r_pocket = /obj/item/grenade/flashbang
-	belt = /obj/item/gun/projectile/silenced
+	id_type = /obj/item/card/id/mtf/ninetail
+	belt = /obj/item/storage/belt/holster/security/fullmk9 
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/grenade/frag = 2,/obj/item/ammo_magazine/shotholder/shell = 6,/obj/item/clothing/accessory/storage/bandolier = 1,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/mtf/epsilon_11/leader
 	name = OUTFIT_JOB_NAME("MTF Epsilon-11 Team Leader")
 	uniform = /obj/item/clothing/under/ert
 	suit = /obj/item/clothing/suit/armor/pcarrier/green/scp/mtf_epsilon
-	head = /obj/item/clothing/head/helmet/site53/guard/mtf_epsilon/leader
+	head = /obj/item/clothing/head/helmet/ballistic
 	mask = /obj/item/clothing/mask/balaclava
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
@@ -58,6 +60,7 @@
 	l_hand = null
 	l_pocket = /obj/item/grenade/smokebomb
 	r_pocket = null
+	id_type = /obj/item/card/id/mtf/ninetail
 	belt = /obj/item/storage/belt/holster/security/fullmateba
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/grenade/frag = 1,/obj/item/crowbar/red = 1,/obj/item/ammo_magazine/scp/m16_mag = 3,/obj/item/ammo_magazine/c44 = 4,/obj/item/clothing/mask/gas = 1)
 
@@ -65,7 +68,7 @@
 	name = OUTFIT_JOB_NAME("MTF Epsilon-11 Medic")
 	uniform = /obj/item/clothing/under/ert
 	suit = /obj/item/clothing/suit/armor/pcarrier/green/scp/mtf_epsilon
-	head = /obj/item/clothing/head/helmet/site53/guard/mtf_epsilon/medic
+	head = /obj/item/clothing/head/helmet/ballistic
 	mask = /obj/item/clothing/mask/balaclava
 	glasses = /obj/item/clothing/glasses/night
 	gloves = /obj/item/clothing/gloves/tactical/scp
@@ -75,6 +78,7 @@
 	l_hand = /obj/item/crowbar/red
 	l_pocket = /obj/item/grenade/smokebomb
 	r_pocket = null
+	id_type = /obj/item/card/id/mtf/ninetail
 	belt = /obj/item/defibrillator/compact/combat/loaded
 	backpack_contents = list(/obj/item/ammo_magazine/scp/p90_mag/ap = 3,/obj/item/clothing/mask/gas = 1,/obj/item/reagent_containers/ivbag/blood/OMinus = 2,/obj/item/storage/pill_bottle/zoom = 1)
 
@@ -92,7 +96,7 @@
 	l_hand = /obj/item/material/hatchet/tacknife
 	l_pocket = null
 	r_pocket = /obj/item/ammo_magazine/scp
-	belt = /obj/item/gun/projectile/pistol
+	belt = /obj/item/storage/belt/holster/security/fullmk9
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 1,/obj/item/grenade/frag = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/mtf/beta_7 // Maz Hatters
@@ -109,7 +113,8 @@
 	l_hand = /obj/item/material/hatchet/tacknife
 	l_pocket = null
 	r_pocket = /obj/item/ammo_magazine/scp
-	belt = /obj/item/gun/projectile/pistol
+	id_type = /obj/item/card/id/mtf/beta_7
+	belt = /obj/item/storage/belt/holster/security/fullmk9
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/plastique = 1,/obj/item/ammo_magazine/scp/p90_mag/ap = 5,/obj/item/clothing/mask/gas = 1)
 
 /decl/hierarchy/outfit/mtf/nu_7 // Hammer Down
@@ -126,6 +131,7 @@
 	l_hand = null
 	l_pocket = /obj/item/grenade/frag
 	r_pocket = /obj/item/grenade/flashbang/clusterbang //gods must be strong
+	id_type = /obj/item/card/id/mtf/nu_7
 	belt = /obj/item/storage/belt/holster/security/tactical
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/ammo_magazine/scp/m16_mag = 5, /obj/item/plastique = 2, /obj/item/grenade/frag = 1, /obj/item/crowbar/red = 1) //Actual util
 
@@ -143,5 +149,6 @@
 	l_hand = null
 	l_pocket = /obj/item/grenade/frag
 	r_pocket = /obj/item/grenade/flashbang/clusterbang //gods must be strong
+	id_type = /obj/item/card/id/mtf/alpha
 	belt = /obj/item/storage/belt/holster/security/tactical
 	backpack_contents = list(/obj/item/storage/box/ifak = 1,/obj/item/ammo_magazine/t12 = 5, /obj/item/plastique = 2, /obj/item/grenade/frag = 5, /obj/item/crowbar/red = 1) //Breach and clear.

--- a/code/game/objects/items/weapons/SCP/armor.dm
+++ b/code/game/objects/items/weapons/SCP/armor.dm
@@ -4,9 +4,8 @@
 /obj/item/clothing/suit/armor/pcarrier/scp/tactical
 	starting_accessories = list(/obj/item/clothing/accessory/armorplate/tactical, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/scp, /obj/item/clothing/accessory/armguards, /obj/item/clothing/accessory/legguards)
 
-
 /obj/item/clothing/suit/armor/pcarrier/green/scp/mtf_epsilon
-	starting_accessories = list(/obj/item/clothing/accessory/storage/pouches/green)
+	starting_accessories = list(/obj/item/clothing/accessory/armorplate/tactical/mtf, /obj/item/clothing/accessory/storage/pouches, /obj/item/clothing/accessory/armor/tag/scp, /obj/item/clothing/accessory/armguards, /obj/item/clothing/accessory/legguards, /obj/item/clothing/accessory/storage/pouches/green)
 
 /obj/item/clothing/suit/armor/vest/scp
 	w_class = ITEM_SIZE_HUGE

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -636,10 +636,35 @@
 	icon_state = "adminlvl5"
 	item_state = "Admin_ID"
 
+/obj/item/card/id/mtf/ninetail
+	name = "mobile task force ID"
+	desc = "A black ID. Looks like the person wearing this won't give it up easy."
+	assignment = "Epsilon-11 Task Force Operative"
+
+/obj/item/card/id/mtf/nu_7
+	name = "mobile task force ID"
+	desc = "A black ID. Looks like the person wearing this won't give it up easy."
+	assignment = "Nu-7 Task Force Operative"
+
+/obj/item/card/id/mtf/beta_7
+	name = "mobile task force ID"
+	desc = "A black ID. Looks like the person wearing this won't give it up easy."
+	assignment = "beta_7 Task Force Operative"
+
+/obj/item/card/id/mtf/alpha
+	name = "mobile task force ID"
+	desc = "A black ID. Looks like the person wearing this won't give it up easy."
+	assignment = "Alpha-1 Task Force Operative"
+
+/obj/item/card/id/mtf/omega
+	name = "mobile task force ID"
+	desc = "A black ID. Looks like the person wearing this won't give it up easy."
+	assignment = "Omega-1 Task Force Operative"
+
 /obj/item/card/id/mtf/Initialize()
 	. = ..()
 	rank = "Mobile Task Force Operative"
-	access |= get_all_station_access()
+	job_access_type = /datum/job/captain
 
 
 /obj/item/card/id/physics

--- a/code/modules/clothing/under/accessories/armor.dm
+++ b/code/modules/clothing/under/accessories/armor.dm
@@ -118,6 +118,19 @@
 		)
 	slowdown = 0.5
 
+/obj/item/clothing/accessory/armorplate/tactical/mtf
+	name = "mtf tactical armor plate"
+	desc = "A heavier armor plate with additional ablative coating. Attaches to a plate carrier. This one is specialized for MTF units."
+	icon_state = "armor_tactical"
+	armor = list(
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_RESISTANT,
+		laser = ARMOR_LASER_MAJOR,
+		energy = ARMOR_ENERGY_RESISTANT,
+		bomb = ARMOR_BOMB_PADDED
+		)
+	slowdown = 0
+	
 /obj/item/clothing/accessory/armorplate/merc
 	name = "heavy armor plate"
 	desc = "A ceramics-reinforced synthetic armor plate, providing state of of the art protection. Attaches to a plate carrier."


### PR DESCRIPTION
Fixes GOC uniforms
Fixes Ninetailed Fox dressups
Adds Belts to MTF
Adds IDs with actual assignments to MTF, so no more guessing which MTF arrived or whomst it came from.

## Changelog

:cl:
add: Adds IDs with actual assignments to MTF, so no more guessing which MTF arrived or whomst it came from.
add: Adds pistolbelts to MTF
balance: adds a custom variant of tactical plates for MTF with no slowdown.
fix: Fixes GOC uniforms
fix: Fixes Ninetailed Fox dressups
/:cl:

