### PR TITLE
Fixes item pickup ghost effect

### DIFF
--- a/code/game/objects/effects/item_pickup_ghost.dm
+++ b/code/game/objects/effects/item_pickup_ghost.dm
@@ -1,11 +1,11 @@
-/obj/effect/temp_visual/temporary/item_pickup_ghost
+/obj/effect/temp_visual/item_pickup_ghost
 	duration = 0.2 SECONDS
 
 /obj/effect/temp_visual/item_pickup_ghost/Initialize(mapload, obj/item/picked_up)
 	. = ..()
 	appearance = picked_up.appearance
 
-/obj/effect/temp_visual/temporary/item_pickup_ghost/proc/animate_towards(atom/target)
+/obj/effect/temp_visual/item_pickup_ghost/proc/animate_towards(atom/target)
 	var/new_pixel_x = pixel_x + (target.x - src.x) * 32
 	var/new_pixel_y = pixel_y + (target.y - src.y) * 32
 	animate(src, pixel_x = new_pixel_x, pixel_y = new_pixel_y, transform = matrix()*0, time = duration)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -246,7 +246,7 @@
 
 	if(user.put_in_active_hand(src))
 		if (isturf(old_loc))
-			var/obj/effect/temp_visual/temporary/item_pickup_ghost/ghost = new(old_loc, src)
+			var/obj/effect/temp_visual/item_pickup_ghost/ghost = new(old_loc, src)
 			ghost.animate_towards(user)
 		if(randpixel)
 			pixel_x = rand(-randpixel, randpixel)


### PR DESCRIPTION
## About the Pull Request

Fixes wrong typepath of the item pickup ghost (the effect that shows when item is being picked up).

## Why It's Good For The Game

Fixes the runtime and brings back the neat effect.

## Changelog

:cl:
fix: When picked up, items will leave behind a tiny effect of the item being taken.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
