### PR TITLE
Updates Chapel Fax Machine department tag.

### DIFF
--- a/maps/site53/site53-2.dmm
+++ b/maps/site53/site53-2.dmm
@@ -43057,7 +43057,9 @@
 	dir = 8
 	},
 /obj/structure/table/woodentable/mahogany,
-/obj/machinery/photocopier/faxmachine,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chapel"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel)
 "nfX" = (
@@ -61734,7 +61736,7 @@
 "wRi" = (
 /obj/structure/table/woodentable/mahogany,
 /obj/machinery/photocopier/faxmachine{
-	req_access = list("ACCESS_CHAPEL_STORAGE")
+	department = "Chapel Office"
 	},
 /turf/simulated/floor/wood/mahogany,
 /area/chapel)


### PR DESCRIPTION
## About the Pull Request

Adds a department tag to the chapel fax machines so they're capable of sending and recieving papers.
![image](https://github.com/user-attachments/assets/7ef47696-03ef-45d3-915b-4338680904a0)
![image](https://github.com/user-attachments/assets/48522df9-1ef9-4834-80f3-aa9c025ea01d)


<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Intended functionality, previous state was a mapping oversight.

Resolves #1699 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
Updated: The fax machine in the chaplains office now has the tag "Chapel Office"
Updated: The fax machine in the main chapel now has the tag "Chapel" 
Removes: Access requirement on Chapel Office fax machine. There seems to be issues there and in retrospect the chaplain really doesn't need an access restriction on their fax machine.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
