### PR TITLE
Make show player info get age correctly

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -84,7 +84,6 @@ var/global/floorIsLava = 0
 
 
 /datum/admins/proc/show_player_info(key as text)
-
 	set category = "Admin"
 	set name = "Show Player Info"
 	if (!istype(src,/datum/admins))
@@ -96,8 +95,9 @@ var/global/floorIsLava = 0
 	var/list/dat = list()
 
 	var/p_age
+	var/key_c = ckey(key)
 	for(var/client/C in GLOB.clients)
-		if(C.ckey == key)
+		if(C.ckey == ckey(key_c))
 			p_age = C.player_age
 			break
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -97,7 +97,7 @@ var/global/floorIsLava = 0
 	var/p_age
 	var/key_c = ckey(key)
 	for(var/client/C in GLOB.clients)
-		if(C.ckey == ckey(key_c))
+		if(C.ckey == key_c)
 			p_age = C.player_age
 			break
 


### PR DESCRIPTION
## About the Pull Request

This might fix player age: unknown issue for people who are connected to the server
Can't test due to it requiring a DB and I am too lazy to set up maria locally but this is better logic anyway

## Why It's Good For The Game

No player age unknown shenanigans

## Changelog

:cl:
admin: Show Player Info verb/notes should no longer show player age 'unknown' for connected clients
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
