### PR TITLE
Change almost all timelocks to be department based

### DIFF
--- a/code/game/jobs/job/command.dm
+++ b/code/game/jobs/job/command.dm
@@ -20,7 +20,7 @@
 	access = list()				// see get_access() override
 	minimal_access = list()		// see get_access() override
 
-	requirements = list(EXP_TYPE_COMMAND = 1800)
+	requirements = list(EXP_TYPE_COMMAND = 1200)
 
 /datum/job/captain/get_access()
 	return get_all_site_access()
@@ -77,7 +77,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/command/commsofficer
 	class = CLASS_B
 	hud_icon = "hudcommsofficer"
-	requirements = list("Communications Technician" = 600)
+	requirements = list(EXP_TYPE_ENGINEERING = 600)
 
 	access = list(
 		ACCESS_SCIENCE_LVL1,
@@ -133,7 +133,7 @@
 	economic_power = 5
 	minimal_player_age = 7
 	ideal_character_age = 30
-	requirements = list(EXP_TYPE_ENGINEERING = 300)
+	requirements = list(EXP_TYPE_ENGINEERING = 120)
 	alt_titles = list(
 		"Communications Programmer",
 		"Communications Dispatcher"
@@ -187,7 +187,7 @@
 	minimal_player_age = 5
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/civ/tribunal
-	requirements = list(EXP_TYPE_COMMAND = 600, EXP_TYPE_SECURITY = 600, EXP_TYPE_BUR = 60)
+	requirements = list(EXP_TYPE_COMMAND = 600, EXP_TYPE_SECURITY = 600)
 	class = CLASS_B
 	hud_icon = "hud05rep"
 	access = list(

--- a/code/game/jobs/job/command.dm
+++ b/code/game/jobs/job/command.dm
@@ -20,7 +20,7 @@
 	access = list()				// see get_access() override
 	minimal_access = list()		// see get_access() override
 
-	requirements = list(EXP_TYPE_COMMAND = 1200)
+	requirements = list(EXP_TYPE_COMMAND = 1800)
 
 /datum/job/captain/get_access()
 	return get_all_site_access()
@@ -77,7 +77,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/command/commsofficer
 	class = CLASS_B
 	hud_icon = "hudcommsofficer"
-	requirements = list(EXP_TYPE_ENGINEERING = 600)
+	requirements = list("Communications Technician" = 360)
 
 	access = list(
 		ACCESS_SCIENCE_LVL1,
@@ -133,7 +133,7 @@
 	economic_power = 5
 	minimal_player_age = 7
 	ideal_character_age = 30
-	requirements = list(EXP_TYPE_ENGINEERING = 120)
+	requirements = list(EXP_TYPE_ENGINEERING = 300)
 	alt_titles = list(
 		"Communications Programmer",
 		"Communications Dispatcher"
@@ -179,7 +179,7 @@
 	title = "Internal Tribunal Department Officer"
 	department = "Civilian"
 	selection_color = "#2f2f7f"
-	department_flag = COM
+	department_flag = COM|BUR
 	total_positions = 1
 	spawn_positions = 1
 	supervisors = "The Tribunal Department"
@@ -187,7 +187,7 @@
 	minimal_player_age = 5
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/civ/tribunal
-	requirements = list(EXP_TYPE_COMMAND = 600, EXP_TYPE_SECURITY = 600)
+	requirements = list(EXP_TYPE_COMMAND = 600, EXP_TYPE_SECURITY = 600, EXP_TYPE_BUR = 60)
 	class = CLASS_B
 	hud_icon = "hud05rep"
 	access = list(
@@ -229,7 +229,7 @@
 /datum/job/goirep
 	title = "Global Occult Coalition Representative"
 	department = "Command"
-	department_flag = REP
+	department_flag = REP|BUR
 	selection_color = "#2f2f7f"
 	supervisors = "Your respective Group of Interest leaders"
 	total_positions = 1
@@ -242,6 +242,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/civ/gocrep
 	class = CLASS_A
 	hud_icon = "hudgoi"
+	requirements = list(EXP_TYPE_BUR = 30)
 
 	access = list(
 		ACCESS_COM_COMMS,

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -92,7 +92,7 @@
 	economic_power = 5
 	minimal_player_age = 7
 	ideal_character_age = 30
-	requirements = list(EXP_TYPE_ENGINEERING = 120)
+	requirements = list(EXP_TYPE_ENGINEERING = 480)
 	alt_titles = list(
 		"Senior Maintenance Technician",
 		"Senior Engine Technician",
@@ -145,7 +145,7 @@
 	minimal_player_age = 10
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/engineering/conteng
-	requirements = list(EXP_TYPE_ENGINEERING = 360)
+	requirements = list(EXP_TYPE_ENGINEERING = 600)
 	class = CLASS_B
 	hud_icon = "hudcontainmentengineer"
 
@@ -228,7 +228,7 @@
 	economic_power = 9
 	ideal_character_age = 35
 	minimal_player_age = 20
-	requirements = list(EXP_TYPE_ENGINEERING = 840)
+	requirements = list(EXP_TYPE_ENGINEERING = 1200)
 	outfit_type = /decl/hierarchy/outfit/job/command/chief_engineer
 	class = CLASS_A
 	hud_icon = "hudchiefengineer"
@@ -287,7 +287,7 @@
 	economic_power = 4
 	minimal_player_age = 3
 	ideal_character_age = 30
-	requirements = list(EXP_TYPE_ENGINEERING = 60)
+	requirements = list(EXP_TYPE_ENGINEERING = 120)
 	outfit_type = /decl/hierarchy/outfit/job/engineering/it_tech
 	class = CLASS_B
 	hud_icon = "hudittech"

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -92,7 +92,7 @@
 	economic_power = 5
 	minimal_player_age = 7
 	ideal_character_age = 30
-	requirements = list("Engineer" = 480)
+	requirements = list(EXP_TYPE_ENGINEERING = 120)
 	alt_titles = list(
 		"Senior Maintenance Technician",
 		"Senior Engine Technician",
@@ -145,7 +145,7 @@
 	minimal_player_age = 10
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/engineering/conteng
-	requirements = list("Engineer" = 480, EXP_TYPE_ENGINEERING = 600)
+	requirements = list(EXP_TYPE_ENGINEERING = 360)
 	class = CLASS_B
 	hud_icon = "hudcontainmentengineer"
 
@@ -228,7 +228,7 @@
 	economic_power = 9
 	ideal_character_age = 35
 	minimal_player_age = 20
-	requirements = list("Senior Engineer" = 480, EXP_TYPE_ENGINEERING = 1200)
+	requirements = list(EXP_TYPE_ENGINEERING = 840)
 	outfit_type = /decl/hierarchy/outfit/job/command/chief_engineer
 	class = CLASS_A
 	hud_icon = "hudchiefengineer"
@@ -287,7 +287,7 @@
 	economic_power = 4
 	minimal_player_age = 3
 	ideal_character_age = 30
-	requirements = list("Engineer" = 180, EXP_TYPE_ENGINEERING = 300)
+	requirements = list(EXP_TYPE_ENGINEERING = 60)
 	outfit_type = /decl/hierarchy/outfit/job/engineering/it_tech
 	class = CLASS_B
 	hud_icon = "hudittech"

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	department = "Medical"
 	department_flag = MED|COM
 	selection_color = "#026865"
-	requirements = list("Surgeon" = 60, "Medical Doctor" = 120, EXP_TYPE_MEDICAL = 1200)
+	requirements = list(EXP_TYPE_MEDICAL = 840)
 
 	head_position = 1
 	total_positions = 1
@@ -173,7 +173,7 @@
 	spawn_positions = 3
 	ideal_character_age = 30
 	economic_power = 5
-	requirements = list("Medical Doctor" = 480)
+	requirements = list(EXP_TYPE_MEDICAL = 180)
 	supervisors = "the Chief Medical Officer"
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/medical/surgeon
@@ -214,7 +214,7 @@
 	spawn_positions = 4
 	ideal_character_age = 40
 	economic_power = 5
-	requirements = list("Medical Doctor" = 480)
+	requirements = list(EXP_TYPE_MEDICAL = 60)
 	//duties = "<big><b>As the EMT it is your job to man the medical post near the Class D cell block, and treat any injuries there of the guards or Class D's. You only have limited supplies, so it's best to make them count.</b></big>"
 	supervisors = "the Chief Medical Officer"
 	outfit_type = /decl/hierarchy/outfit/job/medical/emt

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,7 +12,7 @@
 	department = "Medical"
 	department_flag = MED|COM
 	selection_color = "#026865"
-	requirements = list(EXP_TYPE_MEDICAL = 840)
+	requirements = list(EXP_TYPE_MEDICAL = 1200)
 
 	head_position = 1
 	total_positions = 1
@@ -173,7 +173,7 @@
 	spawn_positions = 3
 	ideal_character_age = 30
 	economic_power = 5
-	requirements = list(EXP_TYPE_MEDICAL = 180)
+	requirements = list(EXP_TYPE_MEDICAL = 480)
 	supervisors = "the Chief Medical Officer"
 	minimal_player_age = 3
 	outfit_type = /decl/hierarchy/outfit/job/medical/surgeon
@@ -214,7 +214,7 @@
 	spawn_positions = 4
 	ideal_character_age = 40
 	economic_power = 5
-	requirements = list(EXP_TYPE_MEDICAL = 60)
+	requirements = list(EXP_TYPE_MEDICAL = 120)
 	//duties = "<big><b>As the EMT it is your job to man the medical post near the Class D cell block, and treat any injuries there of the guards or Class D's. You only have limited supplies, so it's best to make them count.</b></big>"
 	supervisors = "the Chief Medical Officer"
 	outfit_type = /decl/hierarchy/outfit/job/medical/emt

--- a/code/game/jobs/job/research.dm
+++ b/code/game/jobs/job/research.dm
@@ -163,7 +163,7 @@
 	spawn_positions = 3
 	supervisors = "the Research Director"
 	economic_power = 4
-	requirements = list("Researcher" = 480)
+	requirements = list(EXP_TYPE_SCIENCE = 120)
 	alt_titles = list("Senior Xenobiologist", "Senior Xenoarcheologist", "Senior Xenobotanist", "Mentalist")
 	minimal_player_age = 7
 	ideal_character_age = 30
@@ -206,7 +206,7 @@
 	spawn_positions = 2
 	supervisors = "the Research Director"
 	economic_power = 4
-	requirements = list("Robotics Technician" = 480)
+	requirements = list(EXP_TYPE_SCIENCE = 120)
 	alt_titles = list("Senior Exoskeleton Technician", "Senior Hardsuit Technician")
 	minimal_player_age = 7
 	ideal_character_age = 30
@@ -248,7 +248,7 @@
 	spawn_positions = 1
 	supervisors = "the Research Director"
 	economic_power = 4
-	requirements = list("Researcher" = 480)
+	requirements = list(EXP_TYPE_SCIENCE = 120)
 	alt_titles = list("Senior Mentalist")
 	minimal_player_age = 10
 	ideal_character_age = 35
@@ -296,7 +296,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	economic_power = 15
-	requirements = list("Senior Researcher" = 240, EXP_TYPE_SCIENCE = 900)
+	requirements = list(EXP_TYPE_SCIENCE = 840)
 	req_admin_notify = 1
 	supervisors = "the Site Director"
 	alt_titles = list("Chief Science Officer", "Head Researcher")

--- a/code/game/jobs/job/research.dm
+++ b/code/game/jobs/job/research.dm
@@ -163,7 +163,7 @@
 	spawn_positions = 3
 	supervisors = "the Research Director"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SCIENCE = 120)
+	requirements = list(EXP_TYPE_SCIENCE = 480)
 	alt_titles = list("Senior Xenobiologist", "Senior Xenoarcheologist", "Senior Xenobotanist", "Mentalist")
 	minimal_player_age = 7
 	ideal_character_age = 30
@@ -206,7 +206,7 @@
 	spawn_positions = 2
 	supervisors = "the Research Director"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SCIENCE = 120)
+	requirements = list(EXP_TYPE_SCIENCE = 480)
 	alt_titles = list("Senior Exoskeleton Technician", "Senior Hardsuit Technician")
 	minimal_player_age = 7
 	ideal_character_age = 30
@@ -248,7 +248,7 @@
 	spawn_positions = 1
 	supervisors = "the Research Director"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SCIENCE = 120)
+	requirements = list(EXP_TYPE_SCIENCE = 480)
 	alt_titles = list("Senior Mentalist")
 	minimal_player_age = 10
 	ideal_character_age = 35
@@ -296,7 +296,7 @@
 	total_positions = 1
 	spawn_positions = 1
 	economic_power = 15
-	requirements = list(EXP_TYPE_SCIENCE = 840)
+	requirements = list(EXP_TYPE_SCIENCE = 900)
 	req_admin_notify = 1
 	supervisors = "the Site Director"
 	alt_titles = list("Chief Science Officer", "Head Researcher")

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -8,7 +8,7 @@
 	supervisors = "the Site Director"
 	req_admin_notify = 1
 	economic_power = 10
-	requirements = list(EXP_TYPE_SECURITY = 840, EXP_TYPE_COMMAND = 120)
+	requirements = list("LCZ Zone Commander" = 240, "HCZ Zone Commander" = 240, "EZ Supervisor" = 240)
 	total_positions = 1
 	spawn_positions = 1
 	alt_titles = list("Security Chief", "Head of Security")
@@ -71,7 +71,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You also carry the responsibility of guarding the D-Cells. You should not leave your zone under usual SoP</b></big>"
 	supervisors = "the Guard Commander"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SECURITY = 420)
+	requirements = list(EXP_TYPE_LCZ = 900)
 	minimal_player_age = 10
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/security/lcz_zone_commander
@@ -116,7 +116,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You should not leave your zone under usual SoP</b></big>"
 	supervisors = "the Guard Commander"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SECURITY = 600)
+	requirements = list(EXP_TYPE_HCZ = 900)
 	minimal_player_age = 10
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/security/hcz_zone_commander
@@ -162,7 +162,7 @@
 	//duties = "<big><b>As the Entrance Zone Senior Agent, you and your team work independently from the guard commander and regular security structure. In this zone, you are tasked with the protection of administrative personnel, together with the agents stationed here. You should not leave your zone under usual SoP, or allow administration to go without protection detail into the facility.</b></big>"
 	supervisors = "the Guard Commander"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SECURITY = 420)
+	requirements = list(EXP_TYPE_ECZ = 900)
 	minimal_player_age = 10
 	ideal_character_age = 27
 	outfit_type = /decl/hierarchy/outfit/job/security/ez_zone_commander
@@ -221,7 +221,7 @@
 	//duties = "<big><b>As the Guard you have more access than a Junior Guard, but do not control them. You are to guard tests and SCP's in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the LCZ Zone Commander"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SECURITY = 180)
+	requirements = list(EXP_TYPE_LCZ = 480)
 	alt_titles = list("LCZ Senior Containment Response Agent", "LCZ Containment Response Sergeant", "LCZ Senior Combat Medic" = /decl/hierarchy/outfit/job/security/lcz_medic, "LCZ Riot Control Sergeant" = /decl/hierarchy/outfit/job/security/lcz_riot, "LCZ Senior Riot Control Agent" = /decl/hierarchy/outfit/job/security/lcz_riot, "LCZ Senior Agent")
 	minimal_player_age = 5
 	ideal_character_age = 25
@@ -268,7 +268,7 @@
 	//duties = "<big><b>As the Guard you have more access than a Junior Guard, but do not control them. You are to guard tests and SCP's in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the HCZ Zone Commander"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SECURITY = 240)
+	requirements = list(EXP_TYPE_HCZ = 480)
 	alt_titles = list("HCZ Senior Containment Response Agent", "HCZ Containment Response Sergeant", "HCZ Senior Combat Medic", "HCZ Senior Agent")
 	minimal_player_age = 5
 	ideal_character_age = 25
@@ -312,7 +312,7 @@
 	//duties = "<big><b>As the Agent you have more access than a Junior Agent, but do not control them. You are to guard tests and SCP's in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the EZ Supervisor"
 	economic_power = 4
-	requirements = list(EXP_TYPE_SECURITY = 180)
+	requirements = list(EXP_TYPE_ECZ = 480)
 	alt_titles = list("Investigation Officer" = /decl/hierarchy/outfit/job/security/ez_sergeant_investigative, "EZ Senior Combat Medic" = /decl/hierarchy/outfit/job/security/ez_medic)
 	minimal_player_age = 5
 	ideal_character_age = 25
@@ -365,7 +365,7 @@
 	//duties = "<big><b>As the Junior Guard you have minimal access. You are to guard tests, SCP's and provide support in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the LCZ Sergeants and Zone Commander"
 	economic_power = 4
-	requirements = list("Class D" = 60)
+	requirements = list("Class D" = 30)
 	alt_titles = list("LCZ Containment Response Agent", "LCZ Containment Response Guard", "LCZ Combat Medic" = /decl/hierarchy/outfit/job/security/lcz_medic, "LCZ Riot Control Guard" = /decl/hierarchy/outfit/job/security/lcz_riot, "LCZ Riot Control Agent" = /decl/hierarchy/outfit/job/security/lcz_riot, "LCZ Agent")
 	minimal_player_age = 0
 	ideal_character_age = 25
@@ -458,7 +458,7 @@
 	//duties = "<big><b>As the Junior Agent you have minimal access. You are to guard tests, SCP's and provide support in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the EZ Senior Agents and Supervisor"
 	economic_power = 4
-	requirements = list("Class D" = 60)
+	requirements = list("Class D" = 30)
 	alt_titles = list("Investigation Agent" = /decl/hierarchy/outfit/job/security/ez_guard_investigative, "EZ Combat Medic" = /decl/hierarchy/outfit/job/security/ez_medic)
 	minimal_player_age = 0
 	ideal_character_age = 25
@@ -505,7 +505,7 @@
 	spawn_positions = 1
 	supervisors = "the EZ Supervisor"
 	economic_power = 5
-	requirements = list(EXP_TYPE_COMMAND = 120, EXP_TYPE_SECURITY = 180, EXP_TYPE_ENGINEERING = 60)
+	requirements = list(EXP_TYPE_COMMAND = 120, EXP_TYPE_SECURITY = 180, EXP_TYPE_ENGINEERING = 90, EXP_TYPE_BUR = 60)
 	alt_titles = list()
 	minimal_player_age = 7
 	ideal_character_age = 25

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -8,7 +8,7 @@
 	supervisors = "the Site Director"
 	req_admin_notify = 1
 	economic_power = 10
-	requirements = list("LCZ Zone Commander" = 300, "HCZ Zone Commander" = 300, "EZ Supervisor" = 300)
+	requirements = list(EXP_TYPE_SECURITY = 840, EXP_TYPE_COMMAND = 120)
 	total_positions = 1
 	spawn_positions = 1
 	alt_titles = list("Security Chief", "Head of Security")
@@ -71,7 +71,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You also carry the responsibility of guarding the D-Cells. You should not leave your zone under usual SoP</b></big>"
 	supervisors = "the Guard Commander"
 	economic_power = 4
-	requirements = list("LCZ Sergeant" = 240, EXP_TYPE_LCZ = 900)
+	requirements = list(EXP_TYPE_SECURITY = 420)
 	minimal_player_age = 10
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/security/lcz_zone_commander
@@ -116,7 +116,7 @@
 	//duties = "<big><b>As the Zone Commander, you're the right hand of the Guard Commander, and in charge of a specific zone. In this zone, you have full command of the guards stationed there in every situation, except Code Red or higher. You should not leave your zone under usual SoP</b></big>"
 	supervisors = "the Guard Commander"
 	economic_power = 4
-	requirements = list("HCZ Sergeant" = 240, EXP_TYPE_HCZ = 900)
+	requirements = list(EXP_TYPE_SECURITY = 600)
 	minimal_player_age = 10
 	ideal_character_age = 30
 	outfit_type = /decl/hierarchy/outfit/job/security/hcz_zone_commander
@@ -162,7 +162,7 @@
 	//duties = "<big><b>As the Entrance Zone Senior Agent, you and your team work independently from the guard commander and regular security structure. In this zone, you are tasked with the protection of administrative personnel, together with the agents stationed here. You should not leave your zone under usual SoP, or allow administration to go without protection detail into the facility.</b></big>"
 	supervisors = "the Guard Commander"
 	economic_power = 4
-	requirements = list("EZ Senior Agent" = 240, EXP_TYPE_ECZ = 900)
+	requirements = list(EXP_TYPE_SECURITY = 420)
 	minimal_player_age = 10
 	ideal_character_age = 27
 	outfit_type = /decl/hierarchy/outfit/job/security/ez_zone_commander
@@ -221,7 +221,7 @@
 	//duties = "<big><b>As the Guard you have more access than a Junior Guard, but do not control them. You are to guard tests and SCP's in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the LCZ Zone Commander"
 	economic_power = 4
-	requirements = list("LCZ Guard" = 480)
+	requirements = list(EXP_TYPE_SECURITY = 180)
 	alt_titles = list("LCZ Senior Containment Response Agent", "LCZ Containment Response Sergeant", "LCZ Senior Combat Medic" = /decl/hierarchy/outfit/job/security/lcz_medic, "LCZ Riot Control Sergeant" = /decl/hierarchy/outfit/job/security/lcz_riot, "LCZ Senior Riot Control Agent" = /decl/hierarchy/outfit/job/security/lcz_riot, "LCZ Senior Agent")
 	minimal_player_age = 5
 	ideal_character_age = 25
@@ -268,7 +268,7 @@
 	//duties = "<big><b>As the Guard you have more access than a Junior Guard, but do not control them. You are to guard tests and SCP's in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the HCZ Zone Commander"
 	economic_power = 4
-	requirements = list("HCZ Guard" = 480)
+	requirements = list(EXP_TYPE_SECURITY = 240)
 	alt_titles = list("HCZ Senior Containment Response Agent", "HCZ Containment Response Sergeant", "HCZ Senior Combat Medic", "HCZ Senior Agent")
 	minimal_player_age = 5
 	ideal_character_age = 25
@@ -312,7 +312,7 @@
 	//duties = "<big><b>As the Agent you have more access than a Junior Agent, but do not control them. You are to guard tests and SCP's in the zone you spawned in. If in doubt, ask your Zone or Guard Commander. You also have the duty of guarding the D-Class Cell Blocks. You should not leave your zone under usual SoP.</b></big>"
 	supervisors = "the EZ Supervisor"
 	economic_power = 4
-	requirements = list("EZ Agent" = 480)
+	requirements = list(EXP_TYPE_SECURITY = 180)
 	alt_titles = list("Investigation Officer" = /decl/hierarchy/outfit/job/security/ez_sergeant_investigative, "EZ Senior Combat Medic" = /decl/hierarchy/outfit/job/security/ez_medic)
 	minimal_player_age = 5
 	ideal_character_age = 25
@@ -505,7 +505,7 @@
 	spawn_positions = 1
 	supervisors = "the EZ Supervisor"
 	economic_power = 5
-	requirements = list(EXP_TYPE_COMMAND = 120, EXP_TYPE_SECURITY = 180, EXP_TYPE_BUR = 60, "IT Technician" = 120)
+	requirements = list(EXP_TYPE_COMMAND = 120, EXP_TYPE_SECURITY = 180, EXP_TYPE_ENGINEERING = 60)
 	alt_titles = list()
 	minimal_player_age = 7
 	ideal_character_age = 25

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -10,7 +10,7 @@
 	minimal_player_age = 14
 	account_allowed = 0
 	economic_power = 0
-	requirements = list("Robot" = 240)
+	requirements = list("Robot" = 600)
 	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
 	loadout_allowed = FALSE
 	hud_icon = "hudblank"

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -10,7 +10,7 @@
 	minimal_player_age = 14
 	account_allowed = 0
 	economic_power = 0
-	requirements = list("Robot" = 1200)
+	requirements = list("Robot" = 240)
 	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
 	loadout_allowed = FALSE
 	hud_icon = "hudblank"


### PR DESCRIPTION
## About the Pull Request

This is a rework to have time requirements be almost entirely department based, and also tune down the restrictions to be more reasonable. This will definitely need some input to make right, though.

## Why It's Good For The Game

The extremely overwhelming player complaints whenever timelocks are turned on is literally not being able to play any jobs. I, as a Trial GM, do not have R_TIMELOCK permissions (to bypass timelocks) and with a few hundred hours on the server can't access almost any jobs.
This is a consequence of most timelocks requiring **SPECIFIC JOB** restrictions, along with being too restrictive in themselves.

Timelocks are unsustainable to have on with the current requirements and dramatically reduce pop. Let's see if we can fix that.

## Changelog

:cl:
balance: Timelock requirements for all jobs have been significantly re-tuned.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
