### PR TITLE
Fixes orbiting objects when they get deleted

### DIFF
--- a/code/modules/mob/observer/following.dm
+++ b/code/modules/mob/observer/following.dm
@@ -8,7 +8,7 @@
 /mob/observer/proc/stop_following()
 	if(!following)
 		return
-	GLOB.destroyed_event.unregister(following, src)
+	UnregisterSignal(following, COMSIG_PARENT_QDELETING)
 	GLOB.moved_event.unregister(following, src)
 	GLOB.dir_set_event.unregister(following, src)
 	following = null
@@ -16,7 +16,7 @@
 /mob/observer/proc/start_following(atom/a)
 	stop_following()
 	following = a
-	GLOB.destroyed_event.register(a, src, PROC_REF(stop_following))
+	RegisterSignal(a, COMSIG_PARENT_QDELETING, PROC_REF(stop_following))
 	GLOB.moved_event.register(a, src, PROC_REF(keep_following))
 	GLOB.dir_set_event.register(a, src, TYPE_PROC_REF(/atom, recursive_dir_set))
 	keep_following(new_loc = get_turf(following))


### PR DESCRIPTION
## About the Pull Request

vlggms/tegustation-bay12/pull/541

## Why It's Good For The Game

Currently, orbiting someone/something will send you to nullspace if it gets deleted (i.e. gibbed or just deleted).
This Fixes it.

## Changelog

:cl:
fix: You will no longer be sent to nullspace if an object/mob you are orbiting gets deleted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
