### PR TITLE
Fixes custom handcuff breakout times

### DIFF
--- a/code/modules/SCP/SCPs/SCP-049.dm
+++ b/code/modules/SCP/SCPs/SCP-049.dm
@@ -5,7 +5,7 @@
 
 	status_flags = NO_ANTAG | SPECIES_FLAG_NO_EMBED
 
-	handcuffs_breakout_time = 20 SECONDS
+	handcuffs_breakout_modifier = 0.2
 
 	//Config
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -39,7 +39,7 @@
 	var/stasis_value
 
 	var/player_triggered_sleeping = 0
-	var/handcuffs_breakout_time = 2 MINUTES
+	var/handcuffs_breakout_modifier = 1.0
 
 	/// Assoc list of addiction values, key is the type of withdrawal (as singleton type), and the value is the amount of addiction points (as number)
 	var/list/addiction_points

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -38,7 +38,7 @@
 	var/obj/item/handcuffs/HC = handcuffed
 
 	//A default in case you are somehow handcuffed with something that isn't an obj/item/handcuffs type
-	var/breakouttime = istype(HC) ? HC.breakouttime : handcuffs_breakout_time
+	var/breakouttime = istype(HC) ? HC.breakouttime * handcuffs_breakout_modifier : 2 MINUTES * handcuffs_breakout_modifier
 
 	var/mob/living/carbon/human/H = src
 	if(istype(H) && H.gloves && istype(H.gloves,/obj/item/clothing/gloves/rig))


### PR DESCRIPTION
## About the Pull Request

Changes custom breakout time to a modifier, tweaks the code.

## Why It's Good For The Game

I forgot that handcuffs have breakout time defined in them, so 049 edit didn't work as intended. Now mobs have a modifier that works with this instead.
