### PR TITLE
Ossarepantes tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/medicines/medicines_core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/medicines/medicines_core.dm
@@ -285,8 +285,8 @@
 	var/mob/living/carbon/human/H = M
 	for(var/obj/item/organ/external/E in H.organs)
 		if(E.status & ORGAN_BROKEN)
-			E.status &= ~ORGAN_BROKEN
 			playsound(H, 'sounds/effects/wounds/bonebreak1.ogg', 25, TRUE)
-			E.take_external_damage(35)
+			E.take_external_damage(20)
+			E.status &= ~ORGAN_BROKEN
 			H.custom_pain(SPAN_WARNING("You feel bones in your [E.name] move!"), 50, TRUE, E)
 			break


### PR DESCRIPTION
## About the Pull Request

Closes #1438 

- Damage done to the limb reduced to 20, from 35.
- Damage from fixing a bone is done *before* bone is restored.

## Why It's Good For The Game

- Ossarepantes was initially balanced for Tegu, where limbs have nearly twice the health. This makes it less dangerous.
- Prevents people from being locked into eternal loop of suffering (Fix bone - Deal damage - Bone breaks due to damage - REPEAT AD INFINITUM).

## Changelog

:cl:
tweak: Ossarepantes no longer locks you into a loop of bone-breaking. It is now safe to use for its purpose.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
