### PR TITLE
Minor QOL Fixes

### DIFF
--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -540,7 +540,6 @@
 /obj/item/reagent_containers/food/snacks/meat/chicken,
 /obj/item/reagent_containers/food/snacks/meat/chicken,
 /obj/item/reagent_containers/food/snacks/meat/chicken,
-/obj/item/reagent_containers/food/snacks/meat/chicken,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/lowertrams/restaurantkitchenarea)
 "abq" = (
@@ -46175,6 +46174,7 @@
 /obj/item/reagent_containers/food/snacks/meat/chicken,
 /obj/item/reagent_containers/food/snacks/meat/chicken,
 /obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/lowertrams/restaurantkitchenarea)
 "pcN" = (
@@ -52408,7 +52408,6 @@
 /obj/effect/floor_decal/corner/research/three_quarters{
 	dir = 8
 	},
-/obj/item/storage/briefcase/foundation/jerraman,
 /turf/simulated/floor/tiled/nullglass,
 /area/site53/reswing/psionic)
 "ssc" = (
@@ -93963,7 +93962,7 @@ aeB
 aav
 otN
 iGp
-abp
+pcD
 aav
 abz
 abz
@@ -94218,9 +94217,9 @@ aIn
 aId
 aeB
 aav
-pcD
-abj
 abp
+abj
+pcD
 aav
 abH
 aOv

--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -536,6 +536,11 @@
 /area/site53/lowertrams/hub)
 "abp" = (
 /obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/lowertrams/restaurantkitchenarea)
 "abq" = (
@@ -894,9 +899,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/flora/pottedplant/orientaltree{
-	pixel_x = -5;
-	pixel_y = 9
+/obj/structure/table/standard{
+	name = "plastic table frame"
+	},
+/obj/machinery/fabricator/micro/bartender{
+	pixel_x = 4
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/site53/lowertrams/restaurantkitchenarea)
@@ -1151,7 +1158,12 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/machinery/reagent_temperature/cooler,
+/obj/machinery/reagent_temperature/cooler{
+	pixel_x = 7
+	},
+/obj/machinery/reagent_temperature{
+	pixel_x = -7
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/site53/lowertrams/restaurantkitchenarea)
 "adr" = (
@@ -17214,7 +17226,8 @@
 /area/site53/upper_surface/serverfarminterior)
 "aYv" = (
 /obj/machinery/power/smes/buildable/preset/ds90/substation_full{
-	charge = 50000
+	charge = 50000;
+	RCon_tag = "Telecommunications Substation"
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -25345,6 +25358,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 9
 	},
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup/one,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "dJS" = (
@@ -27245,11 +27259,6 @@
 "eNi" = (
 /obj/effect/floor_decal/corner/paleblue/bordercee{
 	dir = 1
-	},
-/obj/effect/landmark/start{
-	name = "Surgeon";
-	icon_state = "medsurgspawn";
-	icon = 'icons/effects/landmarks.dmi'
 	},
 /turf/simulated/floor/tiled/white,
 /area/site53/llcz/dclass/medicalpost/surgery)
@@ -33474,6 +33483,7 @@
 /obj/effect/floor_decal/corner/red/border{
 	dir = 10
 	},
+/obj/item/reagent_containers/food/drinks/glass2/coffeecup/one,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/llcz/checkequip)
 "imq" = (
@@ -45006,6 +45016,10 @@
 "otN" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
 /turf/simulated/floor/tiled/freezer,
 /area/site53/lowertrams/restaurantkitchenarea)
 "ouf" = (
@@ -46156,13 +46170,13 @@
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uhcz/scp1507observation)
 "pcD" = (
-/obj/effect/landmark/start{
-	name = "Medical Doctor";
-	icon_state = "meddocspawn";
-	icon = 'icons/effects/landmarks.dmi'
-	},
-/turf/simulated/floor/tiled/white/monotile,
-/area/site53/llcz/dclass/medicalpost)
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/obj/item/reagent_containers/food/snacks/meat/chicken,
+/turf/simulated/floor/tiled/freezer,
+/area/site53/lowertrams/restaurantkitchenarea)
 "pcN" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -52394,6 +52408,7 @@
 /obj/effect/floor_decal/corner/research/three_quarters{
 	dir = 8
 	},
+/obj/item/storage/briefcase/foundation/jerraman,
 /turf/simulated/floor/tiled/nullglass,
 /area/site53/reswing/psionic)
 "ssc" = (
@@ -71929,7 +71944,7 @@ mcg
 xGE
 sVz
 xGE
-pcD
+hAC
 hAC
 hjN
 hAC
@@ -94203,7 +94218,7 @@ aIn
 aId
 aeB
 aav
-abp
+pcD
 abj
 abp
 aav

--- a/maps/site53/site53-3.dmm
+++ b/maps/site53/site53-3.dmm
@@ -429,6 +429,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/item/storage/box/detergent,
 /turf/simulated/floor/tiled/old_cargo,
 /area/site53/uez/bridge)
 "bh" = (
@@ -8019,6 +8020,7 @@
 	},
 /obj/effect/floor_decal/corner/black/diagonal,
 /obj/structure/table/steel_reinforced,
+/obj/machinery/chemical_dispenser/bar_coffee/full,
 /turf/simulated/floor/tiled/white,
 /area/site53/medical/equipstorage)
 "yZ" = (
@@ -13208,6 +13210,7 @@
 /obj/item/crowbar/prybar,
 /obj/effect/floor_decal/corner/paleblue/mono,
 /obj/machinery/light,
+/obj/item/clothing/head/hardhat/EMS,
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/medical/equipstorage)
 "On" = (
@@ -13327,9 +13330,7 @@
 /obj/effect/floor_decal/corner/beige/border{
 	dir = 8
 	},
-/obj/machinery/chemical_dispenser/bar_coffee{
-	dir = 4
-	},
+/obj/machinery/chemical_dispenser/bar_coffee/full,
 /turf/simulated/floor/tiled/monotile,
 /area/site53/uez/bridge)
 "OB" = (
@@ -13431,6 +13432,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
+/obj/item/clothing/head/hardhat/EMS,
 /turf/simulated/floor/tiled/white/monotile,
 /area/site53/medical/equipstorage)
 "OW" = (

--- a/maps/site53/site53-4.dmm
+++ b/maps/site53/site53-4.dmm
@@ -1285,6 +1285,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/item/device/radio/intercom{
+	pixel_y = 20
+	},
 /turf/simulated/floor/tiled/dark/horizontal,
 /area/site53/uez/equipmentroom)
 "eo" = (
@@ -2257,9 +2260,7 @@
 	req_access = list("ACCESS_SECURITY_LEVEL4");
 	pixel_x = -25
 	},
