### PR TITLE
Ports magazine quickload

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -197,6 +197,38 @@
 	stored_ammo -= A
 	update_icon()
 
+/obj/item/ammo_magazine/afterattack(atom/target, mob/living/user, proximity_flag)
+	if(!proximity_flag || (!istype(target, /turf) && !istype(target, /obj/item/ammo_casing)))
+		return ..()
+
+	var/turf/T = istype(target, /turf) ? target : get_turf(target)
+	if(istype(target, /turf))
+		if(!locate(/obj/item/ammo_casing) in T)
+			return ..()
+
+	var/curr_ammo = length(stored_ammo)
+	if(curr_ammo >= max_ammo)
+		to_chat(user, "<span class='warning'>[src] is full!</span>")
+		return
+
+	to_chat(user, SPAN_NOTICE("You begin inserting casings into \the [src]..."))
+	if(!do_after(user, (max_ammo - curr_ammo) * 2, src))
+		return
+
+	for(var/obj/item/ammo_casing/C in T)
+		if(stored_ammo.len >= max_ammo)
+			break
+		if(C.caliber != caliber)
+			continue
+		stored_ammo.Add(C)
+		C.forceMove(src)
+
+	if(length(stored_ammo) - curr_ammo)
+		to_chat(user, SPAN_NOTICE("You insert [length(stored_ammo) - curr_ammo] casings into \the [src]."))
+		update_icon()
+	else
+		to_chat(user, SPAN_WARNING("You fail to collect any casings!"))
+
 /obj/item/ammo_magazine/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/ammo_casing))
 		var/obj/item/ammo_casing/C = W
@@ -236,13 +268,19 @@
 	if(!stored_ammo.len)
 		to_chat(user, SPAN_NOTICE("[src] is already empty!"))
 		return
+	if(!do_after(user, 10, src))
+		return
 	to_chat(user, SPAN_NOTICE("You empty [src]."))
+	var/curr_sounds = 0
+	var/max_sounds = clamp(round(length(stored_ammo) * 0.2), 1, 10)
 	for(var/obj/item/ammo_casing/C in stored_ammo)
 		C.forceMove(user.loc)
 		C.set_dir(pick(GLOB.alldirs))
+		if(LAZYLEN(C.fall_sounds) && curr_sounds < max_sounds)
+			playsound(user.loc, pick(C.fall_sounds), 20, TRUE)
+			curr_sounds += 1
 	stored_ammo.Cut()
 	update_icon()
-
 
 /obj/item/ammo_magazine/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)


### PR DESCRIPTION
## About the Pull Request

Ports vlggms/tegustation-bay12/pull/493

- Clicking with magazine on a turf or casing will load all casings in the turfs that can be loaded;
- Fully unloading magazine now has do after and plays casing drop sounds.

## Why It's Good For The Game

- Quality Of Life;
- Prevents mistakes, plays silly sounds.

## Changelog

:cl:
tweak: You can now collect all casings from a turf with a magazine. Click on a turf or casing to do so.
tweak: Fully unloading magazine takes 1 second to prevent accidents. Additionally, it plays casing drop sounds now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
