### PR TITLE
Urgent 173 invisible gibs fix

### DIFF
--- a/code/modules/SCP/SCPs/SCP-173.dm
+++ b/code/modules/SCP/SCPs/SCP-173.dm
@@ -359,6 +359,10 @@
 		return 0
 	var/feces_amount = 0
 	for(var/obj/O in A)
+		if(istype(O, /obj/effect/decal/cleanable/blood))
+			var/obj/effect/decal/cleanable/blood/B = O
+			if(B.amount == 0)
+				continue
 		if(O.type in defecation_types)
 			feces_amount += 1
 			continue


### PR DESCRIPTION
## About the Pull Request

173 can breach like 2 minutes after being cleaned because of invisible gibs under the floor
See responsible code that doesnt delete the gibs and instead does stupid bullshit:
https://github.com/Foundation-19/Foundation-19/blob/dev/code/game/objects/effects/decals/Cleanable/humans.dm#L37

## Why It's Good For The Game

no more insta breach

## Changelog

:cl:
fix: 173 dirt in containment chamber is counted correctly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
