### PR TITLE
Spiderling change

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -20,6 +20,21 @@
 				qdel(src)
 	return
 
+/obj/effect/spider/spiderling/attack_hand(mob/living/carbon/human/user)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+
+	if(user.a_intent == I_HURT)
+		if(prob(50))
+			user.visible_message(SPAN_WARNING("\the [user] has missed \the [src]"))
+			disturbed()
+		else
+			user.visible_message(SPAN_WARNING("\the [src] has been squashed by \the [user]"))
+			die()
+		return
+	return
+
+
+
 /obj/effect/spider/attackby(obj/item/W, mob/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 


### PR DESCRIPTION
gives players a 50% chance to kill spiderlings while on harm intent with their bare hands

## About the Pull Request

 A simple line of code allowing players to kill spiderlings while on harm intent. It does have a 50% chance to miss so the spiderling still has a chance to get away. 

## Why It's Good For The Game

 squash spooder 

## Changelog

:cl:
add: Squishing spiderlings
qol: made it easier to squish spiderlings
balance: balanced spiderlings by allowing them to be squished
fix: fixed spiderlings not being able to be squished



<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->


