### PR TITLE
Makes all D-Class latent psionic.

### DIFF
--- a/code/game/jobs/job/misc.dm
+++ b/code/game/jobs/job/misc.dm
@@ -11,6 +11,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/civ/classd
 	class = CLASS_D
 	hud_icon = "huddclass"
+	psi_latency_chance = 100
 	var/static/list/used_numbers = list()
 
 	max_skill = list(


### PR DESCRIPTION
## About the Pull Request

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes D-Class have a 100% chance of being latent psionic.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Lets researchers test psionics with guaranteed psionic D-Class, as opposed to having a single job that's guaranteed psionic.
Lore wise, could be justified by D-Class being in constant stressful situation, and being in frequent close contact with anomalies.

## Changelog

:cl:
add: All D-Class are latent psionic.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
