### PR TITLE
Proper player age in show info fix

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -101,7 +101,7 @@ var/global/floorIsLava = 0
 			p_age = C.player_age
 			break
 
-	if(!p_age)
+	if(p_age == null)
 		p_age = get_player_age(key)
 
 	dat += "<b>Player age: [p_age ? p_age : "unknown"]</b><br><ul id='notes'>"


### PR DESCRIPTION
## About the Pull Request

Because lest merged the pr early

## Why It's Good For The Game

This will actually fix the issue since player age 0 was falsy

## Changelog

:cl:
admin: Player age in notes is actually fully fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
