### PR TITLE
Show_blurb proc fixes

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -546,4 +546,4 @@ SUBSYSTEM_DEF(jobs)
 /proc/show_location_blurb(client/C, duration)
 	var/area/A = get_area(C.mob)
 	var/blurb_text = "[stationdate2text()], [station_time_timestamp("hh:mm")]\n[station_name()], [A.name]"
-	show_blurb(C.mob, duration, blurb_text)
+	show_blurb(C, duration, blurb_text)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -826,7 +826,7 @@ Ccomp's first proc.
 
 	switch(tgui_alert(mob, "Do you wish to send an admin alert to this user?", "Admin Aalert", list("Yes","No","Custom")))
 		if("Yes")
-			show_blurb(M, 15, "An admin is trying to talk to you!<br>Check your chat window and click their name to respond or you may be banned!", null, "center", "center", COLOR_RED, null, null, 1)
+			show_blurb(M.client, 15, "An admin is trying to talk to you!<br>Check your chat window and click their name to respond or you may be banned!", null, "center", "center", COLOR_RED, null, null, 1)
 			log_admin("[key_name(src)] sent a default admin alert to [key_name(M)].")
 			message_staff("[key_name(src)] sent a default admin alert to [key_name(M)].")
 
@@ -839,6 +839,6 @@ Ccomp's first proc.
 			if(!new_color)
 				return
 
-			show_blurb(M, 15, message, null, "center", "center", new_color, null, null, 1)
+			show_blurb(M.client, 15, message, null, "center", "center", new_color, null, null, 1)
 			log_admin("[key_name(src)] sent an admin alert to [key_name(M)] with custom message [message].")
 			message_staff("[key_name(src)] sent an admin alert to [key_name(M)] with custom message [message].")

--- a/maps/away/wizard_den/wizard_den_areas.dm
+++ b/maps/away/wizard_den/wizard_den_areas.dm
@@ -17,7 +17,7 @@
 		return
 
 	var/mob/living/L = A
-	if(!L.ckey)
+	if(!L.ckey || !L.client)
 		return
 
 	if(area_blurb[L.ckey] > world.time)
@@ -26,7 +26,7 @@
 	if(isnull(L.lastarea) || istype(L.lastarea, type))
 		return
 
-	show_blurb(L, 3 SECONDS, name)
+	show_blurb(L.client, 3 SECONDS, name)
 	area_blurb[L.ckey] = world.time + 600 SECONDS
 	return ..()
 


### PR DESCRIPTION
## About the Pull Request

The calls to the show_blurb proc (and the only one that gets called on spawn) were creating runtimes because of incorrect arguments

## Why It's Good For The Game

Blurbs work now

## Changelog

:cl:
fix: Blurbs are now functional
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
