### PR TITLE
Fixes shower curtains not showing above mobs.

### DIFF
--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -31,9 +31,11 @@
 	set_opacity(!opacity)
 	if(opacity)
 		icon_state = "closed"
+		plane = MOB_PLANE
 		layer = ABOVE_HUMAN_LAYER
 	else
 		icon_state = "open"
+		plane = OBJ_PLANE
 		layer = ABOVE_WINDOW_LAYER
 
 /obj/structure/curtain/black


### PR DESCRIPTION
## About the Pull Request

Adjusts the plane of shower curtains to 2 (Mob Plane) when closed so that their layer actually works and puts them above Carbons when closed. 

![image](https://github.com/user-attachments/assets/00d577b9-ee6e-4952-b900-f352d437a923)

<!-- Describe the Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

You would not **Stand** on your shower curtains at home... why would you do it at work?

Resolves #1613, needs review from someone with more experience using planes and layers to verify this is acceptable usage.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

:cl:
Fixed: Shower curtains now show above mobs when closed, rather than the other way around with mobs standing on the curtains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

<!--
Examples were changelog entries are optional/not typically required but encouraged:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

As a courtesy, for ported PRs, please include if you have the blessing of the author. While not required, we encourage basic decency in porting others' work. It is also sufficient to note that the author has not expressed displeasure at the idea of their work getting ported.
Please refrain from porting works of authors that have expressed displeasure in having their work ported, thank you.
-->
