### PR TITLE
Removes spray from 049s containment

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -40,6 +40,7 @@
 	)
 
 	SCP.min_time = 10 MINUTES
+	SCP.min_playercount = 20
 
 	add_verb(src, list(
 		/mob/living/carbon/human/scp049/verb/greetings,

--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -40,7 +40,6 @@
 	)
 
 	SCP.min_time = 10 MINUTES
-	SCP.min_playercount = 20
 
 	add_verb(src, list(
 		/mob/living/carbon/human/scp049/verb/greetings,

--- a/maps/site53/site53-1.dmm
+++ b/maps/site53/site53-1.dmm
@@ -17333,11 +17333,11 @@
 /area/site53/lhcz/scp049containment)
 "PH" = (
 /obj/item/clothing/gloves/latex/nitrile,
-/obj/item/reagent_containers/spray/cleaner,
 /obj/item/clothing/suit/surgicalapron,
 /obj/item/clothing/mask/surgical,
 /obj/structure/table/rack,
 /obj/item/defibrillator/loaded,
+/obj/item/reagent_containers/glass/rag,
 /turf/simulated/floor/tiled/old_tile,
 /area/site53/lhcz/scp049containment)
 "PI" = (


### PR DESCRIPTION
## About the Pull Request
This is a pr made in preparation for Egors buff which would make 049 a proper self breacher and wouldnt need to rely on melting others equipment off with acid sprays
**ONLY MERGE AFTER EGORS PR IS MERGED**
A very minor pr so 049 does not melt off every guards equipment then one shots them at hyperspeed or self breach on lowpop where no one can stop him in time
<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As pointed out above 049 once Egors buff is merged into the game it will lead to issues, 049 requires no pop to be played and would immediately breach at the 25 minute mark every round due to lack of HCZ guards if this is merged.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
Replaces 049s spray within medical storage with a damp rag, makes him require 20 pop to play like other self breachers.
:cl:
add: Added a damp rag to 049's medical storage.
del: Removed reagent spray bottle from 049's medical storage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
