### PR TITLE
Oxyloss brain damage rebalance

### DIFF
--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -54,12 +54,12 @@
 		var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
 		if(istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
 			if(user.skill_check(SKILL_MEDICAL, SKILL_BASIC))
-				switch(brain.get_current_damage_threshold())
-					if(0 to 2)
+				switch(round(brain.damage / brain.max_damage, 0.1))
+					if(0 to 0.2)
 						brain_activity = "normal"
-					if(3 to 5)
+					if(0.3 to 0.5)
 						brain_activity = "weak"
-					if(6 to INFINITY)
+					if(0.6 to INFINITY)
 						brain_activity = "extremely weak"
 			else
 				brain_activity = "some"
@@ -172,14 +172,14 @@
 		return
 	var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
 	if(istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
-		switch(brain.get_current_damage_threshold())
-			if(0 to 2)
+		switch(round(brain.damage / brain.max_damage, 0.1))
+			if(0 to 0.2)
 				add_overlay(image(icon, icon_state = "brain_ok"))
-			if(3 to 5)
+			if(0.3 to 0.5)
 				add_overlay(image(icon, icon_state = "brain_bad"))
 				if(read_alerts)
 					alerts[BRAIN_ALERT] = "Weak brain activity!"
-			if(6 to INFINITY)
+			if(0.6 to INFINITY)
 				add_overlay(image(icon, icon_state = "brain_verybad"))
 				add_overlay(image(icon, icon_state = "brain_warning"))
 				if(read_alerts)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -92,19 +92,19 @@
 				if(skill_level < SKILL_BASIC)
 					brain_result = "there's movement on the graph"
 				else if(istype(brain))
-					switch(brain.get_current_damage_threshold())
+					switch(round(brain.damage / brain.max_damage, 0.1))
 						if(0)
 							brain_result = "normal"
-						if(1 to 2)
-							brain_result = SPAN_CLASS("scan_notice","minor brain damage")
-						if(3 to 5)
-							brain_result = SPAN_CLASS("scan_warning","weak")
-						if(6 to 8)
-							brain_result = SPAN_CLASS("scan_danger","extremely weak")
-						if(9 to INFINITY)
-							brain_result = SPAN_CLASS("scan_danger","fading")
+						if(0.1 to 0.2)
+							brain_result = SPAN_CLASS("scan_notice", "minor brain damage")
+						if(0.3 to 0.5)
+							brain_result = SPAN_CLASS("scan_warning", "weak")
+						if(0.6 to 0.8)
+							brain_result = SPAN_CLASS("scan_danger", "extremely weak")
+						if(0.9 to INFINITY)
+							brain_result = SPAN_CLASS("scan_danger", "fading")
 						else
-							brain_result = SPAN_CLASS("scan_danger","ERROR - Hardware fault")
+							brain_result = SPAN_CLASS("scan_danger", "ERROR - Hardware fault")
 				else
 					brain_result = SPAN_CLASS("scan_danger","ERROR - Organ not recognized")
 	else

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -158,7 +158,7 @@
 
 			// If we've got the proper chems, we can heal no matter what
 			var/healing = owner.chem_effects[CE_BRAIN_REGEN] ? 1.6 : 0
-			healing += ((damage > 50) && owner.chem_effects[CE_STABLE]) ? 0.5 : 0
+			healing += ((damage > 40) && owner.chem_effects[CE_STABLE]) ? 0.5 : 0
 			// At good oxygenation levels, we passively autoheal as well.
 			if(blood_volume > (BLOOD_VOLUME_SAFE + 1))
 				healing += 1.05 * log(12, (blood_volume - BLOOD_VOLUME_SAFE))

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -21,6 +21,7 @@
 	var/const/damage_threshold_count = 10
 	var/damage_threshold_value
 	var/healed_threshold = 1
+	/// Basically, how many Process() calls we have until hardcrit if we run out of oxygen. Maximum value is equal to its starting value.
 	var/oxygen_reserve = 6
 	var/insanity = 0 // higher = bad
 
@@ -160,47 +161,52 @@
 			var/blood_volume = owner.get_blood_oxygenation()
 			if(blood_volume < BLOOD_VOLUME_SURVIVE)
 				if(!owner.chem_effects[CE_STABLE] || prob(60))
-					oxygen_reserve = max(0, oxygen_reserve-1)
+					oxygen_reserve = max(0, oxygen_reserve - 1)
 			else
-				oxygen_reserve = min(initial(oxygen_reserve), oxygen_reserve+1)
+				oxygen_reserve = min(initial(oxygen_reserve), oxygen_reserve + 1)
+
 			if(!oxygen_reserve) //(hardcrit)
 				owner.Paralyse(3)
-			var/can_heal = damage && damage < max_damage && (damage % damage_threshold_value || owner.chem_effects[CE_BRAIN_REGEN] || (!past_damage_threshold(3) && owner.chem_effects[CE_STABLE]))
-			var/damprob
-			//Effects of bloodloss
+
+			// If we've got the proper chems, we can heal no matter what
+			var/healing = owner.chem_effects[CE_BRAIN_REGEN] ? 2 : 0
+			healing += (!past_damage_threshold(3) && owner.chem_effects[CE_STABLE]) ? 0.5 : 0
+			var/incoming_damage
+			// Effects of bloodloss
 			switch(blood_volume)
 				if(BLOOD_VOLUME_SAFE to INFINITY)
-					if(can_heal)
-						damage = max(damage-1, 0)
+					// At good oxygenation levels, we passively autoheal to the top of our threshold.
+					if(damage % damage_threshold_value)
+					healing += min(damage % damage_threshold_value, 1)
 				if(BLOOD_VOLUME_OKAY to BLOOD_VOLUME_SAFE)
+					incoming_damage = owner.chem_effects[CE_STABLE] ? 0.3 : 0.6
+					if(!past_damage_threshold(2))
+						take_internal_damage(incoming_damage)
 					if(prob(1))
 						to_chat(owner, SPAN_WARNING("You feel [pick("dizzy","woozy","faint")]..."))
-					damprob = owner.chem_effects[CE_STABLE] ? 30 : 60
-					if(!past_damage_threshold(2) && prob(damprob))
-						take_internal_damage(1)
 				if(BLOOD_VOLUME_BAD to BLOOD_VOLUME_OKAY)
 					owner.eye_blurry = max(owner.eye_blurry,6)
-					damprob = owner.chem_effects[CE_STABLE] ? 40 : 80
-					if(!past_damage_threshold(4) && prob(damprob))
-						take_internal_damage(1)
-					if(!owner.paralysis && prob(10))
-						owner.Paralyse(rand(1,3))
+					incoming_damage = owner.chem_effects[CE_STABLE] ? 0.4 : 0.8
+					if(!past_damage_threshold(4))
+						take_internal_damage(incoming_damage)
+					if(prob(3))
 						to_chat(owner, SPAN_WARNING("You feel very [pick("dizzy","woozy","faint")]..."))
 				if(BLOOD_VOLUME_SURVIVE to BLOOD_VOLUME_BAD)
 					owner.eye_blurry = max(owner.eye_blurry,6)
-					damprob = owner.chem_effects[CE_STABLE] ? 60 : 100
-					if(!past_damage_threshold(6) && prob(damprob))
-						take_internal_damage(1)
-					if(!owner.paralysis && prob(15))
-						owner.Paralyse(3,5)
+					incoming_damage = owner.chem_effects[CE_STABLE] ? 0.6 : 1
+					if(!past_damage_threshold(6))
+						take_internal_damage(incoming_damage)
+					if(prob(7))
 						to_chat(owner, SPAN_WARNING("You feel extremely [pick("dizzy","woozy","faint")]..."))
 				if(-(INFINITY) to BLOOD_VOLUME_SURVIVE) // Also see heart.dm, being below this point puts you into cardiac arrest.
-					owner.eye_blurry = max(owner.eye_blurry,6)
-					damprob = owner.chem_effects[CE_STABLE] ? 80 : 100
-					if(prob(damprob))
-						take_internal_damage(1)
-					if(prob(damprob))
-						take_internal_damage(1)
+					owner.Paralyse(5)
+					owner.eye_blurry = max(owner.eye_blurry, 6)
+					incoming_damage = owner.chem_effects[CE_STABLE] ? 1.4 : 2
+					take_internal_damage(incoming_damage)
+
+			// we can't heal if we're above max damage
+			if(healing && damage && damage < max_damage)
+				damage = max(damage - healing, 0)
 	..()
 
 /obj/item/organ/internal/brain/proc/take_sanity_damage(damage, silent)

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -169,7 +169,7 @@
 				owner.Paralyse(3)
 
 			// If we've got the proper chems, we can heal no matter what
-			var/healing = owner.chem_effects[CE_BRAIN_REGEN] ? 2 : 0
+			var/healing = owner.chem_effects[CE_BRAIN_REGEN] ? 1.6 : 0
 			healing += (!past_damage_threshold(3) && owner.chem_effects[CE_STABLE]) ? 0.5 : 0
 			var/incoming_damage
 			// Effects of bloodloss

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -164,10 +164,10 @@
 				healing += 1.05 * log(12, (blood_volume - BLOOD_VOLUME_SAFE))
 
 			var/incoming_damage = ((100 - (1.1 * blood_volume)) / 50) + (((blood_volume - 100) / 120) ** 2)
-			if(chem_effects[CE_STABLE])
+			if(owner.chem_effects[CE_STABLE])
 				incoming_damage *= 0.5
 
-			var/max_incoming_damage = (max_damage + 75) - (3 * blood_volume)
+			var/current_max_health = (max_damage + 75) - (3 * blood_volume)
 
 			// Can't heal and take damage at the same time, so the smaller one is taken away from the larger
 			if(healing && incoming_damage)
@@ -178,7 +178,7 @@
 					incoming_damage -= healing
 					healing = 0
 
-			take_internal_damage(min(damage + incoming_damage, max_damage))
+			take_internal_damage(min(damage + incoming_damage, current_max_health - damage))
 
 			// we can't heal if we're above max damage
 			if(healing && damage && damage < max_damage)

--- a/code/modules/reagents/Chemistry-Reagents/medicines/medicines_core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/medicines/medicines_core.dm
@@ -6,7 +6,7 @@
 	name = "Inaprovaline"
 	description = "Inaprovaline is a multipurpose neurostimulant and cardioregulator. Commonly used to slow bleeding and stabilize patients."
 	color = "#00bfff"
-	metabolism = REM * 0.5
+	metabolism = REM * 0.4
 	overdose = REAGENTS_OVERDOSE * 2
 	value = 3.5
 


### PR DESCRIPTION
## About the Pull Request

Red is old, green is new. The X axis represents oxygenation.

#### Oxyloss braindamage per second
![dps](https://github.com/Foundation-19/Foundation-19/assets/34486300/c087f401-1693-49d4-82e8-f45711d8ca5a)
(note that Inaprovaline halves this)

#### Maximum braindamage from oxyloss
![max_damage](https://github.com/Foundation-19/Foundation-19/assets/34486300/226df2d9-7243-4790-9c42-240d58ec4602)

#### Braindamage healing per second
![healing](https://github.com/Foundation-19/Foundation-19/assets/34486300/72ac9abf-d618-41b9-9510-b32eeae6f27b)
(note that Inaprovaline boosts this by 0.5 when damage is below 1/5, and Alkysine boosts this by 1.6 at all times)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
balance: Inaprovaline metabolizes slower, so you'll have more time to heal a patient.
balance: Brain healing from Inaprovaline separated from healing from Alkysine. The former heals 0.5 damage a second, whereas the latter repairs 1.6 damage a second.
balance: Brain oxyloss damage/second, maximum brain oxyloss damage, and brain passive healing is continuous instead of discrete. For details, see graphs attached to PR.
/:cl: