### PR TITLE
Updates EZ SecTech to proper security level.

### DIFF
--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -5408,9 +5408,11 @@
 /turf/simulated/floor/wood,
 /area/site53/uez/canteen)
 "zQ" = (
-/obj/machinery/vending/security,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/vending/security{
+	req_access = list("ACCESS_SECURITY_LEVEL2")
 	},
 /turf/simulated/floor/tiled/dark,
 /area/site53/uez/equipmentroom)


### PR DESCRIPTION
## About the Pull Request

The EZ SecTech was stuck on ACCESS_SECURITY, a relic of the past. It was updated to ACCESS_SECURITY_LEVEL2 which all other SecTechs sit at.

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

All security staff can now access the SecTech in the EZ Security Center; whereas none previously could. 

Resolves #1247

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
Fix: Changed security level of EZ Security Center SecTech from ACCESS_SECURITY to ACCESS_SECURITY_LEVEL2, allowing it to be properly accessed by sec staff. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
