### PR TITLE
SCP-082 tweaks

### DIFF
--- a/code/modules/SCP/SCPs/SCP-082.dm
+++ b/code/modules/SCP/SCPs/SCP-082.dm
@@ -4,13 +4,11 @@
 	icon = 'icons/SCP/scp-082.dmi'
 
 	status_flags = NO_ANTAG | SPECIES_FLAG_NO_EMBED | SPECIES_FLAG_NEED_DIRECT_ABSORB
-
 	roundstart_traits = list(TRAIT_ADVANCED_TOOL_USER)
-
 	handcuffs_breakout_modifier = 0.2
 	pixel_x = -16
 	pixel_y = -16
-	usefov = FALSE // temporary
+	usefov = FALSE
 	health = 2000
 	maxHealth = 2000
 	floating_message_pixel_x_offset = 16
@@ -148,7 +146,7 @@
 	. = ..()
 	if(!.)
 		return
-	priority_announcement.Announce("Motion sensors triggered in the containment chamber of SCP-082, on-site security personnel are to investigate the issue.", "Motion Sensors", 'sounds/AI/049.ogg') // temporary
+	priority_announcement.Announce("Motion sensors triggered in the containment chamber of SCP-082, on-site security personnel are to investigate the issue.", "Motion Sensors")
 	last_interaction_time = world.time + 5 MINUTES
 
 /mob/living/carbon/human/scp082/proc/open_door(obj/machinery/door/door) // this should probably be a component honestly
@@ -216,6 +214,7 @@
 
 	non_hunger_ticks = 0
 	hunger_prob = 0
+	stamina = max_stamina
 	to_chat(src, SPAN_WARNING("You feel like you're getting <b>very</b> hungry..."))
 	var/total_damage_taken = 0
 	for(var/obj/item/organ/external/external in organs)


### PR DESCRIPTION
## About the Pull Request

I wasn't expecting a +/- 8000 line PR to be merged in 6 hours without review, so here's some changes I put off doing.

- 082 motion sensors no longer make the 049 announcement sound
- stamina resets to full on entering hunger state

## Why It's Good For The Game

- Bad placeholder sound that literally had the comment `//temporary` attached to it
- Allows 082 to catch up to people a bit easier, considering his reduced max stamina

## Changelog

:cl:
fix: 082 motion sensor announcement no longer plays 049's announcement sound.
balance: 082 now resets his stamina to full on entering a hungering state.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
