### PR TITLE
Money cannon exploit fix

### DIFF
--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -60,7 +60,7 @@
 		return
 
 	// Must launch at least 100 thaler to incur damage.
-	release_force = dispensing / 100
+	release_force = min(dispensing / 100, 40)
 
 /obj/item/gun/launcher/money/proc/unload_receptacle(mob/user)
 	if(receptacle_value < 1)

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -59,8 +59,8 @@
 		release_force = 0
 		return
 
-	// Must launch at least 100 thaler to incur damage.
-	release_force = min(dispensing / 100, 40)
+	// Must launch at least 100 thaler to incur damage. Max of 15k to prevent infinite damage.
+	release_force = min(dispensing / 100, 150)
 
 /obj/item/gun/launcher/money/proc/unload_receptacle(mob/user)
 	if(receptacle_value < 1)


### PR DESCRIPTION
## About the Pull Request

tin
people found this and abused it, then dukeo7 decided to post the exploit details in discord general

## Why It's Good For The Game

this instant headgib exploit is dumb as hell

## Changelog

:cl:
balance: Made money cannon do a max of 30 damage instead of infinite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
