### PR TITLE
Automatic e-mail login

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -20,6 +20,14 @@
 	hard_drive.store_file(new /datum/computer_file/program/upload_database_c())
 	set_autorun("emailc")
 
+	var/mob/living/carbon/human/H = get_holder_of_type(src, /mob)
+	if(istype(H))
+		if(H.mind?.initial_email_login)
+			var/datum/computer_file/program/email_client/e_client = hard_drive.find_file_by_name("emailc")
+
+			if(e_client && istype(e_client))
+				e_client.stored_login = H.mind.initial_email_login["login"]
+				e_client.stored_password = H.mind.initial_email_login["password"]
 
 /obj/item/modular_computer/pda/medical/install_default_hardware()
 	..()


### PR DESCRIPTION
## About the Pull Request

When spawning in, your PDA will start automatically logged in to your e-mail account, if possible.

## Why It's Good For The Game

With the radio removals and SCiPnet expansion, this'll ensure we'll see fewer people who never actually check their e-mail.

## Changelog

:cl:
qol: Roundstart/latejoin PDAs now start with the e-mail program logged in, if possible.
/:cl: