### PR TITLE
Fix 106 tool override

### DIFF
--- a/code/modules/SCP/SCPs/SCP-106.dm
+++ b/code/modules/SCP/SCPs/SCP-106.dm
@@ -388,6 +388,9 @@
 	pixel_x = 0
 	pixel_y = 0
 
+/mob/living/carbon/human/scp106/IsAdvancedToolUser()
+	return FALSE
+
 /mob/living/carbon/human/scp106/proc/wall_unphase()
 	set name = "Leave wall"
 	set category = "SCP"

--- a/code/modules/SCP/SCPs/SCP-106.dm
+++ b/code/modules/SCP/SCPs/SCP-106.dm
@@ -82,6 +82,8 @@
 	WallEye.visualnet.add_source(src)
 	WallEye.visualnet.add_source(WallEye)
 
+	ADD_TRAIT(src, TRAIT_DISCOORDINATED_TOOL_USER, ROUNDSTART_TRAIT)
+
 /mob/living/carbon/human/scp106/Destroy()
 	QDEL_NULL(WallEye)
 	target = null
@@ -387,9 +389,6 @@
 	layer = old_layer
 	pixel_x = 0
 	pixel_y = 0
-
-/mob/living/carbon/human/scp106/IsAdvancedToolUser()
-	return FALSE
 
 /mob/living/carbon/human/scp106/proc/wall_unphase()
 	set name = "Leave wall"


### PR DESCRIPTION
## About the Pull Request

Ooops

## Why It's Good For The Game

106 should not be an advanced tool user and I am a fool

## Changelog

:cl:
fix: Disabled 106's ability to use advanced tools
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
