### PR TITLE
Fixes SSinput crash on orbiting yourself as ghost

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -99,7 +99,7 @@
  * Default behaviour is to send the [COMSIG_ATOM_EXITED]
  */
 /atom/Exited(atom/movable/exitee, atom/new_loc)
-	SEND_SIGNAL(src, COMSIG_EXITED, src, exitee, new_loc)
+	SEND_SIGNAL(src, COMSIG_EXITED, exitee, new_loc)
 
 /atom/proc/reveal_blood()
 	return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -91,7 +91,7 @@
 			if(is_new_area && is_destination_turf)
 				destination.loc.Entered(src, origin)
 
-	SEND_SIGNAL(src, COMSIG_MOVED, src, origin, destination)
+	SEND_SIGNAL(src, COMSIG_MOVED, origin, destination)
 
 	return 1
 


### PR DESCRIPTION
## About the Pull Request

Title

## Why It's Good For The Game

Obvious

## Changelog

:cl:
fix: fixed crash when orbiting yourself and moving.
/:cl:

