### PR TITLE
Fixes ZC Fax names and Security levels

### DIFF
--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -20074,8 +20074,8 @@
 /area/site53/llcz/checkequip)
 "bko" = (
 /obj/machinery/photocopier/faxmachine{
-	department = "LCZ Zone Commander's Office";
-	send_access = list(204)
+	department = "LCZ Commander's Office";
+	send_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/red/border{
@@ -33985,7 +33985,7 @@
 	},
 /obj/structure/table/standard,
 /obj/machinery/photocopier/faxmachine{
-	department = "Heavy Containment Zone Commander";
+	department = "HCZ Commander's Office";
 	send_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /turf/simulated/floor/tiled/dark,

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -6684,8 +6684,8 @@
 /area/site53/uez/senioragentoffice)
 "KS" = (
 /obj/machinery/photocopier/faxmachine{
-	department = "Guard Commander's Office";
-	send_access = list("ACCESS_SECURITY_LEVEL5")
+	department = "EZ Commander's Office";
+	send_access = list("ACCESS_SECURITY_LEVEL4")
 	},
 /obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark,


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Updates all ZC Fax Department names as well as standardizing the security to level 4. 

## Why It's Good For The Game

Naming conventions should generally be standardized to avoid confusion; as well as generally providing a difference between the EZ Commander FAX and the GC. 

All zone commanders have security level 4 access on their cards, none of them have level 5. The LCZ ZC and EZ ZC can now access their own fax machines.

Resolves #1311 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
Update: Changes the LCZ ZC FAX to Security LVL 4, updates the name to LCZ Commander's Office.
Update: Updates the name of the HCZ ZC FAX to HCZ Commander's Office.
Update: Changes the EZ ZC FAX to Security LVL 4, updates the name to EZ Commander's Office (instead of a duplicate of "Guard Commander's Office".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