-/obj/structure/closet/secure_closet/guard/breachautomatics{
-	req_access = list("ACCESS_SECURITY_LEVEL4")
-	},
+/obj/structure/closet/secure_closet/guard/breachautomatics,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/uez/armory)
 "hD" = (
@@ -6428,6 +6429,7 @@
 /obj/structure/flora/pottedplant/deskfern{
 	pixel_y = 13
 	},
+/obj/item/storage/fancy/cigar,
 /turf/simulated/floor/carpet/green,
 /area/site53/uez/repoffice/ethics)
 "yE" = (
@@ -6649,6 +6651,16 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/site53/uez/commandpanicbunker)
+"zI" = (
+/obj/machinery/button/blast_door{
+	dir = 1;
+	id_tag = "HCZ Secure Armoury";
+	name = "HCZ Secure Armoury";
+	req_access = list("ACCESS_ADMIN_LEVEL3");
+	pixel_y = 2
+	},
+/turf/simulated/floor/exoplanet/snow,
+/area/site53/uez/hallway)
 "zJ" = (
 /obj/machinery/vending/security{
 	req_access = list("ACCESS_SECURITY_LEVEL2");
@@ -11999,6 +12011,13 @@
 	},
 /turf/simulated/floor/tiled/dark/small,
 /area/site53/uez/hallway)
+"XU" = (
+/obj/effect/floor_decal/corner/grey/mono,
+/obj/item/device/radio/intercom{
+	pixel_y = 20
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/site53/uez/equipmentroom)
 "XV" = (
 /obj/effect/catwalk_plated/dark,
 /obj/item/stack/material/tritium/fifty,
@@ -12208,6 +12227,7 @@
 	pixel_y = 13
 	},
 /obj/structure/table/woodentable_reinforced/walnut,
+/obj/item/storage/fancy/cigar,
 /turf/simulated/floor/carpet/purple,
 /area/site53/uez/repoffice/internaltribunal)
 "YM" = (
@@ -43163,7 +43183,7 @@ aw
 aw
 To
 To
-aw
+zI
 aw
 aw
 aw
@@ -52699,7 +52719,7 @@ hk
 hk
 hk
 uP
-wZ
+XU
 Pp
 wZ
 sb
@@ -53470,7 +53490,7 @@ hk
 hk
 hk
 uP
-wZ
+XU
 LR
 wZ
 Bz
@@ -54241,7 +54261,7 @@ hk
 hk
 hk
 uP
-wZ
+XU
 Bk
 wZ
 Gd
@@ -55012,7 +55032,7 @@ hk
 hk
 hk
 uP
-wZ
+XU
 kM
 wZ
 bq


### PR DESCRIPTION
Minor QOL Map Updates

## About the Pull Request

Includes some minor bar and kitchen fixes, making things that didn't work before actually work, and removing annoying medical spawns.

## Why It's Good For The Game

Simple QOL of life fixes that should improve gameplay overall.
- Kitchen and bar can now print glasses and cutlery! Now with added meat!
- Break room coffee dispenser actually works!
- LCZ gets coffee cups! Admin gets more cigars!
- Doctors no longer spawn in CDCZ at random!
- Coffee for medical!

## Changelog

:cl:
add: Added chicken to kitchen.
add: Added chemical heater to bar.
add: Added cutlery microlathe to bar.
add: Added coffee machine to medical break room.
add: Added cigars in ECL and ITDo office.
add: Added the #1 coffee cups to LCZ sergeant offices.
del: Removed random doctor spawn in CDCZ.
fix: Fixed break room coffee machine to now dispense things.
/:cl:
