### PR TITLE
Right click on occupations to decrement priority

### DIFF
--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -211,7 +211,7 @@
 							level_link = FONT_COLORED("#55cc55","High")
 						else
 							level_link = "<font color=black>Never</font>"
-					. += "<a href='?src=\ref[src];set_job=[title];inc_level=-1'>[level_link]</a>"
+					. += {"<a href='?src=\ref[src];set_job=[title];inc_level=-1' oncontextmenu='window.location.href="?src=\ref[src];set_job=[title];inc_level=1"; return false'>[level_link]</a>"}
 				. += "</td></tr>"
 			. += "</td></tr></table>"
 			. += "</center></table><center>"


### PR DESCRIPTION
## About the Pull Request

tin
tested and working

## Why It's Good For The Game

lets you right click on a role button in the occupations menu to decrement the priority instead of having to keep clicking for the one you want

## Changelog

:cl:
qol: Right clicking role buttons in occupation preferences now does the opposite of left clicking them (i.e. decrementing from high -> medium priority).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
