### PR TITLE
This should fix some 049 issues

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -5,6 +5,8 @@
 
 	status_flags = NO_ANTAG | SPECIES_FLAG_NO_EMBED
 
+	handcuffs_breakout_time = 20 SECONDS
+
 	//Config
 
 	/// Emote cooldown
@@ -276,9 +278,6 @@
 
 	return ..()
 
-/mob/living/carbon/human/scp049/can_break_cuffs()
-	return TRUE
-
 /mob/living/carbon/human/scp049/GetUnbuckleTime()
 	return 15 SECONDS
 
@@ -439,7 +438,7 @@
 
 	addtimer(CALLBACK(src, PROC_REF(FinishPlagueDoctorCure), target), 15 SECONDS)
 
-/mob/living/carbon/human/proc/FinishPlagueDoctorCure(mob/living/carbon/human/target)
+/mob/living/carbon/human/scp049/proc/FinishPlagueDoctorCure(mob/living/carbon/human/target)
 	if(QDELETED(target))
 		return
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -39,6 +39,7 @@
 	var/stasis_value
 
 	var/player_triggered_sleeping = 0
+	var/handcuffs_breakout_time = 2 MINUTES
 
 	/// Assoc list of addiction values, key is the type of withdrawal (as singleton type), and the value is the amount of addiction points (as number)
 	var/list/addiction_points

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -38,7 +38,7 @@
 	var/obj/item/handcuffs/HC = handcuffed
 
 	//A default in case you are somehow handcuffed with something that isn't an obj/item/handcuffs type
-	var/breakouttime = istype(HC) ? HC.breakouttime : 2 MINUTES
+	var/breakouttime = istype(HC) ? HC.breakouttime : handcuffs_breakout_time
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H) && H.gloves && istype(H.gloves,/obj/item/clothing/gloves/rig))
@@ -55,7 +55,7 @@
 
 	var/stages = 4
 	for(var/i = 1 to stages)
-		if(do_after(src, breakouttime*0.40, incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED, bonus_percentage = 25))
+		if(do_after(src, (breakouttime / stages), incapacitation_flags = INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED, bonus_percentage = 25))
 			if(!handcuffed || buckled)
 				return
 			visible_message(


### PR DESCRIPTION
## About the Pull Request

Title. Additionally, made handcuffs break out time a variable on carbon and set it to 20 seconds for 049, while also fixing some problems (did you know that time to break out was actually higher than intended?)

## Why It's Good For The Game

Fixes!
