### PR TITLE
adds hardsuits to the exosuit fab

### DIFF
--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -684,6 +684,51 @@
 	id = "null _suit"
 	time = 120
 
+/datum/design/item/mechfab/rig/industrial
+	category = "Hardsuits"
+	name = "Industrial suit control module"
+	build_path = /obj/item/rig/industrial
+	materials = list(DEFAULT_WALL_MATERIAL = 60000, "glass" = 5000, "plasteel" = 10000)
+	req_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 2)
+	id = "industrial _suit"
+	time = 120
+
+/datum/design/item/mechfab/rig/eva
+	category = "Hardsuits"
+	name = "EVA suit control module"
+	build_path = /obj/item/rig/eva
+	materials = list(DEFAULT_WALL_MATERIAL = 60000, "glass" = 5000, "silver" = 1000, "gold" = 1000, "plastic" = 5000)
+	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4, TECH_ENGINEERING = 4)
+	id = "eva _suit"
+	time = 120
+
+/datum/design/item/mechfab/rig/hazmat
+	category = "Hardsuits"
+	name = "Hazmat suit control module"
+	build_path = /obj/item/rig/hazmat
+	materials = list(DEFAULT_WALL_MATERIAL = 60000, "glass" = 5000, "silver" = 1000, "gold" = 1000, "plastic" = 5000)
+	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4)
+	id = "hazmat _suit"
+	time = 120
+
+/datum/design/item/mechfab/rig/medical
+	category = "Hardsuits"
+	name = "Medical suit control module"
+	build_path = /obj/item/rig/medical
+	materials = list(DEFAULT_WALL_MATERIAL = 60000, "glass" = 5000, "silver" = 1000, "gold" = 1000, "plastic" = 5000)
+	req_tech = list(TECH_MATERIAL = 5, TECH_COMBAT = 4, TECH_BIO = 4)
+	id = "medical _suit"
+	time = 120
+
+/datum/design/item/mechfab/rig/hazard
+	category = "Hardsuits"
+	name = "Hazard suit control module"
+	build_path = /obj/item/rig/hazard
+	materials = list(DEFAULT_WALL_MATERIAL = 90000, "glass" = 5000, "silver" = 1000, "diamond" = 1000, "uranium" = 1000)
+	req_tech = list(TECH_ESOTERIC = 4, TECH_COMBAT = 6, TECH_MATERIAL = 6)
+	id = "hazard _suit"
+	time = 240
+
 /datum/design/item/mechfab/rig/meson
 	category = "Hardsuits"
 	name = "Meson Scanner"


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Allows the exosuit fabricator to printer to print the industrial, eva, hazmant, medical, and hazard hardsuits
## Why It's Good For The Game
allows greater use of the hardsuit modules that the exosuit fabricator can already print.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
add: Adds a design datum for the industrial hardsuit
add: Adds a design datum for the EVA hardsuit
add: Adds a design datum for the Hazmat hardsuit
add: Adds a design datum for the medical hardsuit
add: Adds a design datum for the Hazard hardsuit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
