### PR TITLE
Adds override for timelocks for roles already played

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -491,7 +491,7 @@
 
 	jt.update_jobtime()
 	for(var/requirement in requirements)
-		if(max(jt.get_jobtime(requirement), jt.get_jobtime(title) /* allows people who play in the role when timelocks are disabled to earn time for it */) < requirements[requirement])
+		if(Max(jt.get_jobtime(requirement), jt.get_jobtime(title) /* allows people who play in the role when timelocks are disabled to earn time for it */) < requirements[requirement])
 			return FALSE
 
 	return TRUE

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -491,7 +491,7 @@
 
 	jt.update_jobtime()
 	for(var/requirement in requirements)
-		if(Max(jt.get_jobtime(requirement), jt.get_jobtime(title) /* allows people who play in the role when timelocks are disabled to earn time for it */) < requirements[requirement])
+		if(max(jt.get_jobtime(requirement), jt.get_jobtime(title) /* allows people who play in the role when timelocks are disabled to earn time for it */) < requirements[requirement])
 			return FALSE
 
 	return TRUE

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -491,7 +491,7 @@
 
 	jt.update_jobtime()
 	for(var/requirement in requirements)
-		if(jt.get_jobtime(requirement) < requirements[requirement])
+		if(max(jt.get_jobtime(requirement), jt.get_jobtime(title) /* allows people who play in the role when timelocks are disabled to earn time for it */) < requirements[requirement])
 			return FALSE
 
 	return TRUE


### PR DESCRIPTION
## About the Pull Request

Allows timelocks to be overridden by the role itself to allow for individuals who stacked hours when timelocks were disabled to play the roles they put time into.

## Why It's Good For The Game

Makes people happy, makes me tired

## Changelog

:cl:
code: Timelocks will now also accept the time spent in the currently checked role for time reqs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
