### PR TITLE
fix client fps not applying randomly

### DIFF
--- a/code/__defines/dcs/signals.dm
+++ b/code/__defines/dcs/signals.dm
@@ -174,6 +174,9 @@
 /// A mob has just equipped an item. Called on [/mob] from base of [/obj/item/equipped()]: (mob/equipper, obj/item/equipped_item, slot)
 #define COMSIG_MOB_EQUIPPED_ITEM "mob_equipped_item"
 
+/// Called on `/client` after `/datum/preferences/setup` has completed with prefs datum as argument.
+#define COMSIG_CLIENT_PREFS_LOADED "client_prefs_loaded"
+
 /*
 *	Atom
 */

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -211,10 +211,13 @@
 	prefs = SScharacter_setup.preferences_datums[ckey]
 	if(!prefs)
 		prefs = new /datum/preferences(src)
+		if(prefs.will_late_init)
+			RegisterSignal(src, COMSIG_CLIENT_PREFS_LOADED, PROC_REF(on_prefs_loaded))
+		else
+			on_prefs_loaded(src, prefs)
 	prefs.macros.owner = src
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
-	apply_fps(prefs.clientfps)
 
 	. = ..()	//calls mob.Login()
 
@@ -492,6 +495,10 @@
 /client/proc/apply_fps(client_fps)
 	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)
 		vars["fps"] = client_fps
+
+/client/proc/on_prefs_loaded(client/target, datum/preferences/prefs)
+	SIGNAL_HANDLER
+	apply_fps(prefs.clientfps)
 
 /client/MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 	. = ..()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -40,6 +40,8 @@
 	var/client/client = null
 	var/client_ckey = null
 
+	var/will_late_init = FALSE
+
 	var/datum/category_collection/player_setup_collection/player_setup
 	var/datum/browser/panel
 
@@ -55,6 +57,7 @@
 		if(SScharacter_setup.initialized)
 			setup()
 		else
+			will_late_init = TRUE
 			SScharacter_setup.prefs_awaiting_setup += src
 	..()
 
@@ -73,6 +76,7 @@
 			load_data()
 
 	sanitize_preferences()
+	SEND_SIGNAL(client, COMSIG_CLIENT_PREFS_LOADED, src)
 
 /datum/preferences/proc/load_data()
 	load_failed = null


### PR DESCRIPTION
## About the Pull Request

this would happen every time I boot a test server and also randomly on round reboot on the live server to a bunch of people solely based on when SScharacter_setup initialized

## Why It's Good For The Game

annoying to fix my fps every round

## Changelog

:cl:
fix: FPS preference randomly not applying no longer happens
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
